### PR TITLE
Put version, active, date as first 

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1,6 +1,4 @@
-- version: 11.0.1
-  active: false
-  date: 2020-02-05 12:00:00+00:00
+- active: false
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -42,9 +40,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.1.1
-- version: 11.0.0
-  active: true
-  date: 2020-01-29 12:00:00+00:00
+  date: 2020-02-05T12:00:00Z
+  version: 11.0.1
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -57,9 +55,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-- version: 10.1.2
-  active: true
-  date: 2020-02-06 08:00:00+00:00
+  date: 2020-01-29T12:00:00Z
+  version: 11.0.0
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -72,9 +70,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-- version: 10.1.1
-  active: false
-  date: 2020-01-10 08:00:00+00:00
+  date: 2020-02-06T08:00:00Z
+  version: 10.1.2
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -87,9 +85,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.1
-- version: 10.1.0
-  active: false
-  date: 2019-12-18 14:00:00+00:00
+  date: 2020-01-10T08:00:00Z
+  version: 10.1.1
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -102,9 +100,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.0
-- version: 9.1.1
-  active: false
-  date: 2020-02-03 12:00:00+00:00
+  date: 2019-12-18T14:00:00Z
+  version: 10.1.0
+- active: false
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -151,9 +149,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.23.0
-- version: 9.1.0
-  active: true
-  date: 2020-01-28 12:00:00+00:00
+  date: 2020-02-03T12:00:00Z
+  version: 9.1.1
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -166,9 +164,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.4
-- version: 9.0.0
-  active: true
-  date: 2019-10-28 12:00:00+00:00
+  date: 2020-01-28T12:00:00Z
+  version: 9.1.0
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -181,9 +179,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.0
-- version: 8.5.0
-  active: true
-  date: 2019-09-02 13:30:00+00:00
+  date: 2019-10-28T12:00:00Z
+  version: 9.0.0
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -196,9 +194,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.20.0
-- version: 8.4.1
-  active: false
-  date: 2019-09-24 11:00:00+00:00
+  date: 2019-09-02T13:30:00Z
+  version: 8.5.0
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -211,9 +209,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-- version: 8.4.0
-  active: false
-  date: 2019-08-19 16:30:00+00:00
+  date: 2019-09-24T11:00:00Z
+  version: 8.4.1
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -226,9 +224,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-- version: 8.3.0
-  active: false
-  date: 2019-08-19 10:00:00+00:00
+  date: 2019-08-19T16:30:00Z
+  version: 8.4.0
+- active: false
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -239,9 +237,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.18.0
-- version: 8.2.1
-  active: false
-  date: 2019-08-09 10:00:00+00:00
+  date: 2019-08-19T10:00:00Z
+  version: 8.3.0
+- active: false
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -252,9 +250,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-- version: 8.2.0
-  active: false
-  date: 2019-06-03 10:00:00+00:00
+  date: 2019-08-09T10:00:00Z
+  version: 8.2.1
+- active: false
   authorities:
     - name: aws-operator
       version: 5.2.0
@@ -265,9 +263,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-- version: 8.1.0
-  active: false
-  date: 2019-06-04 16:00:00+00:00
+  date: 2019-06-03T10:00:00Z
+  version: 8.2.0
+- active: false
   authorities:
     - name: aws-operator
       version: 5.1.0
@@ -278,9 +276,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.16.0
-- version: 8.0.0
-  active: false
-  date: 2019-04-17 08:00:00+00:00
+  date: 2019-06-04T16:00:00Z
+  version: 8.1.0
+- active: false
   authorities:
     - name: aws-operator
       version: 5.0.0
@@ -291,9 +289,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.15.0
-- version: 7.3.1
-  active: false
-  date: 2019-04-25 18:00:00+00:00
+  date: 2019-04-17T08:00:00Z
+  version: 8.0.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -304,9 +302,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.1
-- version: 7.3.0
-  active: false
-  date: 2019-04-17 08:00:00+00:00
+  date: 2019-04-25T18:00:00Z
+  version: 7.3.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -317,9 +315,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.0
-- version: 7.2.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-04-17T08:00:00Z
+  version: 7.3.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -330,9 +328,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.13.0
-- version: 7.1.1
-  active: false
-  date: 2019-03-12 10:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 7.2.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -343,9 +341,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-- version: 7.1.0
-  active: false
-  date: 2019-03-04 10:00:00+00:00
+  date: 2019-03-12T10:00:00Z
+  version: 7.1.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -356,9 +354,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-- version: 7.0.0
-  active: false
-  date: 2019-02-20 12:00:00+00:00
+  date: 2019-03-04T10:00:00Z
+  version: 7.1.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -369,9 +367,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.11.0
-- version: 6.3.1
-  active: false
-  date: 2019-03-12 10:00:00+00:00
+  date: 2019-02-20T12:00:00Z
+  version: 7.0.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.6.1
@@ -382,9 +380,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-- version: 6.3.0
-  active: false
-  date: 2019-01-16 12:23:00+00:00
+  date: 2019-03-12T10:00:00Z
+  version: 6.3.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.6.0
@@ -395,9 +393,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-- version: 6.2.1
-  active: false
-  date: 2019-02-12 13:08:00+00:00
+  date: 2019-01-16T12:23:00Z
+  version: 6.3.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.5.1
@@ -408,9 +406,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-- version: 6.2.0
-  active: false
-  date: 2019-01-16 11:12:00+00:00
+  date: 2019-02-12T13:08:00Z
+  version: 6.2.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.5.0
@@ -421,9 +419,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-- version: 6.1.1
-  active: false
-  date: 2018-12-03 22:57:00+00:00
+  date: 2019-01-16T11:12:00Z
+  version: 6.2.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.4.1
@@ -434,9 +432,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-- version: 6.1.0
-  active: false
-  date: 2018-11-23 17:00:00+00:00
+  date: 2018-12-03T22:57:00Z
+  version: 6.1.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.4.0
@@ -447,9 +445,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-- version: 6.0.0
-  active: false
-  date: 2018-10-27 13:00:00+00:00
+  date: 2018-11-23T17:00:00Z
+  version: 6.1.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.3.0
@@ -460,9 +458,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-- version: 5.2.4
-  active: false
-  date: 2019-02-12 13:13:00+00:00
+  date: 2018-10-27T13:00:00Z
+  version: 6.0.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.2.2
@@ -473,9 +471,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-- version: 5.2.3
-  active: false
-  date: 2019-01-24 14:00:00+00:00
+  date: 2019-02-12T13:13:00Z
+  version: 5.2.4
+- active: false
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -486,9 +484,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-- version: 5.2.2
-  active: false
-  date: 2018-12-03 22:56:00+00:00
+  date: 2019-01-24T14:00:00Z
+  version: 5.2.3
+- active: false
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -499,9 +497,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-- version: 5.2.1
-  active: false
-  date: 2018-11-05 12:30:00+00:00
+  date: 2018-12-03T22:56:00Z
+  version: 5.2.2
+- active: false
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -512,9 +510,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-- version: 5.2.0
-  active: false
-  date: 2018-09-28 09:00:00+00:00
+  date: 2018-11-05T12:30:00Z
+  version: 5.2.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -525,9 +523,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.0
-- version: 5.1.1
-  active: false
-  date: 2018-09-26 12:00:00+00:00
+  date: 2018-09-28T09:00:00Z
+  version: 5.2.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.1.1
@@ -538,9 +536,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 5.1.0
-  active: false
-  date: 2018-09-10 06:00:00+00:00
+  date: 2018-09-26T12:00:00Z
+  version: 5.1.1
+- active: false
   authorities:
     - name: aws-operator
       version: 4.1.0
@@ -551,9 +549,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 5.0.0
-  active: false
-  date: 2018-08-30 08:00:00+00:00
+  date: 2018-09-10T06:00:00Z
+  version: 5.1.0
+- active: false
   authorities:
     - name: aws-operator
       version: 4.0.0
@@ -564,9 +562,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 4.5.3
-  active: false
-  date: 2018-12-03 22:55:00+00:00
+  date: 2018-08-30T08:00:00Z
+  version: 5.0.0
+- active: false
   authorities:
     - name: aws-operator
       version: 3.3.4
@@ -577,9 +575,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 4.5.2
-  active: false
-  date: 2018-09-25 14:00:00+00:00
+  date: 2018-12-03T22:55:00Z
+  version: 4.5.3
+- active: false
   authorities:
     - name: aws-operator
       version: 3.3.3
@@ -590,9 +588,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 4.5.1
-  active: false
-  date: 2018-09-17 14:00:00+00:00
+  date: 2018-09-25T14:00:00Z
+  version: 4.5.2
+- active: false
   authorities:
     - name: aws-operator
       version: 3.3.2
