### PR TITLE
App & apps' changelog on release 

### DIFF
--- a/app/changelog/cert-exporter.yaml
+++ b/app/changelog/cert-exporter.yaml
@@ -1,0 +1,5 @@
+- version: 1.2.1
+  description: Remove CPU limits.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24

--- a/app/changelog/cert-manager.yaml
+++ b/app/changelog/cert-manager.yaml
@@ -1,0 +1,18 @@
+- version: 1.1.0
+  componentVersion: 0.13.0
+  description: Updated cert-manager app version to v0.13.0.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v110-2020-02-04
+- version: 1.0.4
+  componentVersion: 0.9.0
+  description: Updated helm chart for clusters with restrictive network policies.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v104-2020-01-15
+- version: 1.0.3
+  componentVersion: 0.9.0
+  description: Updated manifests for Kubernetes 1.16.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v103-2020-01-03

--- a/app/changelog/chart-operator.yaml
+++ b/app/changelog/chart-operator.yaml
@@ -1,0 +1,10 @@
+- version: 0.11.4
+  description: Handle timeouts pulling chart tarballs.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/pull/349
+- version: 0.11.2
+  description: Remove CPU Limits
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/pull/335

--- a/app/changelog/cluster-autoscaler.yaml
+++ b/app/changelog/cluster-autoscaler.yaml
@@ -1,0 +1,19 @@
+- version: 1.1.4
+  componentVersion: 1.16.2
+  description: Increase memory request and limits to 400MB.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cluster-autoscaler-app/blob/master/CHANGELOG.md#v114-2020-01-24
+- version: 1.1.3
+  componentVersion: 1.16.2
+  description: Add CSINode access to RBAC role.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cluster-autoscaler-app/blob/master/CHANGELOG.md#v113-2020-01-22
+- version: 1.1.2
+  componentVersion: 1.16.2
+  description: Updated manifests for Kubernetes 1.16.
+  kind: changed
+  urls:
+      - https://github.com/giantswarm/cluster-autoscaler-app/blob/master/CHANGELOG.md#v112-2020-01-03
+

--- a/app/changelog/coredns.yaml
+++ b/app/changelog/coredns.yaml
@@ -1,0 +1,6 @@
+- version: 1.1.3
+  componentVersion: 1.6.5
+  description: Fix HPA manifests for Kubernetes 1.16.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/coredns-app/blob/master/CHANGELOG.md#v113-2020-01-08

--- a/app/changelog/external-dns.yaml
+++ b/app/changelog/external-dns.yaml
@@ -1,0 +1,12 @@
+- version: 1.2.0
+  componentVersion: 0.5.18
+  description: Updated external-dns app version to v0.5.18.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/external-dns-app/blob/master/CHANGELOG.md#v120-2020-02-04
+- version: 1.1.0
+  componentVersion: 0.5.11
+  description: Added support AWS SDK configuration with explicit credentials.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/external-dns-app/blob/master/CHANGELOG.md#v110

--- a/app/changelog/kiam.yaml
+++ b/app/changelog/kiam.yaml
@@ -1,0 +1,12 @@
+- version: 1.1.0
+  componentVersion: 3.5.0
+  description: Updated kiam app version to v3.5.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v110-2020-02-04
+- version: 1.0.2
+  componentVersion: 3.4.0
+  description: Removed CPU limits.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v102-2020-01-04

--- a/app/changelog/kube-state-metrics.yaml
+++ b/app/changelog/kube-state-metrics.yaml
@@ -1,0 +1,6 @@
+- version: 1.0.0
+  componentVersion: 1.9.0
+  description: Upgraded to kube-state-metrics new release 1.9.0
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24

--- a/app/changelog/metrics-server.yaml
+++ b/app/changelog/metrics-server.yaml
@@ -1,0 +1,6 @@
+- version: 1.0.0
+  componentVersion: 0.3.3
+  description: Updated manifests for Kubernetes 1.16.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/metrics-server-app/blob/master/CHANGELOG.md#v100-2020-01-03

--- a/app/changelog/net-exporter.yaml
+++ b/app/changelog/net-exporter.yaml
@@ -1,0 +1,15 @@
+- version: 1.6.0
+  description: Allow to disable DNS TCP check.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#160-2020-01-29
+- version: 1.5.1
+  description: Changed Priority Class to system-node-critical for net-exporter deployed in TC.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#151-2020-01-08
+- version: 1.4.3
+  description: Fix invalid image reference.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#143-2019-12-27

--- a/app/changelog/node-exporter.yaml
+++ b/app/changelog/node-exporter.yaml
@@ -1,0 +1,6 @@
+- version: 1.2.0
+  componentVersion: 0.18.1
+  description: Change Priority Class to system-node-critical
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/node-exporter-app/blob/master/CHANGELOG.md#120-2020-01-08

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,4 @@
-- active: true
+- active: false
   apps:
     - app: chart-operator
       version: 0.11.4
