### PR TITLE
add node pool releases for testing

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1,19 +1,14 @@
 - active: true
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 7.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 2.0.0-dev
   date: 2019-11-26T11:16:00Z

--- a/aws.yaml
+++ b/aws.yaml
@@ -4,6 +4,7 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-np-6-6-0
+      endpoint: http://aws-operator-np-6-6-0:8000
       version: 6.6.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -23,6 +24,7 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-np-6-5-0
+      endpoint: http://aws-operator-np-6-5-0:8000
       version: 6.5.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -42,6 +44,7 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-lock-azs
+      endpoint: http://aws-operator-lock-azs:8000
       version: 6.4.0
     - endpoint: http://cert-operator:8000
       name: cert-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -5,6 +5,26 @@
       version: 1.0.0
     - endpoint: http://aws-operator-np-6-6-0:8000
       name: aws-operator
+      version: 6.6.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.21.0
+  date: 2019-10-18T12:00:00Z
+  version: 8.8.1
+- active: false
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator-np-6-6-0:8000
+      name: aws-operator
       version: 6.6.0
     - endpoint: http://cert-operator:8000
       name: cert-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -4,7 +4,6 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-np-6-6-0
-      endpoint: http://aws-operator-np-6-6-0:8000
       version: 6.6.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -24,7 +23,6 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-np-6-5-0
-      endpoint: http://aws-operator-np-6-5-0:8000
       version: 6.5.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -44,7 +42,6 @@
       name: app-operator
       version: 1.0.0
     - name: aws-operator-lock-azs
-      endpoint: http://aws-operator-lock-azs:8000
       version: 6.4.0
     - endpoint: http://cert-operator:8000
       name: cert-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
+    - endpoint: http://aws-operator-legacy:8000
       name: aws-operator
       version: 5.5.0
     - endpoint: http://cert-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -15,727 +15,573 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 2.0.0-dev
-  date: 2019-11-05T12:00:00Z
-  version: 10.1.0
+      version: 2.0.0-xh3b4sd
+  date: 2019-10-31T11:00:00Z
+  version: 10.0.1
 - active: false
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.5.1-dev
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: aws-operator
+      version: 7.0.1-dev
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
+      provider: aws
+      version: 2.0.0-dev
+  date: 2019-12-05T12:00:00Z
+  version: 10.0.0
+- active: false
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.5.1-dev
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
       provider: aws
       version: 0.21.1-dev
   date: 2019-11-05T12:00:00Z
   version: 9.1.0
 - active: true
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.5.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.21.0
   date: 2019-10-28T12:00:00Z
   version: 9.0.0
 - active: true
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.4.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
 - active: false
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.3.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.19.0
   date: 2019-09-24T11:00:00Z
   version: 8.4.1
 - active: false
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.3.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.19.0
   date: 2019-08-19T16:30:00Z
   version: 8.4.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.18.0
   date: 2019-08-19T10:00:00Z
   version: 8.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.17.0
   date: 2019-08-09T10:00:00Z
   version: 8.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.17.0
   date: 2019-06-03T10:00:00Z
   version: 8.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.1.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.16.0
   date: 2019-06-04T16:00:00Z
   version: 8.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 5.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.15.0
   date: 2019-04-17T08:00:00Z
   version: 8.0.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.9.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.14.1
   date: 2019-04-25T18:00:00Z
   version: 7.3.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.9.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.14.0
   date: 2019-04-17T08:00:00Z
   version: 7.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.8.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.13.0
   date: 2019-03-21T10:00:00Z
   version: 7.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.8.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.12.0
   date: 2019-03-12T10:00:00Z
   version: 7.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.7.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.12.0
   date: 2019-03-04T10:00:00Z
   version: 7.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.7.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.11.0
   date: 2019-02-20T12:00:00Z
   version: 7.0.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.6.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.10.0
   date: 2019-03-12T10:00:00Z
   version: 6.3.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.6.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.10.0
   date: 2019-01-16T12:23:00Z
   version: 6.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.5.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2019-02-12T13:08:00Z
   version: 6.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.5.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2019-01-16T11:12:00Z
   version: 6.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.4.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2018-12-03T22:57:00Z
   version: 6.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.4.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.8.0
   date: 2018-11-23T17:00:00Z
   version: 6.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.3.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.8.0
   date: 2018-10-27T13:00:00Z
   version: 6.0.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.2.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.7.2
   date: 2019-02-12T13:13:00Z
   version: 5.2.4
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.7.2
   date: 2019-01-24T14:00:00Z
   version: 5.2.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.7.1
   date: 2018-12-03T22:56:00Z
   version: 5.2.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.7.1
   date: 2018-11-05T12:30:00Z
   version: 5.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.7.0
   date: 2018-09-28T09:00:00Z
   version: 5.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.1.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-26T12:00:00Z
   version: 5.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.1.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-10T06:00:00Z
   version: 5.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 4.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-08-30T08:00:00Z
   version: 5.0.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.3.4
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-12-03T22:55:00Z
   version: 4.5.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.3.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-25T14:00:00Z
   version: 4.5.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.3.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-17T14:00:00Z
   version: 4.5.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.3.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-08-27T12:00:00Z
   version: 4.5.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.3.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.5.0
   date: 2018-07-26T12:00:00Z
   version: 4.4.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.5.0
   date: 2018-07-11T12:00:00Z
   version: 4.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.1.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.4.0
   date: 2018-07-11T12:01:00Z
   version: 4.2.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.1.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.4.0
   date: 2018-06-21T12:00:00Z
   version: 4.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.1.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.3.0
   date: 2018-05-29T12:00:00Z
   version: 4.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.0.4
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.2.0
   date: 2018-05-30T12:00:00Z
   version: 3.4.4
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 3.0.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 0.2.0
   date: 2018-05-18T12:00:00Z
   version: 3.4.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 2.0.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
   date: 2018-01-31T10:43:00Z
   version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -15,7 +15,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 1.0.0