@@ -603,9 +601,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 4.5.0
-  active: false
-  date: 2018-08-27 12:00:00+00:00
+  date: 2018-09-17T14:00:00Z
+  version: 4.5.1
+- active: false
   authorities:
     - name: aws-operator
       version: 3.3.1
@@ -616,9 +614,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-- version: 4.4.0
-  active: false
-  date: 2018-07-26 12:00:00+00:00
+  date: 2018-08-27T12:00:00Z
+  version: 4.5.0
+- active: false
   authorities:
     - name: aws-operator
       version: 3.3.0
@@ -629,9 +627,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-- version: 4.3.0
-  active: false
-  date: 2018-07-11 12:00:00+00:00
+  date: 2018-07-26T12:00:00Z
+  version: 4.4.0
+- active: false
   authorities:
     - name: aws-operator
       version: 3.2.0
@@ -640,9 +638,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-- version: 4.2.2
-  active: false
-  date: 2018-07-11 12:01:00+00:00
+  date: 2018-07-11T12:00:00Z
+  version: 4.3.0
+- active: false
   authorities:
     - name: aws-operator
       version: 3.1.3
@@ -651,9 +649,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-- version: 4.2.1
-  active: false
-  date: 2018-06-21 12:00:00+00:00
+  date: 2018-07-11T12:01:00Z
+  version: 4.2.2
+- active: false
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -662,9 +660,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-- version: 4.2.0
-  active: false
-  date: 2018-05-29 12:00:00+00:00
+  date: 2018-06-21T12:00:00Z
+  version: 4.2.1
+- active: false
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -673,9 +671,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.3.0
-- version: 3.4.4
-  active: false
-  date: 2018-05-30 12:00:00+00:00
+  date: 2018-05-29T12:00:00Z
+  version: 4.2.0
+- active: false
   authorities:
     - name: aws-operator
       version: 3.0.4
@@ -684,9 +682,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-- version: 3.4.3
-  active: false
-  date: 2018-05-18 12:00:00+00:00
+  date: 2018-05-30T12:00:00Z
+  version: 3.4.4
+- active: false
   authorities:
     - name: aws-operator
       version: 3.0.3
@@ -695,11 +693,13 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-- version: 2.1.2
-  active: false
-  date: 2018-01-31 10:43:00+00:00
+  date: 2018-05-18T12:00:00Z
+  version: 3.4.3
+- active: false
   authorities:
     - name: aws-operator
       version: 2.0.2
     - name: cert-operator
       version: 0.1.0
+  date: 2018-01-31T10:43:00Z
+  version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.0.1
+  active: false
+  date: 2020-02-05T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -40,9 +42,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.1.1
-  date: 2020-02-05T12:00:00Z
-  version: 11.0.1
-- active: true
+- version: 11.0.0
+  active: true
+  date: 2020-01-29T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -55,9 +57,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-  date: 2020-01-29T12:00:00Z
-  version: 11.0.0
-- active: true
+- version: 10.1.2
+  active: true
+  date: 2020-02-06T08:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -70,9 +72,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-  date: 2020-02-06T08:00:00Z
-  version: 10.1.2
-- active: false
+- version: 10.1.1
+  active: false
+  date: 2020-01-10T08:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -85,9 +87,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.1
-  date: 2020-01-10T08:00:00Z
-  version: 10.1.1
-- active: false
+- version: 10.1.0
+  active: false
+  date: 2019-12-18T14:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -100,9 +102,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.0
-  date: 2019-12-18T14:00:00Z
-  version: 10.1.0
-- active: false
+- version: 9.1.1
+  active: false
+  date: 2020-02-03T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -149,9 +151,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.23.0
-  date: 2020-02-03T12:00:00Z
-  version: 9.1.1
-- active: true
+- version: 9.1.0
+  active: true
+  date: 2020-01-28T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -164,9 +166,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.4
-  date: 2020-01-28T12:00:00Z
-  version: 9.1.0
-- active: true
+- version: 9.0.0
+  active: true
+  date: 2019-10-28T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -179,9 +181,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.0
-  date: 2019-10-28T12:00:00Z
-  version: 9.0.0
-- active: true
+- version: 8.5.0
+  active: true
+  date: 2019-09-02T13:30:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -194,9 +196,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.20.0
-  date: 2019-09-02T13:30:00Z
-  version: 8.5.0
-- active: false
+- version: 8.4.1
+  active: false
+  date: 2019-09-24T11:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -209,9 +211,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-  date: 2019-09-24T11:00:00Z
-  version: 8.4.1
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-19T16:30:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -224,9 +226,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-  date: 2019-08-19T16:30:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-08-19T10:00:00Z
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -237,9 +239,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.18.0
-  date: 2019-08-19T10:00:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-08-09T10:00:00Z
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -250,9 +252,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-  date: 2019-08-09T10:00:00Z
-  version: 8.2.1
-- active: false
+- version: 8.2.0
+  active: false
+  date: 2019-06-03T10:00:00Z
   authorities:
     - name: aws-operator
       version: 5.2.0
@@ -263,9 +265,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-  date: 2019-06-03T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.1.0
+  active: false
+  date: 2019-06-04T16:00:00Z
   authorities:
     - name: aws-operator
       version: 5.1.0
@@ -276,9 +278,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.16.0
-  date: 2019-06-04T16:00:00Z
-  version: 8.1.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-04-17T08:00:00Z
   authorities:
     - name: aws-operator
       version: 5.0.0
@@ -289,9 +291,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.15.0
-  date: 2019-04-17T08:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.3.1
+  active: false
+  date: 2019-04-25T18:00:00Z
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -302,9 +304,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.1
-  date: 2019-04-25T18:00:00Z
-  version: 7.3.1
-- active: false
+- version: 7.3.0
+  active: false
+  date: 2019-04-17T08:00:00Z
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -315,9 +317,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.0
-  date: 2019-04-17T08:00:00Z
-  version: 7.3.0
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21T10:00:00Z
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -328,9 +330,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.13.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
+- version: 7.1.1
+  active: false
+  date: 2019-03-12T10:00:00Z
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -341,9 +343,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.1.1
-- active: false
+- version: 7.1.0
+  active: false
+  date: 2019-03-04T10:00:00Z
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -354,9 +356,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-  date: 2019-03-04T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-02-20T12:00:00Z
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -367,9 +369,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.11.0
-  date: 2019-02-20T12:00:00Z
-  version: 7.0.0
-- active: false
+- version: 6.3.1
+  active: false
+  date: 2019-03-12T10:00:00Z
   authorities:
     - name: aws-operator
       version: 4.6.1
@@ -380,9 +382,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-  date: 2019-03-12T10:00:00Z
-  version: 6.3.1
-- active: false
+- version: 6.3.0
+  active: false
+  date: 2019-01-16T12:23:00Z
   authorities:
     - name: aws-operator
       version: 4.6.0
@@ -393,9 +395,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-  date: 2019-01-16T12:23:00Z
-  version: 6.3.0
-- active: false
+- version: 6.2.1
+  active: false
+  date: 2019-02-12T13:08:00Z
   authorities:
     - name: aws-operator
       version: 4.5.1
@@ -406,9 +408,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2019-02-12T13:08:00Z
-  version: 6.2.1
-- active: false
+- version: 6.2.0
+  active: false
+  date: 2019-01-16T11:12:00Z
   authorities:
     - name: aws-operator
       version: 4.5.0
@@ -419,9 +421,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2019-01-16T11:12:00Z
-  version: 6.2.0
-- active: false
+- version: 6.1.1
+  active: false
+  date: 2018-12-03T22:57:00Z
   authorities:
     - name: aws-operator
       version: 4.4.1
@@ -432,9 +434,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2018-12-03T22:57:00Z
-  version: 6.1.1
-- active: false
+- version: 6.1.0
+  active: false
+  date: 2018-11-23T17:00:00Z
   authorities:
     - name: aws-operator
       version: 4.4.0
@@ -445,9 +447,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-  date: 2018-11-23T17:00:00Z
-  version: 6.1.0
-- active: false
+- version: 6.0.0
+  active: false
+  date: 2018-10-27T13:00:00Z
   authorities:
     - name: aws-operator
       version: 4.3.0
@@ -458,9 +460,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-  date: 2018-10-27T13:00:00Z
-  version: 6.0.0
-- active: false
+- version: 5.2.4
+  active: false
+  date: 2019-02-12T13:13:00Z
   authorities:
     - name: aws-operator
       version: 4.2.2
