### PR TITLE
Update WIP releases to use cluster-operator 0.22.0

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -15,7 +15,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: aws
-      version: 0.21.0
+      version: 0.22.0
   date: 2019-09-26T12:00:00Z
   version: 8.6.0
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,15 +35,9 @@
   - endpoint: http://cluster-operator:8000
     name: cluster-operator
     provider: azure
-<<<<<<< HEAD
-    version: 0.22.0
-  date: 2019-09-04T10:00:00Z
-  version: 8.5.0
-=======
     version: 0.21.0
   date: 2019-10-25T10:00:00Z
   version: 9.0.0
->>>>>>> master
 - active: true
   authorities:
   - endpoint: http://app-operator:8000

--- a/azure.yaml
+++ b/azure.yaml
@@ -15,7 +15,7 @@
   - endpoint: http://cluster-operator:8000
     name: cluster-operator
     provider: azure
-    version: 0.21.0
+    version: 0.22.0
   date: 2019-09-04T10:00:00Z
   version: 8.5.0
 - active: true

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -12,7 +12,7 @@
     - endpoint: http://cluster-operator:8000
       name: cluster-operator
       provider: kvm
-      version: 0.21.0
+      version: 0.22.0
     - endpoint: http://flannel-operator:8000
       name: flannel-operator
       version: 0.2.0


### PR DESCRIPTION
Updates the WIP releases to use the new version wired in https://github.com/giantswarm/cluster-operator/pull/752.

@MarcelMue @tfussell Can we use this for the new WIP releases you're preparing?

So we ship cluster-operator 0.21.0 in the new active versions.