+      version: 2.0.0-dev
   date: 2019-11-26T11:16:00Z
   version: 10.0.1
 - active: false

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-detach-elb-subnets:8000
+    - endpoint: http://aws-operator-lock-azs:8000
       name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -3,7 +3,8 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - name: aws-operator-np-6-6-0
+    - endpoint: http://aws-operator-np-6-6-0:8000
+      name: aws-operator
       version: 6.6.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -22,7 +23,8 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - name: aws-operator-np-6-5-0
+    - endpoint: http://aws-operator-np-6-5-0:8000
+      name: aws-operator
       version: 6.5.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -41,7 +43,8 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - name: aws-operator-lock-azs
+    - endpoint: http://aws-operator-lock-azs:8000
+      name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000
       name: cert-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -15,7 +15,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.21.0
+      version: 0.22.0
   date: 2019-10-23T12:00:00Z
   version: 8.8.1
 - active: false
@@ -35,7 +35,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.21.0
+      version: 0.22.0
   date: 2019-10-18T12:00:00Z
   version: 8.8.0
 - active: false
@@ -55,7 +55,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.20.0
+      version: 0.22.0
   date: 2019-10-18T11:00:00Z
   version: 8.7.0
 - active: true

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,18 +1,3 @@
-- active: true
-  authorities:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 7.0.0
-    - name: cert-operator
-      version: 0.1.0
-    - name: chart-operator
-      version: 0.7.0
-    - name: cluster-operator
-      provider: aws
-      version: 2.0.0
-  date: 2019-11-26T11:16:00Z
-  version: 10.0.1
 - active: false
   authorities:
     - name: app-operator
@@ -25,7 +10,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 2.0.0
+      version: 2.0.0-dev
   date: 2019-12-05T12:00:00Z
   version: 10.0.0
 - active: false
@@ -40,7 +25,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 0.21.1
+      version: 0.21.1-dev
   date: 2019-11-05T12:00:00Z
   version: 9.1.0
 - active: true

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,4 @@
-- active: false
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -45,7 +45,7 @@
       version: 1.0.0
     - endpoint: http://aws-operator-legacy:8000
       name: aws-operator
-      version: 5.5.0
+      version: 6.4.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
       version: 0.1.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -58,7 +58,7 @@
       version: 0.20.0
   date: 2019-10-18T11:00:00Z
   version: 8.7.0
-- active: false
+- active: true
   authorities:
     - endpoint: http://app-operator:8000
       name: app-operator
