### PR TITLE
Add WIP release to Azure up-coming-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains giantswarm releases and changelogs.
  - [8.5.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v8.5.0.md)
 
 ### Azure
+ - [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.0.0.md)
+ - 10.0.0 - Skipped to stay in sync with AWS releases
  - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v9.0.0.md)
  - [8.4.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.1.md)
  - [8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.0.md)

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,18 +1,18 @@
-- active: false
+- active: true
   authorities:
-    - name: app-operator
-      version: 1.0.0
-    - name: azure-operator
-      version: 2.8.0
-    - name: cert-operator
-      version: 0.1.0
-    - name: chart-operator
-      version: 0.7.0
-    - name: cluster-operator
-      provider: azure
-      version: 0.21.1-dev
-  date: 2019-10-25T10:00:00Z
-  version: 9.1.0
+  - name: app-operator
+    version: 1.0.0
+  - name: azure-operator
+    version: 2.8.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: chart-operator
+    version: 0.7.0
+  - name: cluster-operator
+    provider: azure
+    version: 0.21.1-dev
+  date: 2019-01-08T12:00:00Z
+  version: 11.0.0
 - active: true
   authorities:
     - name: app-operator
@@ -28,7 +28,7 @@
       version: 0.21.0
   date: 2019-10-25T10:00:00Z
   version: 9.0.0
-- active: true
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,7 +10,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.21.1-dev
+    version: 0.21.1
   date: 2019-01-08T12:00:00Z
   version: 11.0.0
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,3 +1,18 @@
+- active: false
+  authorities:
+  - name: app-operator
+    version: 1.0.0
+  - name: azure-operator
+    version: 2.9.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: chart-operator
+    version: 0.7.0
+  - name: cluster-operator
+    provider: azure
+    version: 0.21.3
+  date: 2019-01-22T12:00:00Z
+  version: 12.0.0
 - active: true
   authorities:
   - name: app-operator

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,7 +10,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.21.1
+    version: 0.21.2-dev
   date: 2019-01-08T12:00:00Z
   version: 11.0.0
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,7 +10,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.21.2-dev
+    version: 0.21.2
   date: 2019-01-08T12:00:00Z
   version: 11.0.0
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,7 +10,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.21.2
+    version: 0.21.3
   date: 2019-01-08T12:00:00Z
   version: 11.0.0
 - active: true

--- a/release-notes/azure/v11.0.0.md
+++ b/release-notes/azure/v11.0.0.md
@@ -1,0 +1,40 @@
+## :zap: Giant Swarm Release 11.0.0 for Azure is now active for you! :zap:
+
+### Kubernetes v1.16.3
+- Updated from v1.15.5 - [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#kubernetes-v1160-release-notes)
+- Custom resources: CRDs are in widespread use as a way to extend Kubernetes to persist and serve new resource types, and have been available in beta since the 1.7 release. The 1.16 release marks the graduation of CRDs to general availability (GA).
+- Admission webhooks: Admission webhooks are in widespread use as a Kubernetes extensibility mechanism and have been available in beta since the 1.9 release. The 1.16 release marks the graduation of admission webhooks to general availability (GA).
+- Overhauled metrics: Kubernetes has previously made extensive use of a global metrics registry to register metrics to be exposed. By implementing a metrics registry, metrics are registered in more transparent means. Previously, Kubernetes metrics have been excluded from any kind of stability requirements.
+- Volume Extension: There are quite a few enhancements in this release that pertain to volumes and volume modifications. Volume resizing support in CSI specs is moving to beta which allows for any CSI spec volume plugin to be resizable.
+- Node labels beta.kubernetes.io/metadata-proxy-ready, beta.kubernetes.io/metadata-proxy-ready and beta.kubernetes.io/kube-proxy-ds-ready are no longer added on new nodes.
+- As previously communicated, resources under `apps/v1beta1` and `apps/v1beta2` groups have been moved to `apps/v1` instead. Similarly, `daemonsets`, `deployments`, `replicasets` resources under `extensions/v1beta1` have been moved to `apps/v1`, `networkpolicies` under `extensions/v1beta1` to `networking.k8s.io/v1`, and `podsecuritypolicies` under `extensions/v1beta1` to `policy/v1beta1`.
+
+### Calico v3.10.1
+- Updated from v3.9.1 - [changelog](https://docs.projectcalico.org/v3.10/release-notes/)
+- Calico now supports two new top-level selectors to make writing Calico network policy easier. The `namespaceSelector` allows you to select the namespace(s) to apply a global network policy to. This enables you to write a single network policy applicable to one or more namespaces.
+- Calico now supports BGP advertisement of Kubernetes service ExternalIPs in addition to advertising ClusterIPs. Advertising service external IPs allows for more flexible routing architectures.
+- Configurable default IPv4, IPv6 block sizes and pool node selectors.
+- Typha is now run as a non-root user for improved security.
+
+### CoreOS Container Linux v2247.6.0
+- Updated from v2191.5.0 - [changelog](https://coreos.com/releases/#2247.6.0)
+- The Linux kernel was updated to 4.19.78.
+- The timezone for Brazil was fixed.
+
+### etcd v3.3.17
+- Updated from v3.3.15 - [changelog](https://github.com/etcd-io/etcd/blob/master/CHANGELOG-3.3.md#v3317-2019-10-11)
+- Added `etcd --experimental-peer-skip-client-san-verification` to skip verification of peer client address.
+- Added `etcd_debugging_mvcc_current_revision` and `etcd_debugging_mvcc_compact_revision` Prometheus metrics.
+
+### Helm v2.16.1 (primarily for GS-internal use)
+- Updated from v2.14.3 - [changelog](https://github.com/helm/helm/releases/tag/v2.16.1)
+- Helm v2.15 was the last feature release for Helm v2 as new feature development now happens in Helm v3. The v2.16 release include fixes to issues that are too large of a change for a patch release.
+
+### coreDNS v1.6.5 ([GS v1.1.0](https://github.com/giantswarm/coredns-app/blob/master/CHANGELOG.md#v110))
+- Updated from upstream `coredns` v1.6.4 - [changelog](https://coredns.io/2019/11/05/coredns-1.6.5-release/)
+- Migrated to be deployed via an app CR not a chartconfig CR.
+
+### Cluster Autoscaler v1.16.2 ([GS v1.1.0](https://github.com/giantswarm/cluster-autoscaler-app/blob/master/CHANGELOG.md#v110))
+- Updated from upstream `Cluster Autoscaler` v1.16.2 - [changelog](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.2)
+- Migrated to be deployed via an app CR not a chartconfig CR.
+- Ignore `kops.k8s.io/instancegroup` and `alpha.eksctl.io/nodegroup-name` when comparing node groups for similarity.


### PR DESCRIPTION
Latest WIP of `azure-operator` is missing from everywhere.