@@ -471,9 +473,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-  date: 2019-02-12T13:13:00Z
-  version: 5.2.4
-- active: false
+- version: 5.2.3
+  active: false
+  date: 2019-01-24T14:00:00Z
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -484,9 +486,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-  date: 2019-01-24T14:00:00Z
-  version: 5.2.3
-- active: false
+- version: 5.2.2
+  active: false
+  date: 2018-12-03T22:56:00Z
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -497,9 +499,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-  date: 2018-12-03T22:56:00Z
-  version: 5.2.2
-- active: false
+- version: 5.2.1
+  active: false
+  date: 2018-11-05T12:30:00Z
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -510,9 +512,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-  date: 2018-11-05T12:30:00Z
-  version: 5.2.1
-- active: false
+- version: 5.2.0
+  active: false
+  date: 2018-09-28T09:00:00Z
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -523,9 +525,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.0
-  date: 2018-09-28T09:00:00Z
-  version: 5.2.0
-- active: false
+- version: 5.1.1
+  active: false
+  date: 2018-09-26T12:00:00Z
   authorities:
     - name: aws-operator
       version: 4.1.1
@@ -536,9 +538,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-26T12:00:00Z
-  version: 5.1.1
-- active: false
+- version: 5.1.0
+  active: false
+  date: 2018-09-10T06:00:00Z
   authorities:
     - name: aws-operator
       version: 4.1.0
@@ -549,9 +551,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-10T06:00:00Z
-  version: 5.1.0
-- active: false
+- version: 5.0.0
+  active: false
+  date: 2018-08-30T08:00:00Z
   authorities:
     - name: aws-operator
       version: 4.0.0
@@ -562,9 +564,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-08-30T08:00:00Z
-  version: 5.0.0
-- active: false
+- version: 4.5.3
+  active: false
+  date: 2018-12-03T22:55:00Z
   authorities:
     - name: aws-operator
       version: 3.3.4
@@ -575,9 +577,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-12-03T22:55:00Z
-  version: 4.5.3
-- active: false
+- version: 4.5.2
+  active: false
+  date: 2018-09-25T14:00:00Z
   authorities:
     - name: aws-operator
       version: 3.3.3
@@ -588,9 +590,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-25T14:00:00Z
-  version: 4.5.2
-- active: false
+- version: 4.5.1
+  active: false
+  date: 2018-09-17T14:00:00Z
   authorities:
     - name: aws-operator
       version: 3.3.2
@@ -601,9 +603,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-17T14:00:00Z
-  version: 4.5.1
-- active: false
+- version: 4.5.0
+  active: false
+  date: 2018-08-27T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.3.1
@@ -614,9 +616,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-08-27T12:00:00Z
-  version: 4.5.0
-- active: false
+- version: 4.4.0
+  active: false
+  date: 2018-07-26T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.3.0
@@ -627,9 +629,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-  date: 2018-07-26T12:00:00Z
-  version: 4.4.0
-- active: false
+- version: 4.3.0
+  active: false
+  date: 2018-07-11T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.2.0
@@ -638,9 +640,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-  date: 2018-07-11T12:00:00Z
-  version: 4.3.0
-- active: false
+- version: 4.2.2
+  active: false
+  date: 2018-07-11T12:01:00Z
   authorities:
     - name: aws-operator
       version: 3.1.3
@@ -649,9 +651,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-  date: 2018-07-11T12:01:00Z
-  version: 4.2.2
-- active: false
+- version: 4.2.1
+  active: false
+  date: 2018-06-21T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -660,9 +662,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-  date: 2018-06-21T12:00:00Z
-  version: 4.2.1
-- active: false
+- version: 4.2.0
+  active: false
+  date: 2018-05-29T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -671,9 +673,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.3.0
-  date: 2018-05-29T12:00:00Z
-  version: 4.2.0
-- active: false
+- version: 3.4.4
+  active: false
+  date: 2018-05-30T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.0.4
@@ -682,9 +684,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-  date: 2018-05-30T12:00:00Z
-  version: 3.4.4
-- active: false
+- version: 3.4.3
+  active: false
+  date: 2018-05-18T12:00:00Z
   authorities:
     - name: aws-operator
       version: 3.0.3
@@ -693,13 +695,11 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-  date: 2018-05-18T12:00:00Z
-  version: 3.4.3
-- active: false
+- version: 2.1.2
+  active: false
+  date: 2018-01-31T10:43:00Z
   authorities:
     - name: aws-operator
       version: 2.0.2
     - name: cert-operator
       version: 0.1.0
-  date: 2018-01-31T10:43:00Z
-  version: 2.1.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.0.1
+  active: false
+  date: 2020-02-05 12:00:00+00:00
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -40,9 +42,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.1.1
-  date: 2020-02-05T12:00:00Z
-  version: 11.0.1
-- active: true
+- version: 11.0.0
+  active: true
+  date: 2020-01-29 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -55,9 +57,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-  date: 2020-01-29T12:00:00Z
-  version: 11.0.0
-- active: true
+- version: 10.1.2
+  active: true
+  date: 2020-02-06 08:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -70,9 +72,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.2
-  date: 2020-02-06T08:00:00Z
-  version: 10.1.2
-- active: false
+- version: 10.1.1
+  active: false
+  date: 2020-01-10 08:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -85,9 +87,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.1
-  date: 2020-01-10T08:00:00Z
-  version: 10.1.1
-- active: false
+- version: 10.1.0
+  active: false
+  date: 2019-12-18 14:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -100,9 +102,9 @@
     - name: cluster-operator
       provider: aws
       version: 2.0.0
-  date: 2019-12-18T14:00:00Z
-  version: 10.1.0
-- active: false
+- version: 9.1.1
+  active: false
+  date: 2020-02-03 12:00:00+00:00
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -149,9 +151,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.23.0
-  date: 2020-02-03T12:00:00Z
-  version: 9.1.1
-- active: true
+- version: 9.1.0
+  active: true
+  date: 2020-01-28 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -164,9 +166,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.4
-  date: 2020-01-28T12:00:00Z
-  version: 9.1.0
-- active: true
+- version: 9.0.0
+  active: true
+  date: 2019-10-28 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -179,9 +181,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.21.0
-  date: 2019-10-28T12:00:00Z
-  version: 9.0.0
-- active: true
+- version: 8.5.0
+  active: true
+  date: 2019-09-02 13:30:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -194,9 +196,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.20.0
-  date: 2019-09-02T13:30:00Z
-  version: 8.5.0
-- active: false
+- version: 8.4.1
+  active: false
+  date: 2019-09-24 11:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -209,9 +211,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-  date: 2019-09-24T11:00:00Z
-  version: 8.4.1
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-19 16:30:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -224,9 +226,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.19.0
-  date: 2019-08-19T16:30:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-08-19 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -237,9 +239,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.18.0
-  date: 2019-08-19T10:00:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-08-09 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 5.2.1
@@ -250,9 +252,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-  date: 2019-08-09T10:00:00Z
-  version: 8.2.1
-- active: false
+- version: 8.2.0
+  active: false
+  date: 2019-06-03 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 5.2.0
@@ -263,9 +265,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.17.0
-  date: 2019-06-03T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.1.0
+  active: false
+  date: 2019-06-04 16:00:00+00:00
   authorities:
     - name: aws-operator
       version: 5.1.0
@@ -276,9 +278,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.16.0
-  date: 2019-06-04T16:00:00Z
-  version: 8.1.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-04-17 08:00:00+00:00
   authorities:
     - name: aws-operator
       version: 5.0.0
@@ -289,9 +291,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.15.0
-  date: 2019-04-17T08:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.3.1
+  active: false
+  date: 2019-04-25 18:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -302,9 +304,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.1
-  date: 2019-04-25T18:00:00Z
-  version: 7.3.1
-- active: false
+- version: 7.3.0
+  active: false
+  date: 2019-04-17 08:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.9.0
@@ -315,9 +317,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.14.0
-  date: 2019-04-17T08:00:00Z
-  version: 7.3.0
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -328,9 +330,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.13.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
+- version: 7.1.1
+  active: false
+  date: 2019-03-12 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.8.0
@@ -341,9 +343,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.1.1
-- active: false
+- version: 7.1.0
+  active: false
+  date: 2019-03-04 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -354,9 +356,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.12.0
-  date: 2019-03-04T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-02-20 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.7.0
@@ -367,9 +369,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.11.0
-  date: 2019-02-20T12:00:00Z
-  version: 7.0.0
-- active: false
+- version: 6.3.1
+  active: false
+  date: 2019-03-12 10:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.6.1
@@ -380,9 +382,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-  date: 2019-03-12T10:00:00Z
-  version: 6.3.1
-- active: false
+- version: 6.3.0
+  active: false
+  date: 2019-01-16 12:23:00+00:00
   authorities:
     - name: aws-operator
       version: 4.6.0