@@ -140,622 +140,622 @@
   version: 8.4.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 5.2.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.7.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.18.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.2.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.18.0
   date: 2019-08-19T10:00:00Z
   version: 8.3.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 5.2.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.6.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.17.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.2.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.6.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.17.0
   date: 2019-08-09T10:00:00Z
   version: 8.2.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 5.2.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.6.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.17.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.2.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.6.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.17.0
   date: 2019-06-03T10:00:00Z
   version: 8.2.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 5.1.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.6.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.16.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.1.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.6.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.16.0
   date: 2019-06-04T16:00:00Z
   version: 8.1.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 5.0.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.15.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.0.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.15.0
   date: 2019-04-17T08:00:00Z
   version: 8.0.0
 - active: true
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.9.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.14.1
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.9.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.14.1
   date: 2019-04-25T18:00:00Z
   version: 7.3.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.9.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.14.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.9.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.14.0
   date: 2019-04-17T08:00:00Z
   version: 7.3.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.8.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.13.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.8.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.13.0
   date: 2019-03-21T10:00:00Z
   version: 7.2.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.8.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.12.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.8.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.12.0
   date: 2019-03-12T10:00:00Z
   version: 7.1.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.7.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.12.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.7.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.12.0
   date: 2019-03-04T10:00:00Z
   version: 7.1.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.7.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.11.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.7.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.11.0
   date: 2019-02-20T12:00:00Z
   version: 7.0.0
 - active: true
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.6.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.10.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.6.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.10.0
   date: 2019-03-12T10:00:00Z
   version: 6.3.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.6.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.10.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.6.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.10.0
   date: 2019-01-16T12:23:00Z
   version: 6.3.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.5.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.9.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.5.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.9.0
   date: 2019-02-12T13:08:00Z
   version: 6.2.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.5.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.9.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.5.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.9.0
   date: 2019-01-16T11:12:00Z
   version: 6.2.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.4.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.9.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.4.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.9.0
   date: 2018-12-03T22:57:00Z
   version: 6.1.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.4.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.8.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.4.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.8.0
   date: 2018-11-23T17:00:00Z
   version: 6.1.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.3.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.5.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.8.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.3.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.5.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.8.0
   date: 2018-10-27T13:00:00Z
   version: 6.0.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.2.2
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.4.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.7.2
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.2.2
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.4.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.7.2
   date: 2019-02-12T13:13:00Z
   version: 5.2.4
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.2.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.4.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.7.2
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.2.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.4.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.7.2
   date: 2019-01-24T14:00:00Z
   version: 5.2.3
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.2.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.4.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.7.1
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.2.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.4.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.7.1
   date: 2018-12-03T22:56:00Z
   version: 5.2.2
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.2.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.4.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.7.1
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.2.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.4.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.7.1
   date: 2018-11-05T12:30:00Z
   version: 5.2.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.2.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.4.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.7.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.2.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.4.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.7.0
   date: 2018-09-28T09:00:00Z
   version: 5.2.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.1.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.1.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-09-26T12:00:00Z
   version: 5.1.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.1.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.1.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-09-10T06:00:00Z
   version: 5.1.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 4.0.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 4.0.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-08-30T08:00:00Z
   version: 5.0.0
 - active: true
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.3.4
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.3.4
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-12-03T22:55:00Z
   version: 4.5.3
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.3.3
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.3.3
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-09-25T14:00:00Z
   version: 4.5.2
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.3.2
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.3.2
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-09-17T14:00:00Z
   version: 4.5.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.3.1
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.6.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.3.1
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.6.0
   date: 2018-08-27T12:00:00Z
   version: 4.5.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.3.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://chart-operator:8000
-    name: chart-operator
-    version: 0.3.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.5.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.3.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.3.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.5.0
   date: 2018-07-26T12:00:00Z
   version: 4.4.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.2.0
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.5.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.2.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.5.0
   date: 2018-07-11T12:00:00Z
   version: 4.3.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.1.3
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.4.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.1.3
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.4.0
   date: 2018-07-11T12:01:00Z
   version: 4.2.2
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.1.2
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.4.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.1.2
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.4.0
   date: 2018-06-21T12:00:00Z
   version: 4.2.1
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.1.2
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.3.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.1.2
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.3.0
   date: 2018-05-29T12:00:00Z
   version: 4.2.0
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.0.4
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.2.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.0.4
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.2.0
   date: 2018-05-30T12:00:00Z
   version: 3.4.4
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 3.0.3
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
-  - endpoint: http://cluster-operator:8000
-    name: cluster-operator
-    provider: aws
-    version: 0.2.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 3.0.3
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.2.0
   date: 2018-05-18T12:00:00Z
   version: 3.4.3
 - active: false
   authorities:
-  - endpoint: http://aws-operator:8000
-    name: aws-operator
-    version: 2.0.2
-  - endpoint: http://cert-operator:8000
-    name: cert-operator
-    version: 0.1.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 2.0.2
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
   date: 2018-01-31T10:43:00Z
   version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
+    - endpoint: http://aws-operator-master:8000
       name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -16,6 +16,26 @@
       name: cluster-operator
       provider: aws
       version: 1.0.0
+  date: 2019-11-26T11:16:00Z
+  version: 10.0.1
+- active: true
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 7.0.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 1.0.0
   date: 2019-10-31T11:00:00Z
   version: 10.0.0
 - active: false

--- a/aws.yaml
+++ b/aws.yaml
@@ -3,7 +3,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-np-6-6-0:8000
+    - endpoint: http://aws-operator-cf-collector:8000
       name: aws-operator
       version: 6.6.1
     - endpoint: http://cert-operator:8000
@@ -16,7 +16,7 @@
       name: cluster-operator
       provider: aws
       version: 0.21.0
-  date: 2019-10-18T12:00:00Z
+  date: 2019-10-23T12:00:00Z
   version: 8.8.1
 - active: false
   authorities:

--- a/aws.yaml
+++ b/aws.yaml
@@ -3,8 +3,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-np-6-6-0:8000
-      name: aws-operator
+    - name: aws-operator-np-6-6-0
       version: 6.6.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -23,8 +22,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-np-6-5-0:8000
-      name: aws-operator
+    - name: aws-operator-np-6-5-0
       version: 6.5.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
@@ -43,8 +41,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-lock-azs:8000
-      name: aws-operator
+    - name: aws-operator-lock-azs
       version: 6.4.0
     - endpoint: http://cert-operator:8000
       name: cert-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,23 +1,33 @@
 - active: true
   authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
+    - name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
+    - name: aws-operator
       version: 7.0.1-tuommaki
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
+    - name: cert-operator
       version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
+    - name: chart-operator
       version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
+    - name: cluster-operator
       provider: aws
       version: 2.0.0-xh3b4sd
   date: 2019-10-31T11:00:00Z
   version: 10.0.1
+- active: true
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 7.0.0-dev
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: aws
+      version: 2.0.0-dev
+  date: 2019-10-31T11:00:00Z
+  version: 10.0.0
 - active: false
   authorities:
     - name: app-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -10,7 +10,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 2.0.0-dev
+      version: 2.0.0
   date: 2019-11-26T11:16:00Z
   version: 10.0.1
 - active: false
@@ -25,7 +25,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 2.0.0-dev
+      version: 2.0.0
   date: 2019-12-05T12:00:00Z
   version: 10.0.0
 - active: false
@@ -40,7 +40,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 0.21.1-dev
+      version: 0.21.1
   date: 2019-11-05T12:00:00Z
   version: 9.1.0
 - active: true

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-drop-unused-azs:8000
+    - endpoint: http://aws-operator-detach-elb-subnets:8000
       name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,71 +1,51 @@
-- active: false
-  authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
-      version: 1.0.0
-    - endpoint: http://aws-operator-cf-collector:8000
-      name: aws-operator
-      version: 6.6.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.22.0
-  date: 2019-10-23T12:00:00Z
-  version: 8.8.1
-- active: false
-  authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
-      version: 1.0.0
-    - endpoint: http://aws-operator-np-6-6-0:8000
-      name: aws-operator
-      version: 6.6.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.22.0
-  date: 2019-10-18T12:00:00Z
-  version: 8.8.0
-- active: false
-  authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
-      version: 1.0.0
-    - endpoint: http://aws-operator-np-6-5-0:8000
-      name: aws-operator
-      version: 6.5.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.22.0
-  date: 2019-10-18T11:00:00Z
-  version: 8.7.0
 - active: true
   authorities:
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-master:8000
+    - endpoint: http://aws-operator:8000
       name: aws-operator
