### PR TITLE
Cluster-operator 2.1.0 for WIP

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -39,7 +39,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: aws
-      version: 2.1.0
+      version: 2.1.1
   date: 2020-02-05T12:00:00Z
   version: 11.0.1
 - active: true

--- a/aws.yaml
+++ b/aws.yaml
@@ -39,7 +39,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: aws
-      version: 2.1.0-dev
+      version: 2.1.0
   date: 2020-02-05T12:00:00Z
   version: 11.0.1
 - active: true


### PR DESCRIPTION
Fixing cluster-operator version from `*-dev` release to `2.1.0`. 