@@ -393,9 +395,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.10.0
-  date: 2019-01-16T12:23:00Z
-  version: 6.3.0
-- active: false
+- version: 6.2.1
+  active: false
+  date: 2019-02-12 13:08:00+00:00
   authorities:
     - name: aws-operator
       version: 4.5.1
@@ -406,9 +408,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2019-02-12T13:08:00Z
-  version: 6.2.1
-- active: false
+- version: 6.2.0
+  active: false
+  date: 2019-01-16 11:12:00+00:00
   authorities:
     - name: aws-operator
       version: 4.5.0
@@ -419,9 +421,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2019-01-16T11:12:00Z
-  version: 6.2.0
-- active: false
+- version: 6.1.1
+  active: false
+  date: 2018-12-03 22:57:00+00:00
   authorities:
     - name: aws-operator
       version: 4.4.1
@@ -432,9 +434,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.9.0
-  date: 2018-12-03T22:57:00Z
-  version: 6.1.1
-- active: false
+- version: 6.1.0
+  active: false
+  date: 2018-11-23 17:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.4.0
@@ -445,9 +447,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-  date: 2018-11-23T17:00:00Z
-  version: 6.1.0
-- active: false
+- version: 6.0.0
+  active: false
+  date: 2018-10-27 13:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.3.0
@@ -458,9 +460,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.8.0
-  date: 2018-10-27T13:00:00Z
-  version: 6.0.0
-- active: false
+- version: 5.2.4
+  active: false
+  date: 2019-02-12 13:13:00+00:00
   authorities:
     - name: aws-operator
       version: 4.2.2
@@ -471,9 +473,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-  date: 2019-02-12T13:13:00Z
-  version: 5.2.4
-- active: false
+- version: 5.2.3
+  active: false
+  date: 2019-01-24 14:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -484,9 +486,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.2
-  date: 2019-01-24T14:00:00Z
-  version: 5.2.3
-- active: false
+- version: 5.2.2
+  active: false
+  date: 2018-12-03 22:56:00+00:00
   authorities:
     - name: aws-operator
       version: 4.2.1
@@ -497,9 +499,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-  date: 2018-12-03T22:56:00Z
-  version: 5.2.2
-- active: false
+- version: 5.2.1
+  active: false
+  date: 2018-11-05 12:30:00+00:00
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -510,9 +512,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.1
-  date: 2018-11-05T12:30:00Z
-  version: 5.2.1
-- active: false
+- version: 5.2.0
+  active: false
+  date: 2018-09-28 09:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.2.0
@@ -523,9 +525,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.7.0
-  date: 2018-09-28T09:00:00Z
-  version: 5.2.0
-- active: false
+- version: 5.1.1
+  active: false
+  date: 2018-09-26 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.1.1
@@ -536,9 +538,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-26T12:00:00Z
-  version: 5.1.1
-- active: false
+- version: 5.1.0
+  active: false
+  date: 2018-09-10 06:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.1.0
@@ -549,9 +551,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-10T06:00:00Z
-  version: 5.1.0
-- active: false
+- version: 5.0.0
+  active: false
+  date: 2018-08-30 08:00:00+00:00
   authorities:
     - name: aws-operator
       version: 4.0.0
@@ -562,9 +564,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-08-30T08:00:00Z
-  version: 5.0.0
-- active: false
+- version: 4.5.3
+  active: false
+  date: 2018-12-03 22:55:00+00:00
   authorities:
     - name: aws-operator
       version: 3.3.4
@@ -575,9 +577,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-12-03T22:55:00Z
-  version: 4.5.3
-- active: false
+- version: 4.5.2
+  active: false
+  date: 2018-09-25 14:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.3.3
@@ -588,9 +590,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-25T14:00:00Z
-  version: 4.5.2
-- active: false
+- version: 4.5.1
+  active: false
+  date: 2018-09-17 14:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.3.2
@@ -601,9 +603,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-09-17T14:00:00Z
-  version: 4.5.1
-- active: false
+- version: 4.5.0
+  active: false
+  date: 2018-08-27 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.3.1
@@ -614,9 +616,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.6.0
-  date: 2018-08-27T12:00:00Z
-  version: 4.5.0
-- active: false
+- version: 4.4.0
+  active: false
+  date: 2018-07-26 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.3.0
@@ -627,9 +629,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-  date: 2018-07-26T12:00:00Z
-  version: 4.4.0
-- active: false
+- version: 4.3.0
+  active: false
+  date: 2018-07-11 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.2.0
@@ -638,9 +640,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.5.0
-  date: 2018-07-11T12:00:00Z
-  version: 4.3.0
-- active: false
+- version: 4.2.2
+  active: false
+  date: 2018-07-11 12:01:00+00:00
   authorities:
     - name: aws-operator
       version: 3.1.3
@@ -649,9 +651,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-  date: 2018-07-11T12:01:00Z
-  version: 4.2.2
-- active: false
+- version: 4.2.1
+  active: false
+  date: 2018-06-21 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -660,9 +662,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.4.0
-  date: 2018-06-21T12:00:00Z
-  version: 4.2.1
-- active: false
+- version: 4.2.0
+  active: false
+  date: 2018-05-29 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.1.2
@@ -671,9 +673,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.3.0
-  date: 2018-05-29T12:00:00Z
-  version: 4.2.0
-- active: false
+- version: 3.4.4
+  active: false
+  date: 2018-05-30 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.0.4
@@ -682,9 +684,9 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-  date: 2018-05-30T12:00:00Z
-  version: 3.4.4
-- active: false
+- version: 3.4.3
+  active: false
+  date: 2018-05-18 12:00:00+00:00
   authorities:
     - name: aws-operator
       version: 3.0.3
@@ -693,13 +695,11 @@
     - name: cluster-operator
       provider: aws
       version: 0.2.0
-  date: 2018-05-18T12:00:00Z
-  version: 3.4.3
-- active: false
+- version: 2.1.2
+  active: false
+  date: 2018-01-31 10:43:00+00:00
   authorities:
     - name: aws-operator
       version: 2.0.2
     - name: cert-operator
       version: 0.1.0
-  date: 2018-01-31T10:43:00Z
-  version: 2.1.2

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.1.0
+  active: false
+  date: 2020-01-29 12:00:00+00:00
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -25,35 +27,35 @@
       componentVersion: 0.18.1
       version: 1.2.0
   authorities:
-  - name: app-operator
-    version: 1.0.0
-  - name: azure-operator
-    version: 2.9.0
-  - name: cert-operator
-    version: 0.1.0
-  - name: chart-operator
-    version: 0.7.0
-  - name: cluster-operator
-    provider: azure
-    version: 0.23.0
-  date: 2020-01-29T12:00:00Z
-  version: 11.1.0
-- active: true
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 2.9.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.23.0
+- version: 11.0.0
+  active: true
+  date: 2020-01-08 12:00:00+00:00
   authorities:
-  - name: app-operator
-    version: 1.0.0
-  - name: azure-operator
-    version: 2.8.0
-  - name: cert-operator
-    version: 0.1.0
-  - name: chart-operator
-    version: 0.7.0
-  - name: cluster-operator
-    provider: azure
-    version: 0.21.4
-  date: 2020-01-08T12:00:00Z
-  version: 11.0.0
-- active: true
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 2.8.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.21.4
+- version: 9.0.0
+  active: true
+  date: 2019-10-25 10:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -66,9 +68,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.21.0
-  date: 2019-10-25T10:00:00Z
-  version: 9.0.0
-- active: false
+- version: 8.4.1
+  active: false
+  date: 2019-09-26 17:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -81,9 +83,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-  date: 2019-09-26T17:00:00Z
-  version: 8.4.1
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-14 10:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -96,9 +98,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-  date: 2019-08-14T10:00:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-07-11 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.5.0
@@ -109,9 +111,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.18.0
-  date: 2019-07-11T10:00:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-03-30 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.4.1
@@ -122,9 +124,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
-  date: 2019-03-30T10:00:00Z
-  version: 8.2.1
-- active: false
+- version: 8.2.0
+  active: false
+  date: 2019-03-30 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.4.0
@@ -135,9 +137,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
-  date: 2019-03-30T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.3.0
@@ -148,9 +150,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.15.0
-  date: 2019-03-21T10:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.2.1
+  active: false
+  date: 2019-04-25 18:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -161,9 +163,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.14.1
-  date: 2019-04-25T18:00:00Z
-  version: 7.2.1
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -174,9 +176,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.13.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
+- version: 7.1.1
+  active: false
+  date: 2019-03-12 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -187,9 +189,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.1.1
-- active: false
+- version: 7.1.0
+  active: false
+  date: 2019-03-04 10:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -200,9 +202,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-  date: 2019-03-04T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-03-01 15:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -213,9 +215,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.11.0
-  date: 2019-03-01T15:00:00Z
-  version: 7.0.0
-- active: false
+- version: 2.0.3
+  active: false
+  date: 2019-02-12 13:09:00+00:00
   authorities:
     - name: azure-operator
       version: 2.0.2