-      version: 6.4.0
+      version: 7.0.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 1.0.0
+  date: 2019-10-31T11:00:00Z
+  version: 10.0.0
+- active: false
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.6.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.22.0
+  date: 2019-10-28T12:00:00Z
+  version: 9.1.0
+- active: true
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 5.5.0
     - endpoint: http://cert-operator:8000
       name: cert-operator
       version: 0.1.0
@@ -76,8 +56,8 @@
       name: cluster-operator
       provider: aws
       version: 0.21.0
-  date: 2019-09-26T12:00:00Z
-  version: 8.6.0
+  date: 2019-10-28T12:00:00Z
+  version: 9.0.0
 - active: true
   authorities:
     - endpoint: http://app-operator:8000
@@ -140,622 +120,622 @@
   version: 8.4.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.18.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 5.2.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.7.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.18.0
   date: 2019-08-19T10:00:00Z
   version: 8.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.17.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 5.2.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.6.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.17.0
   date: 2019-08-09T10:00:00Z
   version: 8.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.17.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 5.2.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.6.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.17.0
   date: 2019-06-03T10:00:00Z
   version: 8.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.1.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.6.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.16.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 5.1.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.6.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.16.0
   date: 2019-06-04T16:00:00Z
   version: 8.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 5.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.15.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 5.0.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.15.0
   date: 2019-04-17T08:00:00Z
   version: 8.0.0
-- active: true
+- active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.9.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.14.1
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.9.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.14.1
   date: 2019-04-25T18:00:00Z
   version: 7.3.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.9.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.14.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.9.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.14.0
   date: 2019-04-17T08:00:00Z
   version: 7.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.8.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.13.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.8.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.13.0
   date: 2019-03-21T10:00:00Z
   version: 7.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.8.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.12.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.8.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.12.0
   date: 2019-03-12T10:00:00Z
   version: 7.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.7.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.12.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.7.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.12.0
   date: 2019-03-04T10:00:00Z
   version: 7.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.7.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.11.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.7.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.11.0
   date: 2019-02-20T12:00:00Z
   version: 7.0.0
-- active: true
+- active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.6.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.10.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.6.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.10.0
   date: 2019-03-12T10:00:00Z
   version: 6.3.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.6.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.10.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.6.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.10.0
   date: 2019-01-16T12:23:00Z
   version: 6.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.5.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.9.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.5.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.9.0
   date: 2019-02-12T13:08:00Z
   version: 6.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.5.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.9.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.5.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.9.0
   date: 2019-01-16T11:12:00Z
   version: 6.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.4.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.9.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.4.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.9.0
   date: 2018-12-03T22:57:00Z
   version: 6.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.4.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.8.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.4.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.8.0
   date: 2018-11-23T17:00:00Z
   version: 6.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.3.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.5.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.8.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.3.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.5.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.8.0
   date: 2018-10-27T13:00:00Z
   version: 6.0.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.2.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.7.2
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.2.2
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.4.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.7.2
   date: 2019-02-12T13:13:00Z
   version: 5.2.4
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.7.2
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.2.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.4.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.7.2
   date: 2019-01-24T14:00:00Z
   version: 5.2.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.2.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.7.1
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.2.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.4.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.7.1
   date: 2018-12-03T22:56:00Z
   version: 5.2.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.7.1
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.2.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.4.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.7.1
   date: 2018-11-05T12:30:00Z
   version: 5.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.4.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.7.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.2.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.4.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.7.0
   date: 2018-09-28T09:00:00Z
   version: 5.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.1.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.1.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-09-26T12:00:00Z
   version: 5.1.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.1.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.1.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-09-10T06:00:00Z
   version: 5.1.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 4.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 4.0.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-08-30T08:00:00Z
   version: 5.0.0
