### PR TITLE
add cluster autoscaler update to aws release notes

### DIFF
--- a/release-notes/aws/v9.0.0.md
+++ b/release-notes/aws/v9.0.0.md
@@ -25,3 +25,6 @@
 
 *coredns v1.6.4 (GS v0.8.0)*
 • Updated from upstream `coredns` v1.6.2. https://coredns.io/2019/09/27/coredns-1.6.4-release/
+
+*Cluster Autoscaler v1.5.2 (GS v0.9.0)*
+• Updated from upstream `Cluster Autoscaler` v1.14.3. https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.2


### PR DESCRIPTION
This adds a missing note about the cluster autoscaler update which is AWS specific.