### PR TITLE
Use 8.0.3-dev for AWS WIP release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -3,7 +3,7 @@
     - name: app-operator
       version: 1.0.0
     - name: aws-operator
-      version: 8.0.2
+      version: 8.0.3-dev
     - name: cert-operator
       version: 0.1.0
     - name: chart-operator


### PR DESCRIPTION
See https://github.com/giantswarm/releases/pull/68/files#r365353269 

This is the WIP AWS release so it should use WIP version of aws-operaotor.