### PR TITLE
Add AWS 10.2.0 WIP release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1,3 +1,18 @@
+- active: false
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 8.0.2
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: aws
+      version: 2.1.0-dev
+  date: 2019-12-27T14:00:00Z
+  version: 10.2.0
 - active: true
   authorities:
     - name: app-operator


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6817

Supports testing cluster-operator master branch HEAD 2.1.0-dev version (see [here](https://github.com/giantswarm/cluster-operator/blob/master/pkg/project/project.go#L4)).