### PR TITLE
App list for legacy 

### DIFF
--- a/app/changelog/chart-operator.yaml
+++ b/app/changelog/chart-operator.yaml
@@ -3,6 +3,11 @@
   kind: changed
   urls:
     - https://github.com/giantswarm/chart-operator/pull/349
+- version: 0.11.3
+  description: Make priorityclasses plural in cluster roles
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/pull/347
 - version: 0.11.2
   description: Remove CPU Limits
   kind: changed

--- a/app/changelog/kiam.yaml
+++ b/app/changelog/kiam.yaml
@@ -4,6 +4,12 @@
   kind: changed
   urls:
     - https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v110-2020-02-04
+- version: 1.0.3
+  componentVersion: 3.4.0
+  description: Improvements to helm chart for clusters with restrictive network policies.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v103-2020-01-17
 - version: 1.0.2
   componentVersion: 3.4.0
   description: Removed CPU limits.

--- a/app/changelog/kube-state-metrics.yaml
+++ b/app/changelog/kube-state-metrics.yaml
@@ -1,6 +1,12 @@
+- version: 1.0.2
+  componentVersion: 1.9.2
+  description: Adjust RBAC configuration to include networkpolicies and admissionregistration for k8s 1.16 compatibility
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v102
 - version: 1.0.0
   componentVersion: 1.9.0
   description: Upgraded to kube-state-metrics new release 1.9.0
   kind: changed
   urls:
-    - https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#121-2019-12-24
+    - https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v100

--- a/app/changelog/nginx-ingress-controller.yaml
+++ b/app/changelog/nginx-ingress-controller.yaml
@@ -1,0 +1,6 @@
+- version: 1.3.0
+  componentVersion: 0.28.0
+  description: Upgrade to nginx-ingress-controller 0.28.0.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v130-2020-01-30

--- a/aws.yaml
+++ b/aws.yaml
@@ -148,7 +148,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 0.22.1-dev
+      version: 0.23.0-dev
   date: 2020-02-03T12:00:00Z
   version: 9.1.1
 - active: true

--- a/aws.yaml
+++ b/aws.yaml
@@ -103,6 +103,40 @@
   date: 2019-12-18T14:00:00Z
   version: 10.1.0
 - active: false
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: cert-manager
+      componentVersion: 0.9.0
+      version: 1.0.4
+    - app: chart-operator
+      version: 0.11.3
+    - app: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.3
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: external-dns
+      componentVersion: 0.5.18
+      version: 1.1.0
+    - app: kiam
+      componentVersion: 3.5.0
+      version: 1.0.3
+    - app: kube-state-metrics
+      componentVersion: 1.9.0
+      version: 1.0.2
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.28.0
+      version: 1.3.0
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -118,13 +118,13 @@
       componentVersion: 1.6.5
       version: 1.1.3
     - app: external-dns
-      componentVersion: 0.5.18
+      componentVersion: 0.5.11
       version: 1.1.0
     - app: kiam
-      componentVersion: 3.5.0
+      componentVersion: 3.4.0
       version: 1.0.3
     - app: kube-state-metrics
-      componentVersion: 1.9.0
+      componentVersion: 1.9.2
       version: 1.0.2
     - app: metrics-server
       componentVersion: 0.3.3

--- a/aws.yaml
+++ b/aws.yaml
@@ -148,7 +148,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 0.23.0-dev
+      version: 0.23.0
   date: 2020-02-03T12:00:00Z
   version: 9.1.1
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,7 +35,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.22.2-dev
+    version: 0.23.0-dev
   date: 2020-01-29T12:00:00Z
   version: 11.1.0
 - active: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,29 @@
 - active: false
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.11.3
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: external-dns
+      componentVersion: 0.5.11
+      version: 1.1.0
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.2
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.28.0
+      version: 1.3.0
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
   authorities:
   - name: app-operator
     version: 1.0.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,7 +35,7 @@
     version: 0.7.0
   - name: cluster-operator
     provider: azure
-    version: 0.23.0-dev
+    version: 0.23.0
   date: 2020-01-29T12:00:00Z
   version: 11.1.0
 - active: true

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -30,7 +30,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: kvm
-      version: 0.22.1-dev
+      version: 0.23.0-dev
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,4 +1,26 @@
 - active: false
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.11.3
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.2
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.28.0
+      version: 1.3.0
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
   authorities:
     - name: app-operator
       version: 1.0.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -30,7 +30,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: kvm
-      version: 0.23.0-dev
+      version: 0.23.0
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -34,7 +34,7 @@
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator
-      version: 3.11.0
+      version: 3.11.0-dev
   date: 2020-01-29T13:00:00Z
   version: 11.1.1
 - active: true


### PR DESCRIPTION
Toward giantswarm/giantswarm#8135

App list on legacy cluster.
All changelogs, app versions are updated as the latest today (Feb 10).

Spec: https://github.com/giantswarm/giantswarm/blob/master/areas/managed-services/specs/app-on-release.md


Listing apps: 
- [x] aws 
- [x] azure
- [x] kvm 

Tested?
- [x] aws 
- [x] azure
- [x] kvm 