@@ -19,8 +19,8 @@
       version: 1.2.0
       componentVersion: 0.18.1
     - app: cert-manager
-      version: 1.1.0
-      componentVersion: 0.13.0
+      version: 1.0.4
+      componentVersion: 0.9.0
     - app: cluster-autoscaler
       version: 1.1.4
       componentVersion: 1.16.2
@@ -30,6 +30,21 @@
     - app: kiam
       version: 1.1.0
       componentVersion: 3.5.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 8.1.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: aws
+      version: 2.1.0-dev
+  date: 2020-02-05T12:00:00Z
+  version: 11.0.1
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -34,7 +34,7 @@
     - name: app-operator
       version: 1.0.0
     - name: aws-operator
-      version: 8.1.0
+      version: 8.1.1-dev
     - name: cert-operator
       version: 0.1.0
     - name: chart-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -3,33 +3,33 @@
     - app: chart-operator
       version: 0.11.4
     - app: coredns
-      version: 1.1.3
       componentVersion: 1.6.5
+      version: 1.1.3
     - app: cert-exporter
       version: 1.2.1
     - app: kube-state-metrics
-      version: 1.0.0
       componentVersion: 1.9.0
-    - app: metrics-server
       version: 1.0.0
+    - app: metrics-server
       componentVersion: 0.3.3
+      version: 1.0.0
     - app: net-exporter
       version: 1.5.1
     - app: node-exporter
-      version: 1.2.0
       componentVersion: 0.18.1
-    - app: cert-manager
-      version: 1.0.4
-      componentVersion: 0.9.0
-    - app: cluster-autoscaler
-      version: 1.1.4
-      componentVersion: 1.16.2
-    - app: external-dns
       version: 1.2.0
+    - app: cert-manager
+      componentVersion: 0.9.0
+      version: 1.0.4
+    - app: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - app: external-dns
       componentVersion: 0.5.18
+      version: 1.2.0
     - app: kiam
-      version: 1.1.0
       componentVersion: 3.5.0
+      version: 1.1.0
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -37,8 +37,6 @@
       version: 8.1.1-dev
     - name: cert-operator
       version: 0.1.0
-    - name: chart-operator
-      version: 0.7.0
     - name: cluster-operator
       provider: aws
       version: 2.1.0-dev

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,12 +1,24 @@
 - active: false
   apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: cert-manager
+      componentVersion: 0.9.0
+      version: 1.0.4
     - app: chart-operator
       version: 0.11.4
+    - app: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
     - app: coredns
       componentVersion: 1.6.5
       version: 1.1.3
-    - app: cert-exporter
-      version: 1.2.1
+    - app: external-dns
+      componentVersion: 0.5.18
+      version: 1.2.0
+    - app: kiam
+      componentVersion: 3.5.0
+      version: 1.1.0
     - app: kube-state-metrics
       componentVersion: 1.9.0
       version: 1.0.0
@@ -18,18 +30,6 @@
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0
-    - app: cert-manager
-      componentVersion: 0.9.0
-      version: 1.0.4
-    - app: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - app: external-dns
-      componentVersion: 0.5.18
-      version: 1.2.0
-    - app: kiam
-      componentVersion: 3.5.0
-      version: 1.1.0
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,35 @@
 - active: true
+  apps:
+    - app: chart-operator
+      version: 0.11.4
+    - app: coredns
+      version: 1.1.3
+      componentVersion: 1.6.5
+    - app: cert-exporter
+      version: 1.2.1
+    - app: kube-state-metrics
+      version: 1.0.0
+      componentVersion: 1.9.0
+    - app: metrics-server
+      version: 1.0.0
+      componentVersion: 0.3.3
+    - app: net-exporter
+      version: 1.5.1
+    - app: node-exporter
+      version: 1.2.0
+      componentVersion: 0.18.1
+    - app: cert-manager
+      version: 1.1.0
+      componentVersion: 0.13.0
+    - app: cluster-autoscaler
+      version: 1.1.4
+      componentVersion: 1.16.2
+    - app: external-dns
+      version: 1.2.0
+      componentVersion: 0.5.18
+    - app: kiam
+      version: 1.1.0
+      componentVersion: 3.5.0
   authorities:
     - name: app-operator
       version: 1.0.0


### PR DESCRIPTION
Toward giantswarm/giantswarm#8135

App list on AWS only for node pool cluster. 
All changelogs, app versions are updated as the latest today (Feb 5). 

Spec: https://github.com/giantswarm/giantswarm/blob/master/areas/managed-services/specs/app-on-release.md

It will close https://github.com/giantswarm/releases/pull/70