@@ -226,9 +228,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-  date: 2019-02-12T13:09:00Z
-  version: 2.0.3
-- active: false
+- version: 2.0.2
+  active: false
+  date: 2018-11-05 12:31:00+00:00
   authorities:
     - name: azure-operator
       version: 2.0.1
@@ -239,9 +241,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-  date: 2018-11-05T12:31:00Z
-  version: 2.0.2
-- active: false
+- version: 2.0.1
+  active: false
+  date: 2018-11-05 12:30:00+00:00
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -252,9 +254,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.1
-  date: 2018-11-05T12:30:00Z
-  version: 2.0.1
-- active: false
+- version: 2.0.0
+  active: false
+  date: 2018-08-28 09:00:00+00:00
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -265,9 +267,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.0
-  date: 2018-08-28T09:00:00Z
-  version: 2.0.0
-- active: false
+- version: 1.1.2
+  active: false
+  date: 2018-12-03 22:55:00+00:00
   authorities:
     - name: azure-operator
       version: 1.1.2
@@ -278,9 +280,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-12-03T22:55:00Z
-  version: 1.1.2
-- active: false
+- version: 1.1.1
+  active: false
+  date: 2018-09-17 14:00:00+00:00
   authorities:
     - name: azure-operator
       version: 1.1.1
@@ -291,9 +293,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-09-17T14:00:00Z
-  version: 1.1.1
-- active: false
+- version: 1.1.0
+  active: false
+  date: 2018-08-16 17:00:00+00:00
   authorities:
     - name: azure-operator
       version: 1.1.0
@@ -304,9 +306,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-08-16T17:00:00Z
-  version: 1.1.0
-- active: false
+- version: 1.0.1
+  active: false
+  date: 2018-08-07 12:00:00+00:00
   authorities:
     - name: azure-operator
       version: 1.0.1
@@ -315,9 +317,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-  date: 2018-08-07T12:00:00Z
-  version: 1.0.1
-- active: false
+- version: 1.0.0
+  active: false
+  date: 2018-06-21 12:00:00+00:00
   authorities:
     - name: azure-operator
       version: 1.0.0
@@ -326,9 +328,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-  date: 2018-06-21T12:00:00Z
-  version: 1.0.0
-- active: false
+- version: 0.4.0
+  active: false
+  date: 2018-04-16 12:00:00+00:00
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -337,9 +339,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.2.0
-  date: 2018-04-16T12:00:00Z
-  version: 0.4.0
-- active: false
+- version: 0.3.0
+  active: false
+  date: 2018-03-28 07:30:00+00:00
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -348,13 +350,11 @@
     - name: cluster-operator
       provider: azure
       version: 0.1.0
-  date: 2018-03-28T07:30:00Z
-  version: 0.3.0
-- active: false
+- version: 0.2.0
+  active: false
+  date: 2018-01-07 08:35:00+00:00
   authorities:
     - name: azure-operator
       version: 0.1.0
     - name: cert-operator
       version: 0.1.0
-  date: 2018-01-07T08:35:00Z
-  version: 0.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.1.0
+  active: false
+  date: 2020-01-29T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -25,35 +27,35 @@
       componentVersion: 0.18.1
       version: 1.2.0
   authorities:
-  - name: app-operator
-    version: 1.0.0
-  - name: azure-operator
-    version: 2.9.0
-  - name: cert-operator
-    version: 0.1.0
-  - name: chart-operator
-    version: 0.7.0
-  - name: cluster-operator
-    provider: azure
-    version: 0.23.0
-  date: 2020-01-29T12:00:00Z
-  version: 11.1.0
-- active: true
-  authorities:
-  - name: app-operator
-    version: 1.0.0
-  - name: azure-operator
-    version: 2.8.0
-  - name: cert-operator
-    version: 0.1.0
-  - name: chart-operator
-    version: 0.7.0
-  - name: cluster-operator
-    provider: azure
-    version: 0.21.4
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 2.9.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.23.0
+- version: 11.0.0
+  active: true
   date: 2020-01-08T12:00:00Z
-  version: 11.0.0
-- active: true
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 2.8.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: chart-operator
+      version: 0.7.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.21.4
+- version: 9.0.0
+  active: true
+  date: 2019-10-25T10:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -66,9 +68,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.21.0
-  date: 2019-10-25T10:00:00Z
-  version: 9.0.0
-- active: false
+- version: 8.4.1
+  active: false
+  date: 2019-09-26T17:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -81,9 +83,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-  date: 2019-09-26T17:00:00Z
-  version: 8.4.1
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-14T10:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -96,9 +98,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-  date: 2019-08-14T10:00:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-07-11T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.5.0
@@ -109,9 +111,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.18.0
-  date: 2019-07-11T10:00:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-03-30T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.4.1
@@ -122,9 +124,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
+- version: 8.2.0
+  active: false
   date: 2019-03-30T10:00:00Z
-  version: 8.2.1
-- active: false
   authorities:
     - name: azure-operator
       version: 2.4.0
@@ -135,9 +137,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
-  date: 2019-03-30T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-03-21T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.3.0
@@ -148,9 +150,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.15.0
-  date: 2019-03-21T10:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.2.1
+  active: false
+  date: 2019-04-25T18:00:00Z
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -161,9 +163,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.14.1
-  date: 2019-04-25T18:00:00Z
-  version: 7.2.1
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -174,9 +176,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.13.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
+- version: 7.1.1
+  active: false
+  date: 2019-03-12T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -187,9 +189,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.1.1
-- active: false
+- version: 7.1.0
+  active: false
+  date: 2019-03-04T10:00:00Z
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -200,9 +202,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-  date: 2019-03-04T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-03-01T15:00:00Z
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -213,9 +215,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.11.0
-  date: 2019-03-01T15:00:00Z
-  version: 7.0.0
-- active: false
+- version: 2.0.3
+  active: false
+  date: 2019-02-12T13:09:00Z
   authorities:
     - name: azure-operator
       version: 2.0.2
@@ -226,9 +228,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-  date: 2019-02-12T13:09:00Z
-  version: 2.0.3
-- active: false
+- version: 2.0.2
+  active: false
+  date: 2018-11-05T12:31:00Z
   authorities:
     - name: azure-operator
       version: 2.0.1
@@ -239,9 +241,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-  date: 2018-11-05T12:31:00Z
-  version: 2.0.2
-- active: false
+- version: 2.0.1
+  active: false
+  date: 2018-11-05T12:30:00Z
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -252,9 +254,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.1
-  date: 2018-11-05T12:30:00Z
-  version: 2.0.1
-- active: false
+- version: 2.0.0
+  active: false
+  date: 2018-08-28T09:00:00Z
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -265,9 +267,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.0
-  date: 2018-08-28T09:00:00Z
-  version: 2.0.0
-- active: false
+- version: 1.1.2
+  active: false
+  date: 2018-12-03T22:55:00Z
   authorities:
     - name: azure-operator
       version: 1.1.2
@@ -278,9 +280,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-12-03T22:55:00Z
-  version: 1.1.2
-- active: false
+- version: 1.1.1
+  active: false
+  date: 2018-09-17T14:00:00Z
   authorities:
     - name: azure-operator
       version: 1.1.1
@@ -291,9 +293,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-09-17T14:00:00Z
-  version: 1.1.1
-- active: false
+- version: 1.1.0
+  active: false
+  date: 2018-08-16T17:00:00Z
   authorities:
     - name: azure-operator
       version: 1.1.0
@@ -304,9 +306,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-  date: 2018-08-16T17:00:00Z
-  version: 1.1.0
-- active: false
+- version: 1.0.1
+  active: false
+  date: 2018-08-07T12:00:00Z
   authorities:
     - name: azure-operator
       version: 1.0.1
@@ -315,9 +317,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-  date: 2018-08-07T12:00:00Z
-  version: 1.0.1
-- active: false
+- version: 1.0.0
+  active: false
+  date: 2018-06-21T12:00:00Z
   authorities:
     - name: azure-operator
       version: 1.0.0
@@ -326,9 +328,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-  date: 2018-06-21T12:00:00Z
-  version: 1.0.0
-- active: false
+- version: 0.4.0
+  active: false
+  date: 2018-04-16T12:00:00Z
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -337,9 +339,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.2.0
-  date: 2018-04-16T12:00:00Z
-  version: 0.4.0
-- active: false
+- version: 0.3.0
+  active: false
+  date: 2018-03-28T07:30:00Z
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -348,13 +350,11 @@
     - name: cluster-operator
       provider: azure
       version: 0.1.0
