### PR TITLE
Add release 8.4.1 for AWS

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -18,7 +18,7 @@
       version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
-- active: false
+- active: true
   authorities:
     - endpoint: http://app-operator:8000
       name: app-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -18,6 +18,26 @@
       version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
+- active: false
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.3.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.19.0
+  date: 2019-09-20T15:00:00Z
+  version: 8.4.1
 - active: true
   authorities:
     - endpoint: http://app-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -36,7 +36,7 @@
       name: cluster-operator
       provider: aws
       version: 0.19.0
-  date: 2019-09-20T15:00:00Z
+  date: 2019-09-24T11:00:00Z
   version: 8.4.1
 - active: true
   authorities:


### PR DESCRIPTION
:zap:  Giant Swarm Release 8.4.1 for AWS is now active for you! :zap:

This release contains multiple fixes to the private/public hosted zones which were altered in the previous release. In-Cluster communication between services and the kubernetes API should now stay inside the VPC without issues.

*aws-operator 5.3.1*
- Duplicate etcd record set into public hosted zone.
- Add ingress internal load-balancer in private hosted zone.
- Use private subnets for internal Kubernetes API loadbalancer.
