### PR TITLE
Azure release 9.0.0 with Kubernetes 1.15.5

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -16,8 +16,28 @@
     name: cluster-operator
     provider: azure
     version: 0.21.0
-  date: 2019-09-04T10:00:00Z
-  version: 8.5.0
+  date: 2019-10-25T10:00:00Z
+  version: 9.1.0
+- active: true
+  authorities:
+  - endpoint: http://app-operator:8000
+    name: app-operator
+    version: 1.0.0
+  - endpoint: http://azure-operator:8000
+    name: azure-operator
+    version: 2.7.0
+  - endpoint: http://cert-operator:8000
+    name: cert-operator
+    version: 0.1.0
+  - endpoint: http://chart-operator:8000
+    name: chart-operator
+    version: 0.7.0
+  - endpoint: http://cluster-operator:8000
+    name: cluster-operator
+    provider: azure
+    version: 0.21.0
+  date: 2019-10-25T10:00:00Z
+  version: 9.0.0
 - active: true
   authorities:
   - endpoint: http://app-operator:8000
@@ -126,7 +146,7 @@
     version: 0.15.0
   date: 2019-03-21T10:00:00Z
   version: 8.0.0
-- active: true
+- active: false
   authorities:
   - endpoint: http://azure-operator:8000
     name: azure-operator
@@ -211,7 +231,7 @@
     version: 0.11.0
   date: 2019-03-01T15:00:00Z
   version: 7.0.0
-- active: true
+- active: false
   authorities:
   - endpoint: http://azure-operator:8000
     name: azure-operator
@@ -279,7 +299,7 @@
     version: 0.7.0
   date: 2018-08-28T09:00:00Z
   version: 2.0.0
-- active: true
+- active: false
   authorities:
   - endpoint: http://azure-operator:8000
     name: azure-operator

--- a/azure.yaml
+++ b/azure.yaml
@@ -5,7 +5,7 @@
     version: 1.0.0
   - endpoint: http://azure-operator:8000
     name: azure-operator
-    version: 2.7.0
+    version: 2.8.0
   - endpoint: http://cert-operator:8000
     name: cert-operator
     version: 0.1.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -15,7 +15,7 @@
   - endpoint: http://cluster-operator:8000
     name: cluster-operator
     provider: azure
-    version: 0.21.0
+    version: 0.22.0
   date: 2019-10-25T10:00:00Z
   version: 9.1.0
 - active: true

--- a/release-notes/azure/v9.0.0.md
+++ b/release-notes/azure/v9.0.0.md
@@ -1,29 +1,30 @@
 :lightning: Giant Swarm Release 9.0.0 for Azure is now active for you! :lightning:
-##### azure-operator (v2.7.0)
-- Add all service endpoints to the VNET.
-- Add new rule to the public load balancer to allow outgoing UDP traffic from the master nodes to allow communication with NTP time servers.
-#### Core components
-##### Kubernetes (v1.15.5)
-- Updated from v1.14.6. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes
-##### Calico (v3.9.1)
-- Updated from v3.8.2. https://docs.projectcalico.org/v3.9/release-notes/
-##### CoreOS Container Linux (v2191.5.0)
-- Updated from v2135.4.0. https://coreos.com/releases/#2191.5.0
-##### etcd (v3.3.15)
-- Updated from v3.3.13. https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3315-2019-08-19
-#### Managed apps
-##### kube-state-metrics (GS v0.6.0, upstream v1.8.0)
-- Updated from GS v0.5.0. https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v060
-- Updated from upstream `kube-state-metrics` v1.7.2. https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v180--2019-10-01
-##### nginx-ingress-controller (GS v1.0.0, upstream v0.26.1)
-- Updated from GS v0.10.2. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md#100
-- Updated from upstream `ingress-nginx` v0.25.1. https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0261
-- **Note** Includes the following breaking changes
-  - The variable `$the_real_ip` was removed from template and default `log_format`.
-  - The default value of configmap setting `proxy-add-original-uri-header` is now `false`.
-  - When the setting `proxy-add-original-uri-header` is `true`, the ingress controller adds a new header `X-Original-Uri` with the value of NGINX variable `$request_uri`. In most of the cases this is not an issue but with request with long URLs it could lead to unexpected errors in the application defined in the `Ingress` `serviceName`, like issue [4593 - 431 Request Header Fields Too Large](https://github.com/kubernetes/ingress-nginx/issues/4593).
-##### coredns (GS v0.8.0, upstream v1.16.4)
-- Updated from GS v0.7.0. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080
-- Updated from upstream `coredns` v1.16.2. https://coredns.io/2019/09/27/coredns-1.6.4-release/
-##### metrics-server (GS v0.4.1, upstream v0.3.3)
-- Updated from GS v0.4.0. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041
+
+*azure-operator v2.7.0*
+• Add all service endpoints to the VNET.
+• Add new rule to the public load balancer for outgoing UDP traffic from the master nodes to allow communication with NTP time servers.
+
+*Kubernetes v1.15.5*
+• Updated from v1.14.6. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes
+
+*Calico v3.9.1*
+• Updated from v3.8.2. https://docs.projectcalico.org/v3.9/release-notes/
+
+*CoreOS Container Linux v2191.5.0*
+• Updated from v2135.4.0. https://coreos.com/releases/#2191.5.0
+
+*etcd v3.3.15*
+• Updated from v3.3.13. https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3315-2019-08-19
+
+*kube-state-metrics v1.8.0 (GS v0.6.0)*
+• Updated from upstream `kube-state-metrics` v1.7.2. https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v180--2019-10-01
+
+*nginx-ingress-controller v0.26.1 (GS v1.0.0)*
+• Updated from upstream `ingress-nginx` v0.25.1. https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0261
+• *Note* Includes the following breaking changes
+  • The variable `$the_real_ip` was removed from template and default `log_format`.
+  • The default value of configmap setting `proxy-add-original-uri-header` is now `false`.
+  • When the setting `proxy-add-original-uri-header` is `true`, the ingress controller adds a new header `X-Original-Uri` with the value of NGINX variable `$request_uri`. In most of the cases this is not an issue but with request with long URLs it could lead to unexpected errors in the application defined in the `Ingress` `serviceName`, like issue [4593 • 431 Request Header Fields Too Large](https://github.com/kubernetes/ingress-nginx/issues/4593).
+
+*coredns v1.16.4 (GS v0.8.0)*
+• Updated from upstream `coredns` v1.16.2. https://coredns.io/2019/09/27/coredns-1.6.4-release/

--- a/release-notes/azure/v9.0.0.md
+++ b/release-notes/azure/v9.0.0.md
@@ -1,0 +1,29 @@
+:lightning: Giant Swarm Release 9.0.0 for Azure is now active for you! :lightning:
+##### azure-operator (v2.7.0)
+- Add all service endpoints to the VNET.
+- Add new rule to the public load balancer to allow outgoing UDP traffic from the master nodes to allow communication with NTP time servers.
+#### Core components
+##### Kubernetes (v1.15.5)
+- Updated from v1.14.6. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes
+##### Calico (v3.9.1)
+- Updated from v3.8.2. https://docs.projectcalico.org/v3.9/release-notes/
+##### CoreOS Container Linux (v2191.5.0)
+- Updated from v2135.4.0. https://coreos.com/releases/#2191.5.0
+##### etcd (v3.3.15)
+- Updated from v3.3.13. https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3315-2019-08-19
+#### Managed apps
+##### kube-state-metrics (GS v0.6.0, upstream v1.8.0)
+- Updated from GS v0.5.0. https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v060
+- Updated from upstream `kube-state-metrics` v1.7.2. https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v180--2019-10-01
+##### nginx-ingress-controller (GS v1.0.0, upstream v0.26.1)
+- Updated from GS v0.10.2. https://github.com/giantswarm/kubernetes-nginx-ingress-controller/blob/master/CHANGELOG.md#100
+- Updated from upstream `ingress-nginx` v0.25.1. https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0261
+- **Note** Includes the following breaking changes
+  - The variable `$the_real_ip` was removed from template and default `log_format`.
+  - The default value of configmap setting `proxy-add-original-uri-header` is now `false`.
+  - When the setting `proxy-add-original-uri-header` is `true`, the ingress controller adds a new header `X-Original-Uri` with the value of NGINX variable `$request_uri`. In most of the cases this is not an issue but with request with long URLs it could lead to unexpected errors in the application defined in the `Ingress` `serviceName`, like issue [4593 - 431 Request Header Fields Too Large](https://github.com/kubernetes/ingress-nginx/issues/4593).
+##### coredns (GS v0.8.0, upstream v1.16.4)
+- Updated from GS v0.7.0. https://github.com/giantswarm/kubernetes-coredns/blob/eb9e6979e4bb35b03bd9b0c99e1c68b6a4f3b4c6/CHANGELOG.md#v080
+- Updated from upstream `coredns` v1.16.2. https://coredns.io/2019/09/27/coredns-1.6.4-release/
+##### metrics-server (GS v0.4.1, upstream v0.3.3)
+- Updated from GS v0.4.0. https://github.com/giantswarm/metrics-server-app/blob/db61c5c13c4ba55c357ab098253b3f3fe8f4e2cd/CHANGELOG.md#v041


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6431

Starting with this release, release notes are included as a permanent record in markdown form in this repo. The Slack formatted release notes are here https://gigantic.slack.com/archives/CHAHY6VMF/p1572019708004300

Split off from https://github.com/giantswarm/releases/pull/17 in the interest of speed.