### PR TITLE
Clean up 11.0 and 11.1 (WIP) releases

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -11,7 +11,7 @@
   - name: cluster-operator
     provider: azure
     version: 0.21.5-dev
-  date: 2019-01-29T12:00:00Z
+  date: 2020-01-29T12:00:00Z
   version: 11.1.0
 - active: true
   authorities:
@@ -26,7 +26,7 @@
   - name: cluster-operator
     provider: azure
     version: 0.21.4
-  date: 2019-01-08T12:00:00Z
+  date: 2020-01-08T12:00:00Z
   version: 11.0.0
 - active: true
   authorities:

--- a/azure.yaml
+++ b/azure.yaml
@@ -10,7 +10,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.21.5-dev
+    version: 0.22.1-dev
   date: 2020-01-29T12:00:00Z
   version: 11.1.0
 - active: true

--- a/release-notes/azure/v11.0.0.md
+++ b/release-notes/azure/v11.0.0.md
@@ -36,9 +36,6 @@ This is the first Giant Swarm release which includes Kubernetes v1.16. In additi
 ### cert-exporter [v1.2.1](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24)
 - Removed CPU limits to improve reliability.
 
-### cert-manager v0.9.0 ([Giant Swarm app v1.0.4](https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v104-2020-01-15))
-- Removed CPU limits to improve reliability.
-
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
 - Removed CPU limits to improve reliability.
 - Adjusted RBAC permissions.

--- a/release-notes/azure/v11.1.0.md
+++ b/release-notes/azure/v11.1.0.md
@@ -1,0 +1,8 @@
+## :zap: Giant Swarm Release 11.1.0 for Azure is now active for you! :zap:
+
+_Introduction here_
+
+---
+
+### azure-operator v2.9.0
+- TODO.

--- a/release-notes/azure/v11.1.0.md
+++ b/release-notes/azure/v11.1.0.md
@@ -1,8 +1,0 @@
-## :zap: Giant Swarm Release 11.1.0 for Azure is now active for you! :zap:
-
-_Introduction here_
-
----
-
-### azure-operator v2.9.0
-- TODO.

--- a/release-notes/kvm/v11.0.0.md
+++ b/release-notes/kvm/v11.0.0.md
@@ -32,9 +32,6 @@ This is the first Giant Swarm release which includes Kubernetes v1.16. In additi
 ### cert-exporter [v1.2.1](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24)
 - Removed CPU limits to improve reliability.
 
-### cert-manager v0.9.0 ([Giant Swarm app v1.0.4](https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v104-2020-01-15))
-- Removed CPU limits to improve reliability.
-
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
 - Removed CPU limits to improve reliability.
 - Adjusted RBAC permissions.


### PR DESCRIPTION
- Fix 11.0 and 11.1 release dates (copy and paste error)
- Add stub 11.1 release notes (trying this out for the next release)
- Remove cert-manager from release notes (only used in AWS w/ node pools AFAICT)