-  date: 2018-03-28T07:30:00Z
-  version: 0.3.0
-- active: false
+- version: 0.2.0
+  active: false
+  date: 2018-01-07T08:35:00Z
   authorities:
     - name: azure-operator
       version: 0.1.0
     - name: cert-operator
       version: 0.1.0
-  date: 2018-01-07T08:35:00Z
-  version: 0.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,4 @@
-- version: 11.1.0
-  active: false
-  date: 2020-01-29 12:00:00+00:00
+- active: false
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -27,35 +25,35 @@
       componentVersion: 0.18.1
       version: 1.2.0
   authorities:
-    - name: app-operator
-      version: 1.0.0
-    - name: azure-operator
-      version: 2.9.0
-    - name: cert-operator
-      version: 0.1.0
-    - name: chart-operator
-      version: 0.7.0
-    - name: cluster-operator
-      provider: azure
-      version: 0.23.0
-- version: 11.0.0
-  active: true
-  date: 2020-01-08 12:00:00+00:00
+  - name: app-operator
+    version: 1.0.0
+  - name: azure-operator
+    version: 2.9.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: chart-operator
+    version: 0.7.0
+  - name: cluster-operator
+    provider: azure
+    version: 0.23.0
+  date: 2020-01-29T12:00:00Z
+  version: 11.1.0
+- active: true
   authorities:
-    - name: app-operator
-      version: 1.0.0
-    - name: azure-operator
-      version: 2.8.0
-    - name: cert-operator
-      version: 0.1.0
-    - name: chart-operator
-      version: 0.7.0
-    - name: cluster-operator
-      provider: azure
-      version: 0.21.4
-- version: 9.0.0
-  active: true
-  date: 2019-10-25 10:00:00+00:00
+  - name: app-operator
+    version: 1.0.0
+  - name: azure-operator
+    version: 2.8.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: chart-operator
+    version: 0.7.0
+  - name: cluster-operator
+    provider: azure
+    version: 0.21.4
+  date: 2020-01-08T12:00:00Z
+  version: 11.0.0
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -68,9 +66,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.21.0
-- version: 8.4.1
-  active: false
-  date: 2019-09-26 17:00:00+00:00
+  date: 2019-10-25T10:00:00Z
+  version: 9.0.0
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -83,9 +81,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-- version: 8.4.0
-  active: false
-  date: 2019-08-14 10:00:00+00:00
+  date: 2019-09-26T17:00:00Z
+  version: 8.4.1
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -98,9 +96,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.19.0
-- version: 8.3.0
-  active: false
-  date: 2019-07-11 10:00:00+00:00
+  date: 2019-08-14T10:00:00Z
+  version: 8.4.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.5.0
@@ -111,9 +109,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.18.0
-- version: 8.2.1
-  active: false
-  date: 2019-03-30 10:00:00+00:00
+  date: 2019-07-11T10:00:00Z
+  version: 8.3.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.4.1
@@ -124,9 +122,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
-- version: 8.2.0
-  active: false
-  date: 2019-03-30 10:00:00+00:00
+  date: 2019-03-30T10:00:00Z
+  version: 8.2.1
+- active: false
   authorities:
     - name: azure-operator
       version: 2.4.0
@@ -137,9 +135,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.17.0
-- version: 8.0.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-03-30T10:00:00Z
+  version: 8.2.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.3.0
@@ -150,9 +148,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.15.0
-- version: 7.2.1
-  active: false
-  date: 2019-04-25 18:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 8.0.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -163,9 +161,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.14.1
-- version: 7.2.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-04-25T18:00:00Z
+  version: 7.2.1
+- active: false
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -176,9 +174,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.13.0
-- version: 7.1.1
-  active: false
-  date: 2019-03-12 10:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 7.2.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.2.0
@@ -189,9 +187,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-- version: 7.1.0
-  active: false
-  date: 2019-03-04 10:00:00+00:00
+  date: 2019-03-12T10:00:00Z
+  version: 7.1.1
+- active: false
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -202,9 +200,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.12.0
-- version: 7.0.0
-  active: false
-  date: 2019-03-01 15:00:00+00:00
+  date: 2019-03-04T10:00:00Z
+  version: 7.1.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.1.0
@@ -215,9 +213,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.11.0
-- version: 2.0.3
-  active: false
-  date: 2019-02-12 13:09:00+00:00
+  date: 2019-03-01T15:00:00Z
+  version: 7.0.0
+- active: false
   authorities:
     - name: azure-operator
       version: 2.0.2
@@ -228,9 +226,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-- version: 2.0.2
-  active: false
-  date: 2018-11-05 12:31:00+00:00
+  date: 2019-02-12T13:09:00Z
+  version: 2.0.3
+- active: false
   authorities:
     - name: azure-operator
       version: 2.0.1
@@ -241,9 +239,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.9.0
-- version: 2.0.1
-  active: false
-  date: 2018-11-05 12:30:00+00:00
+  date: 2018-11-05T12:31:00Z
+  version: 2.0.2
+- active: false
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -254,9 +252,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.1
-- version: 2.0.0
-  active: false
-  date: 2018-08-28 09:00:00+00:00
+  date: 2018-11-05T12:30:00Z
+  version: 2.0.1
+- active: false
   authorities:
     - name: azure-operator
       version: 2.0.0
@@ -267,9 +265,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.7.0
-- version: 1.1.2
-  active: false
-  date: 2018-12-03 22:55:00+00:00
+  date: 2018-08-28T09:00:00Z
+  version: 2.0.0
+- active: false
   authorities:
     - name: azure-operator
       version: 1.1.2
@@ -280,9 +278,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-- version: 1.1.1
-  active: false
-  date: 2018-09-17 14:00:00+00:00
+  date: 2018-12-03T22:55:00Z
+  version: 1.1.2
+- active: false
   authorities:
     - name: azure-operator
       version: 1.1.1
@@ -293,9 +291,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-- version: 1.1.0
-  active: false
-  date: 2018-08-16 17:00:00+00:00
+  date: 2018-09-17T14:00:00Z
+  version: 1.1.1
+- active: false
   authorities:
     - name: azure-operator
       version: 1.1.0
@@ -306,9 +304,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.6.0
-- version: 1.0.1
-  active: false
-  date: 2018-08-07 12:00:00+00:00
+  date: 2018-08-16T17:00:00Z
+  version: 1.1.0
+- active: false
   authorities:
     - name: azure-operator
       version: 1.0.1
@@ -317,9 +315,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-- version: 1.0.0
-  active: false
-  date: 2018-06-21 12:00:00+00:00
+  date: 2018-08-07T12:00:00Z
+  version: 1.0.1
+- active: false
   authorities:
     - name: azure-operator
       version: 1.0.0
@@ -328,9 +326,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.4.0
-- version: 0.4.0
-  active: false
-  date: 2018-04-16 12:00:00+00:00
+  date: 2018-06-21T12:00:00Z
+  version: 1.0.0
+- active: false
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -339,9 +337,9 @@
     - name: cluster-operator
       provider: azure
       version: 0.2.0
-- version: 0.3.0
-  active: false
-  date: 2018-03-28 07:30:00+00:00
+  date: 2018-04-16T12:00:00Z
+  version: 0.4.0
+- active: false
   authorities:
     - name: azure-operator
       version: 0.1.0
@@ -350,11 +348,13 @@
     - name: cluster-operator
       provider: azure
       version: 0.1.0
-- version: 0.2.0
-  active: false
-  date: 2018-01-07 08:35:00+00:00
+  date: 2018-03-28T07:30:00Z
+  version: 0.3.0
+- active: false
   authorities:
     - name: azure-operator
       version: 0.1.0
     - name: cert-operator
       version: 0.1.0
