### PR TITLE
set aws-operator@5.5.1-dev in the WIP AWS release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -5,7 +5,7 @@
       version: 1.0.0
     - endpoint: http://aws-operator:8000
       name: aws-operator
-      version: 5.6.0
+      version: 5.5.1-dev
     - endpoint: http://cert-operator:8000
       name: cert-operator
       version: 0.1.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -16,7 +16,7 @@
       name: cluster-operator
       provider: aws
       version: 0.22.0
-  date: 2019-10-28T12:00:00Z
+  date: 2019-11-05T12:00:00Z
   version: 9.1.0
 - active: true
   authorities:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7511

See related aws-operator PR: https://github.com/giantswarm/aws-operator/pull/2061