### PR TITLE
Enable old KVM releases

### DIFF
--- a/kvm.yaml
+++ b/kvm.yaml
@@ -44,7 +44,7 @@
       version: 3.8.0
   date: 2019-08-20T17:00:00Z
   version: 8.4.0
-- active: false
+- active: true
   authorities:
   - endpoint: http://cert-operator:8000
     name: cert-operator
@@ -64,7 +64,7 @@
     version: 3.7.1
   date: 2019-08-20T16:40:00Z
   version: 8.3.0
-- active: false
+- active: true
   authorities:
   - endpoint: http://cert-operator:8000
     name: cert-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -84,7 +84,7 @@
     version: 3.7.1
   date: 2019-06-24T10:00:00Z
   version: 8.2.1
-- active: false
+- active: true
   authorities:
   - endpoint: http://cert-operator:8000
     name: cert-operator


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6902

Enabling 

- 8.2.0
- 8.2.1
- 8.3.0

8.2.0 -> 8.2.1: the unique difference is in the k8s version.

8.2.0 has a version affected by a security issue but it is not broken.