+  date: 2018-01-07T08:35:00Z
+  version: 0.2.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,6 +1,4 @@
-- version: 11.1.1
-  active: false
-  date: 2020-01-29 13:00:00+00:00
+- active: false
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -37,9 +35,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.11.0-dev
-- version: 11.1.0
-  active: true
-  date: 2020-01-29 12:00:00+00:00
+  date: 2020-01-29T13:00:00Z
+  version: 11.1.1
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -54,9 +52,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-- version: 11.0.0
-  active: false
-  date: 2020-01-10 12:00:00+00:00
+  date: 2020-01-29T12:00:00Z
+  version: 11.1.0
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -71,9 +69,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-- version: 9.0.0
-  active: true
-  date: 2019-10-28 12:00:00+00:00
+  date: 2020-01-10T12:00:00Z
+  version: 11.0.0
+- active: true
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -88,9 +86,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.9.0
-- version: 8.4.0
-  active: false
-  date: 2019-08-20 17:00:00+00:00
+  date: 2019-10-28T12:00:00Z
+  version: 9.0.0
+- active: false
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -105,9 +103,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.8.0
-- version: 8.3.0
-  active: false
-  date: 2019-08-20 16:40:00+00:00
+  date: 2019-08-20T17:00:00Z
+  version: 8.4.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -120,9 +118,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
-- version: 8.2.1
-  active: false
-  date: 2019-06-24 10:00:00+00:00
+  date: 2019-08-20T16:40:00Z
+  version: 8.3.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -135,9 +133,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
-- version: 8.2.0
-  active: false
-  date: 2019-06-24 10:00:00+00:00
+  date: 2019-06-24T10:00:00Z
+  version: 8.2.1
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -150,9 +148,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.0
-- version: 8.1.0
-  active: false
-  date: 2019-04-30 10:00:00+00:00
+  date: 2019-06-24T10:00:00Z
+  version: 8.2.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -165,9 +163,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.6.0
-- version: 8.0.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-04-30T10:00:00Z
+  version: 8.1.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -180,9 +178,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.5.0
-- version: 7.2.1
-  active: false
-  date: 2019-04-25 18:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 8.0.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -195,9 +193,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
-- version: 7.2.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-04-25T18:00:00Z
+  version: 7.2.1
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -210,9 +208,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
-- version: 7.1.0
-  active: false
-  date: 2019-03-21 10:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 7.2.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -225,9 +223,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-- version: 7.0.1
-  active: false
-  date: 2019-03-12 10:00:00+00:00
+  date: 2019-03-21T10:00:00Z
+  version: 7.1.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -240,9 +238,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-- version: 7.0.0
-  active: false
-  date: 2019-03-01 15:00:00+00:00
+  date: 2019-03-12T10:00:00Z
+  version: 7.0.1
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -255,9 +253,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.2.0
-- version: 6.0.2
-  active: false
-  date: 2019-02-12 13:29:00+00:00
+  date: 2019-03-01T15:00:00Z
+  version: 7.0.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -270,9 +268,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.2
-- version: 6.0.1
-  active: false
-  date: 2018-12-04 16:01:00+00:00
+  date: 2019-02-12T13:29:00Z
+  version: 6.0.2
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -285,9 +283,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.1
-- version: 6.0.0
-  active: false
-  date: 2018-11-09 21:00:00+00:00
+  date: 2018-12-04T16:01:00Z
+  version: 6.0.1
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -300,9 +298,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.0
-- version: 3.0.0
-  active: false
-  date: 2018-08-09 13:00:00+00:00
+  date: 2018-11-09T21:00:00Z
+  version: 6.0.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -315,9 +313,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.0.0
-- version: 2.12.4
-  active: false
-  date: 2019-02-12 13:12:00+00:00
+  date: 2018-08-09T13:00:00Z
+  version: 3.0.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -330,9 +328,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.4
-- version: 2.12.3
-  active: false
-  date: 2019-01-23 12:00:00+00:00
+  date: 2019-02-12T13:12:00Z
+  version: 2.12.4
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -345,9 +343,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-- version: 2.12.2
-  active: false
-  date: 2018-12-04 16:00:00+00:00
+  date: 2019-01-23T12:00:00Z
+  version: 2.12.3
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -360,9 +358,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-- version: 2.12.1
-  active: false
-  date: 2018-09-17 14:00:00+00:00
+  date: 2018-12-04T16:00:00Z
+  version: 2.12.2
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -375,9 +373,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.2
-- version: 2.12.0
-  active: false
-  date: 2018-08-29 15:00:00+00:00
+  date: 2018-09-17T14:00:00Z
+  version: 2.12.1
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -390,9 +388,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.1
-- version: 2.11.0
-  active: false
-  date: 2018-08-09 12:00:00+00:00
+  date: 2018-08-29T15:00:00Z
+  version: 2.12.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -405,9 +403,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.0
-- version: 2.10.0
-  active: false
-  date: 2018-06-01 15:00:00+00:00
+  date: 2018-08-09T12:00:00Z
+  version: 2.11.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -418,9 +416,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.4.0
-- version: 2.9.0
-  active: false
-  date: 2018-06-01 13:00:00+00:00
+  date: 2018-06-01T15:00:00Z
+  version: 2.10.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -431,9 +429,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.3.0
-- version: 2.7.0
-  active: false
-  date: 2018-04-25 12:00:00+00:00
+  date: 2018-06-01T13:00:00Z
+  version: 2.9.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -444,9 +442,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.2.0
-- version: 1.4.0
-  active: false
-  date: 2018-02-08 12:00:00+00:00
+  date: 2018-04-25T12:00:00Z
+  version: 2.7.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -454,9 +452,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.2.0
-- version: 1.2.0
-  active: false
-  date: 2017-12-12 12:00:00+00:00
+  date: 2018-02-08T12:00:00Z
+  version: 1.4.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -464,9 +462,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.0.0
-- version: 0.3.0
-  active: false
-  date: 2017-10-26 12:00:00+00:00
+  date: 2017-12-12T12:00:00Z
+  version: 1.2.0
+- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -474,3 +472,5 @@
       version: 0.1.0
     - name: kvm-operator
       version: 0.1.0
+  date: 2017-10-26T12:00:00Z
+  version: 0.3.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.1.1
+  active: false
+  date: 2020-01-29T13:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -35,9 +37,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.11.0-dev
-  date: 2020-01-29T13:00:00Z
-  version: 11.1.1
-- active: true
+- version: 11.1.0
+  active: true
+  date: 2020-01-29T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -52,9 +54,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-  date: 2020-01-29T12:00:00Z
-  version: 11.1.0
-- active: false
+- version: 11.0.0
+  active: false
+  date: 2020-01-10T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -69,9 +71,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-  date: 2020-01-10T12:00:00Z
-  version: 11.0.0
-- active: true
+- version: 9.0.0
+  active: true
+  date: 2019-10-28T12:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -86,9 +88,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.9.0
-  date: 2019-10-28T12:00:00Z
-  version: 9.0.0
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-20T17:00:00Z
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -103,9 +105,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.8.0
-  date: 2019-08-20T17:00:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-08-20T16:40:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -118,9 +120,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
-  date: 2019-08-20T16:40:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-06-24T10:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -133,9 +135,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
+- version: 8.2.0
+  active: false
   date: 2019-06-24T10:00:00Z
-  version: 8.2.1
-- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -148,9 +150,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.0
-  date: 2019-06-24T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.1.0
+  active: false
+  date: 2019-04-30T10:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -163,9 +165,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.6.0
-  date: 2019-04-30T10:00:00Z
-  version: 8.1.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-03-21T10:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -178,9 +180,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.5.0
-  date: 2019-03-21T10:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.2.1
+  active: false
+  date: 2019-04-25T18:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -193,9 +195,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
-  date: 2019-04-25T18:00:00Z
-  version: 7.2.1
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21T10:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -208,9 +210,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
+- version: 7.1.0
+  active: false
   date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -223,9 +225,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.1