-- active: true
+- active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.3.4
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.3.4
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-12-03T22:55:00Z
   version: 4.5.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.3.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.3.3
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-09-25T14:00:00Z
   version: 4.5.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.3.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.3.2
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-09-17T14:00:00Z
   version: 4.5.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.3.1
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.6.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.3.1
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.6.0
   date: 2018-08-27T12:00:00Z
   version: 4.5.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.3.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.3.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.5.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.3.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.3.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.5.0
   date: 2018-07-26T12:00:00Z
   version: 4.4.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.2.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.5.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.2.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.5.0
   date: 2018-07-11T12:00:00Z
   version: 4.3.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.1.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.4.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.1.3
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.4.0
   date: 2018-07-11T12:01:00Z
   version: 4.2.2
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.1.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.4.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.1.2
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.4.0
   date: 2018-06-21T12:00:00Z
   version: 4.2.1
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.1.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.3.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.1.2
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.3.0
   date: 2018-05-29T12:00:00Z
   version: 4.2.0
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.0.4
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.2.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.0.4
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.2.0
   date: 2018-05-30T12:00:00Z
   version: 3.4.4
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 3.0.3
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 0.2.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 3.0.3
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: aws
+    version: 0.2.0
   date: 2018-05-18T12:00:00Z
   version: 3.4.3
 - active: false
   authorities:
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 2.0.2
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
+  - endpoint: http://aws-operator:8000
+    name: aws-operator
+    version: 2.0.2
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
   date: 2018-01-31T10:43:00Z
   version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -3,6 +3,46 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
+    - endpoint: http://aws-operator-np-6-6-0:8000
+      name: aws-operator
+      version: 6.6.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.21.0
+  date: 2019-10-18T12:00:00Z
+  version: 8.8.0
+- active: false
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
+    - endpoint: http://aws-operator-np-6-5-0:8000
+      name: aws-operator
+      version: 6.5.0
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
+      version: 0.1.0
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
+      version: 0.7.0
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
+      provider: aws
+      version: 0.20.0
+  date: 2019-10-18T11:00:00Z
+  version: 8.7.0
+- active: false
+  authorities:
+    - endpoint: http://app-operator:8000
+      name: app-operator
+      version: 1.0.0
     - endpoint: http://aws-operator:8000
       name: aws-operator
       version: 5.5.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -18,26 +18,6 @@
       version: 1.0.0
   date: 2019-11-26T11:16:00Z
   version: 10.0.1
-- active: true
-  authorities:
-    - endpoint: http://app-operator:8000
-      name: app-operator
-      version: 1.0.0
-    - endpoint: http://aws-operator:8000
-      name: aws-operator
-      version: 7.0.0
-    - endpoint: http://cert-operator:8000
-      name: cert-operator
-      version: 0.1.0
-    - endpoint: http://chart-operator:8000
-      name: chart-operator
-      version: 0.7.0
-    - endpoint: http://cluster-operator:8000
-      name: cluster-operator
-      provider: aws
-      version: 1.0.0
-  date: 2019-10-31T11:00:00Z
-  version: 10.0.0
 - active: false
   authorities:
     - endpoint: http://app-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,567 +1,741 @@
 - active: true
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
-      version: 7.0.1-dev
-    - name: cert-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
+      version: 7.0.1-tuommaki
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 2.0.0-dev
-  date: 2019-12-05T12:00:00Z
-  version: 10.0.0
+  date: 2019-11-05T12:00:00Z
+  version: 10.1.0
 - active: false
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.5.1-dev
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.21.1-dev
   date: 2019-11-05T12:00:00Z
   version: 9.1.0
 - active: true
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.5.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.21.0
   date: 2019-10-28T12:00:00Z
   version: 9.0.0
 - active: true
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.4.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.20.0
   date: 2019-09-02T13:30:00Z
   version: 8.5.0
 - active: false
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.3.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.19.0
   date: 2019-09-24T11:00:00Z
   version: 8.4.1
 - active: false
   authorities:
