### PR TITLE
Deactivate 10.1.0 release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -13,7 +13,7 @@
       version: 2.0.1-dev
   date: 2020-01-03T14:00:00Z
   version: 10.1.1
-- active: true
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0


### PR DESCRIPTION
Deactivate 10.1.0 release from AWS installation. 
We found a CoreDNS helm chart having a template issue on this release which causing DNS errors. So I would like to deactivate it so we can stop outages from installations. 

It will disable creating a node pool cluster after that. 