+  active: false
+  date: 2019-03-12T10:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -238,9 +240,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.0.1
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-03-01T15:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -253,9 +255,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.2.0
-  date: 2019-03-01T15:00:00Z
-  version: 7.0.0
-- active: false
+- version: 6.0.2
+  active: false
+  date: 2019-02-12T13:29:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -268,9 +270,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.2
-  date: 2019-02-12T13:29:00Z
-  version: 6.0.2
-- active: false
+- version: 6.0.1
+  active: false
+  date: 2018-12-04T16:01:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -283,9 +285,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.1
-  date: 2018-12-04T16:01:00Z
-  version: 6.0.1
-- active: false
+- version: 6.0.0
+  active: false
+  date: 2018-11-09T21:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -298,9 +300,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.0
-  date: 2018-11-09T21:00:00Z
-  version: 6.0.0
-- active: false
+- version: 3.0.0
+  active: false
+  date: 2018-08-09T13:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -313,9 +315,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.0.0
-  date: 2018-08-09T13:00:00Z
-  version: 3.0.0
-- active: false
+- version: 2.12.4
+  active: false
+  date: 2019-02-12T13:12:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -328,9 +330,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.4
-  date: 2019-02-12T13:12:00Z
-  version: 2.12.4
-- active: false
+- version: 2.12.3
+  active: false
+  date: 2019-01-23T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -343,9 +345,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-  date: 2019-01-23T12:00:00Z
-  version: 2.12.3
-- active: false
+- version: 2.12.2
+  active: false
+  date: 2018-12-04T16:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -358,9 +360,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-  date: 2018-12-04T16:00:00Z
-  version: 2.12.2
-- active: false
+- version: 2.12.1
+  active: false
+  date: 2018-09-17T14:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -373,9 +375,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.2
-  date: 2018-09-17T14:00:00Z
-  version: 2.12.1
-- active: false
+- version: 2.12.0
+  active: false
+  date: 2018-08-29T15:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -388,9 +390,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.1
-  date: 2018-08-29T15:00:00Z
-  version: 2.12.0
-- active: false
+- version: 2.11.0
+  active: false
+  date: 2018-08-09T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -403,9 +405,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.0
-  date: 2018-08-09T12:00:00Z
-  version: 2.11.0
-- active: false
+- version: 2.10.0
+  active: false
+  date: 2018-06-01T15:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -416,9 +418,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.4.0
-  date: 2018-06-01T15:00:00Z
-  version: 2.10.0
-- active: false
+- version: 2.9.0
+  active: false
+  date: 2018-06-01T13:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -429,9 +431,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.3.0
-  date: 2018-06-01T13:00:00Z
-  version: 2.9.0
-- active: false
+- version: 2.7.0
+  active: false
+  date: 2018-04-25T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -442,9 +444,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.2.0
-  date: 2018-04-25T12:00:00Z
-  version: 2.7.0
-- active: false
+- version: 1.4.0
+  active: false
+  date: 2018-02-08T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -452,9 +454,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.2.0
-  date: 2018-02-08T12:00:00Z
-  version: 1.4.0
-- active: false
+- version: 1.2.0
+  active: false
+  date: 2017-12-12T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -462,9 +464,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.0.0
-  date: 2017-12-12T12:00:00Z
-  version: 1.2.0
-- active: false
+- version: 0.3.0
+  active: false
+  date: 2017-10-26T12:00:00Z
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -472,5 +474,3 @@
       version: 0.1.0
     - name: kvm-operator
       version: 0.1.0
-  date: 2017-10-26T12:00:00Z
-  version: 0.3.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,4 +1,6 @@
-- active: false
+- version: 11.1.1
+  active: false
+  date: 2020-01-29 13:00:00+00:00
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -35,9 +37,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.11.0-dev
-  date: 2020-01-29T13:00:00Z
-  version: 11.1.1
-- active: true
+- version: 11.1.0
+  active: true
+  date: 2020-01-29 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -52,9 +54,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-  date: 2020-01-29T12:00:00Z
-  version: 11.1.0
-- active: false
+- version: 11.0.0
+  active: false
+  date: 2020-01-10 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -69,9 +71,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
-  date: 2020-01-10T12:00:00Z
-  version: 11.0.0
-- active: true
+- version: 9.0.0
+  active: true
+  date: 2019-10-28 12:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -86,9 +88,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.9.0
-  date: 2019-10-28T12:00:00Z
-  version: 9.0.0
-- active: false
+- version: 8.4.0
+  active: false
+  date: 2019-08-20 17:00:00+00:00
   authorities:
     - name: app-operator
       version: 1.0.0
@@ -103,9 +105,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.8.0
-  date: 2019-08-20T17:00:00Z
-  version: 8.4.0
-- active: false
+- version: 8.3.0
+  active: false
+  date: 2019-08-20 16:40:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -118,9 +120,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
-  date: 2019-08-20T16:40:00Z
-  version: 8.3.0
-- active: false
+- version: 8.2.1
+  active: false
+  date: 2019-06-24 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -133,9 +135,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.1
-  date: 2019-06-24T10:00:00Z
-  version: 8.2.1
-- active: false
+- version: 8.2.0
+  active: false
+  date: 2019-06-24 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -148,9 +150,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.7.0
-  date: 2019-06-24T10:00:00Z
-  version: 8.2.0
-- active: false
+- version: 8.1.0
+  active: false
+  date: 2019-04-30 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -163,9 +165,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.6.0
-  date: 2019-04-30T10:00:00Z
-  version: 8.1.0
-- active: false
+- version: 8.0.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -178,9 +180,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.5.0
-  date: 2019-03-21T10:00:00Z
-  version: 8.0.0
-- active: false
+- version: 7.2.1
+  active: false
+  date: 2019-04-25 18:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -193,9 +195,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
-  date: 2019-04-25T18:00:00Z
-  version: 7.2.1
-- active: false
+- version: 7.2.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -208,9 +210,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.4.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.2.0
-- active: false
+- version: 7.1.0
+  active: false
+  date: 2019-03-21 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -223,9 +225,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-  date: 2019-03-21T10:00:00Z
-  version: 7.1.0
-- active: false
+- version: 7.0.1
+  active: false
+  date: 2019-03-12 10:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -238,9 +240,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.3.0
-  date: 2019-03-12T10:00:00Z
-  version: 7.0.1
-- active: false
+- version: 7.0.0
+  active: false
+  date: 2019-03-01 15:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -253,9 +255,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.2.0
-  date: 2019-03-01T15:00:00Z
-  version: 7.0.0
-- active: false
+- version: 6.0.2
+  active: false
+  date: 2019-02-12 13:29:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -268,9 +270,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.2
-  date: 2019-02-12T13:29:00Z
-  version: 6.0.2
-- active: false
+- version: 6.0.1
+  active: false
+  date: 2018-12-04 16:01:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -283,9 +285,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.1
-  date: 2018-12-04T16:01:00Z
-  version: 6.0.1
-- active: false
+- version: 6.0.0
+  active: false
+  date: 2018-11-09 21:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -298,9 +300,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.1.0
-  date: 2018-11-09T21:00:00Z
-  version: 6.0.0
-- active: false
+- version: 3.0.0
+  active: false
+  date: 2018-08-09 13:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -313,9 +315,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.0.0
-  date: 2018-08-09T13:00:00Z
-  version: 3.0.0
-- active: false
+- version: 2.12.4
+  active: false
+  date: 2019-02-12 13:12:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -328,9 +330,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.4
-  date: 2019-02-12T13:12:00Z
-  version: 2.12.4
-- active: false
+- version: 2.12.3
+  active: false
+  date: 2019-01-23 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -343,9 +345,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-  date: 2019-01-23T12:00:00Z
-  version: 2.12.3
-- active: false
+- version: 2.12.2
+  active: false
+  date: 2018-12-04 16:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -358,9 +360,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.3
-  date: 2018-12-04T16:00:00Z
-  version: 2.12.2
-- active: false
+- version: 2.12.1
+  active: false
+  date: 2018-09-17 14:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -373,9 +375,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.2
-  date: 2018-09-17T14:00:00Z
-  version: 2.12.1
-- active: false
+- version: 2.12.0
+  active: false
+  date: 2018-08-29 15:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -388,9 +390,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.1
-  date: 2018-08-29T15:00:00Z
-  version: 2.12.0
-- active: false
+- version: 2.11.0
+  active: false
+  date: 2018-08-09 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -403,9 +405,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.5.0
-  date: 2018-08-09T12:00:00Z
-  version: 2.11.0
-- active: false
+- version: 2.10.0
+  active: false
+  date: 2018-06-01 15:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -416,9 +418,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.4.0
-  date: 2018-06-01T15:00:00Z
-  version: 2.10.0
-- active: false
+- version: 2.9.0
+  active: false
+  date: 2018-06-01 13:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -429,9 +431,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.3.0
-  date: 2018-06-01T13:00:00Z
-  version: 2.9.0
-- active: false
+- version: 2.7.0
+  active: false
+  date: 2018-04-25 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -442,9 +444,9 @@
       version: 0.2.0
     - name: kvm-operator
       version: 2.2.0
-  date: 2018-04-25T12:00:00Z
-  version: 2.7.0
-- active: false
+- version: 1.4.0
+  active: false
+  date: 2018-02-08 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -452,9 +454,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.2.0
-  date: 2018-02-08T12:00:00Z
-  version: 1.4.0
-- active: false
+- version: 1.2.0
+  active: false
+  date: 2017-12-12 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -462,9 +464,9 @@
       version: 0.1.0
     - name: kvm-operator
       version: 1.0.0
-  date: 2017-12-12T12:00:00Z
-  version: 1.2.0
-- active: false
+- version: 0.3.0
+  active: false
+  date: 2017-10-26 12:00:00+00:00
   authorities:
     - name: cert-operator
       version: 0.1.0
@@ -472,5 +474,3 @@
       version: 0.1.0
     - name: kvm-operator
       version: 0.1.0
-  date: 2017-10-26T12:00:00Z
-  version: 0.3.0


### PR DESCRIPTION
As I mentioned this in #sig-releng channel, It would be much easier to look into the version in the first line of release rather than scrolling down to a file. 