### PR TITLE
Mention nginx IC in Azure 11.0.0 release notes

### DIFF
--- a/release-notes/azure/v11.0.0.md
+++ b/release-notes/azure/v11.0.0.md
@@ -75,3 +75,6 @@ This is the first Giant Swarm release which includes Kubernetes v1.16. In additi
 ### node_exporter v0.18.1 ([Giant Swarm app v1.2.0](https://github.com/giantswarm/node-exporter-app/blob/master/CHANGELOG.md#120-2020-01-08))
 - Updated to upstream version 0.18.1 - [changelog](https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md#0181--2019-06-04).
 - Changed priority class to `system-node-critical`.
+
+### nginx-ingress-controller v0.26.1 ([Giant Swarm app v1.1.1](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v111-2020-01-04))
+- Updated manifests for Kubernetes v1.16 compatibility.

--- a/release-notes/azure/v11.0.0.md
+++ b/release-notes/azure/v11.0.0.md
@@ -72,9 +72,9 @@ This is the first Giant Swarm release which includes Kubernetes v1.16. In additi
 ### net-exporter [v1.5.1](https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#151-2020-01-08)
 - Changed priority class to `system-node-critical`.
 
+### nginx-ingress-controller v0.26.1 ([Giant Swarm app v1.1.1](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v111-2020-01-04))
+- Updated manifests for Kubernetes v1.16 compatibility.
+
 ### node_exporter v0.18.1 ([Giant Swarm app v1.2.0](https://github.com/giantswarm/node-exporter-app/blob/master/CHANGELOG.md#120-2020-01-08))
 - Updated to upstream version 0.18.1 - [changelog](https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md#0181--2019-06-04).
 - Changed priority class to `system-node-critical`.
-
-### nginx-ingress-controller v0.26.1 ([Giant Swarm app v1.1.1](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v111-2020-01-04))
-- Updated manifests for Kubernetes v1.16 compatibility.


### PR DESCRIPTION
We forgot to mention that nginx IC was updated to support 1.16. Not that important but added for the sake of completeness. AWS 9.1 and KVM 11.0 release PRs have been updated correspondingly.