### PR TITLE
Add 8.4.1 for azure

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -25,6 +25,26 @@
     version: 1.0.0
   - endpoint: http://azure-operator:8000
     name: azure-operator
+    version: 2.6.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.7.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: azure
+    version: 0.19.0
+  date: 2019-09-26T17:00:00Z
+  version: 8.4.1
+- active: true
+  authorities:
+  - endpoint: http://app-operator:8000
+    name: app-operator
+    version: 1.0.0
+  - endpoint: http://azure-operator:8000
+    name: azure-operator
     version: 2.6.0
   - endpoint: http://cert-operator:8000
     name: cert-operator

--- a/azure.yaml
+++ b/azure.yaml
@@ -38,7 +38,7 @@
     version: 0.19.0
   date: 2019-09-26T17:00:00Z
   version: 8.4.1
-- active: true
+- active: false
   authorities:
   - endpoint: http://app-operator:8000
     name: app-operator


### PR DESCRIPTION
*:postal_horn:  Giant Swarm Release 8.4.1 for Azure is now active for you! :postal_horn:*

This release adds the following service endpoints to the worker VNET:
`Storage`, `Sql`, `AzureCosmosDB`, `KeyVault`, `ServiceBus`, `EventHub`, `AzureActiveDirectory`, `ContainerRegistry`, `Web`.

*azure-operator 2.6.1*
- Add service endpoints to the worker VNET.

