### PR TITLE
Adding default catalog on app

### DIFF
--- a/app/config/default.yaml
+++ b/app/config/default.yaml
@@ -1,2 +1,3 @@
+catalog: default
 namespace: kube-system
 useUpgradeForce: true


### PR DESCRIPTION
Toward giantswarm/giantswarm#8135

For the spec, please check https://github.com/giantswarm/giantswarm/blob/master/areas/managed-services/specs/app-on-release.md

Forgot to add `catalog` on default app setting. 