-    - name: app-operator
+    - endpoint: http://app-operator:8000
+      name: app-operator
       version: 1.0.0
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.3.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.19.0
   date: 2019-08-19T16:30:00Z
   version: 8.4.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.2.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.7.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.18.0
   date: 2019-08-19T10:00:00Z
   version: 8.3.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.2.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.6.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.17.0
   date: 2019-08-09T10:00:00Z
   version: 8.2.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.2.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.6.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.17.0
   date: 2019-06-03T10:00:00Z
   version: 8.2.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.1.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.6.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.16.0
   date: 2019-06-04T16:00:00Z
   version: 8.1.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 5.0.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.15.0
   date: 2019-04-17T08:00:00Z
   version: 8.0.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.9.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.14.1
   date: 2019-04-25T18:00:00Z
   version: 7.3.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.9.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.14.0
   date: 2019-04-17T08:00:00Z
   version: 7.3.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.8.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.13.0
   date: 2019-03-21T10:00:00Z
   version: 7.2.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.8.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.12.0
   date: 2019-03-12T10:00:00Z
   version: 7.1.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.7.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.12.0
   date: 2019-03-04T10:00:00Z
   version: 7.1.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.7.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.11.0
   date: 2019-02-20T12:00:00Z
   version: 7.0.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.6.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.10.0
   date: 2019-03-12T10:00:00Z
   version: 6.3.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.6.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.10.0
   date: 2019-01-16T12:23:00Z
   version: 6.3.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.5.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2019-02-12T13:08:00Z
   version: 6.2.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.5.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2019-01-16T11:12:00Z
   version: 6.2.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.4.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.9.0
   date: 2018-12-03T22:57:00Z
   version: 6.1.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.4.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.8.0
   date: 2018-11-23T17:00:00Z
   version: 6.1.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.3.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.5.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.8.0
   date: 2018-10-27T13:00:00Z
   version: 6.0.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.2.2
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.4.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.7.2
   date: 2019-02-12T13:13:00Z
   version: 5.2.4
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.2.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.4.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.7.2
   date: 2019-01-24T14:00:00Z
   version: 5.2.3
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.2.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.4.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.7.1
   date: 2018-12-03T22:56:00Z
   version: 5.2.2
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.2.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.4.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.7.1
   date: 2018-11-05T12:30:00Z
   version: 5.2.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.2.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.4.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.7.0
   date: 2018-09-28T09:00:00Z
   version: 5.2.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.1.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-26T12:00:00Z
   version: 5.1.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.1.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-10T06:00:00Z
   version: 5.1.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 4.0.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-08-30T08:00:00Z
   version: 5.0.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.3.4
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-12-03T22:55:00Z
   version: 4.5.3
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.3.3
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-25T14:00:00Z
   version: 4.5.2
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.3.2
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-09-17T14:00:00Z
   version: 4.5.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.3.1
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.6.0
   date: 2018-08-27T12:00:00Z
   version: 4.5.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.3.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: chart-operator
+    - endpoint: http://chart-operator:8000
+      name: chart-operator
       version: 0.3.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.5.0
   date: 2018-07-26T12:00:00Z
   version: 4.4.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.2.0
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.5.0
   date: 2018-07-11T12:00:00Z
   version: 4.3.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.1.3
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.4.0
   date: 2018-07-11T12:01:00Z
   version: 4.2.2
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.1.2
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.4.0
   date: 2018-06-21T12:00:00Z
   version: 4.2.1
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.1.2
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.3.0
   date: 2018-05-29T12:00:00Z
   version: 4.2.0
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.0.4
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.2.0
   date: 2018-05-30T12:00:00Z
   version: 3.4.4
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 3.0.3
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
-    - name: cluster-operator
+    - endpoint: http://cluster-operator:8000
+      name: cluster-operator
       provider: aws
       version: 0.2.0
   date: 2018-05-18T12:00:00Z
   version: 3.4.3
 - active: false
   authorities:
-    - name: aws-operator
+    - endpoint: http://aws-operator:8000
+      name: aws-operator
       version: 2.0.2
-    - name: cert-operator
+    - endpoint: http://cert-operator:8000
+      name: cert-operator
       version: 0.1.0
   date: 2018-01-31T10:43:00Z
   version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-legacy:8000
+    - endpoint: http://aws-operator-drop-unused-azs:8000
       name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000

--- a/aws.yaml
+++ b/aws.yaml
@@ -43,7 +43,7 @@
     - endpoint: http://app-operator:8000
       name: app-operator
       version: 1.0.0
-    - endpoint: http://aws-operator-lock-azs:8000
+    - endpoint: http://aws-operator:8000
       name: aws-operator
       version: 6.4.0
     - endpoint: http://cert-operator:8000


### PR DESCRIPTION
Here is nothing interesting. We only want to deploy some versions of the operator to test Node Pool upgrades.