### PR TITLE
Use cluster-operator 0.21.0 for Azure and KVM WIP

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -15,7 +15,7 @@
   - endpoint: http://cluster-operator:8000
     name: cluster-operator
     provider: azure
-    version: 0.20.0
+    version: 0.21.0
   date: 2019-09-04T10:00:00Z
   version: 8.5.0
 - active: true

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -12,7 +12,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: kvm
-      version: 0.20.0
+      version: 0.21.0
     - endpoint: http://flannel-operator:8000
       name: flannel-operator
       version: 0.2.0


### PR DESCRIPTION
0.21.0 got added as WIP for AWS. We should use it for Azure and KVM too because of the shared code under pkg.