### PR TITLE
Add AWS v10.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains Giant Swarm releases and changelogs.
 
 ### AWS
  - [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.0.0.md)
+ - [10.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.2.md)
+ - [10.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.1.md)
  - [10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
  - [9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
  - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -25,6 +25,21 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
+      version: 2.0.2
+  date: 2020-02-06T08:00:00Z
+  version: 10.1.2
+- active: false
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 8.0.2
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: aws
       version: 2.0.1
   date: 2020-01-10T08:00:00Z
   version: 10.1.1

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -1,0 +1,17 @@
+# :zap: Giant Swarm Release 10.1.2 for AWS is now active for you! :zap:
+
+This release fixes a problem with the chart-operator cluster role. The changes
+only affect managed apps and upgrading to this release will not cause tenant
+cluster nodes to be rolled.
+
+### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
+- Adjusted RBAC permissions.
+
+### cluster-autoscaler v1.16.2 ([Giant Swarm app v1.1.3](https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.3))
+- Updated manifests for Kubernetes 1.16 compatibility.
+
+### kiam v3.4 ([Giant Swarm app v1.0.3](https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3))
+- Updated manifests for Kubernetes 1.16 compatibility.
+
+### cert-manager v0.9.0 ([Giant Swarm app v1.0.4](https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.4))
+- Improvements for clusters with restrictive network policies.

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -2,6 +2,8 @@
 
 This release fixes a problem with the cluster role for chart-operator, which is responsible for installing and updating Managed Apps. The changes affect only Managed Apps and upgrading to this release will not cause cluster nodes to be rolled. **To prevent encountering problems when installing or updating an app, please upgrade to this release.**
 
+**Please note:** We are still resolving the issue with network traffic between node pools in 10.x and 11.x clusters reported yesterday (5th Feb 2020).
+
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
 - Adjusted RBAC permissions.
 

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -10,8 +10,15 @@ cluster nodes to be rolled.
 ### cluster-autoscaler v1.16.2 ([Giant Swarm app v1.1.3](https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.1.3))
 - Updated manifests for Kubernetes 1.16 compatibility.
 
-### kiam v3.4 ([Giant Swarm app v1.0.3](https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3))
+### kiam v3.4 ([Giant Swarm app v1.0.4](https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3))
 - Updated manifests for Kubernetes 1.16 compatibility.
 
 ### cert-manager v0.9.0 ([Giant Swarm app v1.0.4](https://github.com/giantswarm/cert-manager-app/releases/tag/v1.0.4))
 - Improvements for clusters with restrictive network policies.
+
+### kube-state-metrics v1.9.2 ([Giant Swarm app v1.0.2](https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v102))
+- Updated to upstream version 1.9.2 - [changelog](https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v192--2020-01-13).
+- Adjusted RBAC configuration.
+
+### net-exporter [v1.5.1](https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#151-2020-01-08)
+- Changed priority class to `system-node-critical`.

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -4,6 +4,8 @@ This release fixes a problem with the chart-operator cluster role. The changes
 only affect managed apps and upgrading to this release will not cause tenant
 cluster nodes to be rolled.
 
+This release fixes a problem with the cluster role for chart-operator, which is responsible for installing and updating Managed Apps. The changes affect only Managed Apps and upgrading to this release will not cause cluster nodes to be rolled. **To prevent encountering problems when installing or updating an app, please upgrade to this release.**
+
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
 - Adjusted RBAC permissions.
 

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -2,7 +2,7 @@
 
 This release fixes a problem with the cluster role for chart-operator, which is responsible for installing and updating Managed Apps. The changes affect only Managed Apps and upgrading to this release will not cause cluster nodes to be rolled. **To prevent encountering problems when installing or updating an app, please upgrade to this release.**
 
-**Please note:** We are still resolving the issue with network traffic between node pools in 10.x and 11.x clusters reported yesterday (5th Feb 2020).
+**Please Note:** We are still resolving the issue with network traffic between node pools in 10.x and 11.x clusters reported yesterday (5th Feb 2020).
 
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)
 - Adjusted RBAC permissions.

--- a/release-notes/aws/v10.1.2.md
+++ b/release-notes/aws/v10.1.2.md
@@ -1,9 +1,5 @@
 # :zap: Giant Swarm Release 10.1.2 for AWS is now active for you! :zap:
 
-This release fixes a problem with the chart-operator cluster role. The changes
-only affect managed apps and upgrading to this release will not cause tenant
-cluster nodes to be rolled.
-
 This release fixes a problem with the cluster role for chart-operator, which is responsible for installing and updating Managed Apps. The changes affect only Managed Apps and upgrading to this release will not cause cluster nodes to be rolled. **To prevent encountering problems when installing or updating an app, please upgrade to this release.**
 
 ### chart-operator [v0.11.3](https://github.com/giantswarm/chart-operator/releases/tag/v0.11.3)


### PR DESCRIPTION
This PR replaces the AWS 10.1.1 release for Kubernetes 1.15. 

It uses cluster-operator 2.0.1 which uses chart-operator 0.11.2. This has a bug in its cluster role that I fixed in 0.11.3 https://github.com/giantswarm/chart-operator/pull/347.

@paurosello Reported hitting this with a TC in gorilla on Friday.

https://gigantic.slack.com/archives/C76JX6YLQ/p1579268936006700

I was able to create a 10.1.1 cluster without hitting the error. But I think its safest to create this release so we are sure it's fixed.




 
