### PR TITLE
Activate release 8.5.0 and deprecate 8.4.1

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -15,7 +15,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.19.0
+      version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
 - active: false

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,4 @@
-- active: false
+- active: true
   authorities:
     - endpoint: http://app-operator:8000
       name: app-operator
@@ -18,7 +18,7 @@
       version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
-- active: true
+- active: false
   authorities:
     - endpoint: http://app-operator:8000
       name: app-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -15,7 +15,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.20.0
+      version: 0.19.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
 - active: false


### PR DESCRIPTION
:zap: *Giant Swarm Release 8.5.0 for AWS is now active for you!* :zap:

Due to cgroup restructure (https://github.com/giantswarm/k8scloudconfig/pull/564) and more resource reservation for core components, we now switch to bigger master instance type (from `m4.large` to `m4.xlarge`). As this change is reflected in multiple services, related PRs are merged after `8.5.0` release is activated:
  - new clusters: https://github.com/giantswarm/cluster-service/pull/384
  - upgraded clusters: https://github.com/giantswarm/kubernetesd/pull/449

This release also contains multiple fixes to the private/public hosted zones which were altered in the previous release. In-Cluster communication between services and the Kubernetes API should now stay inside the VPC without issues.

On the feature side, the release introduces `internal-api` endpoint, which allows communication with Kubernetes API via the private network. That allows you, for example, restrict public Kubernetes API access to Giant Swarm VPN addresses only and use internal API via peered networks. All the related changes are referenced in issue https://github.com/giantswarm/giantswarm/issues/6924

*aws-operator 5.4.0*

- Duplicate etcd recordset into public hosted zone.
- Add ingress internal load-balancer in private hosted zone.
- Use private subnets for internal Kubernetes API loadbalancer.
- Refactor Kuberntes API whitelisting with public/private subnets.
- Add `internal-api` recordset into public hosted zone.