### PR TITLE
Use cluster-operator 0.23.1 in legacy WIP releases

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -150,7 +150,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: aws
-      version: 0.23.0
+      version: 0.23.1
 - version: 9.1.0
   active: true
   date: 2020-01-28T12:00:00Z

--- a/azure.yaml
+++ b/azure.yaml
@@ -35,7 +35,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: azure
-      version: 0.23.0
+      version: 0.23.1
 - version: 11.1.0
   active: true
   date: 2020-01-08T12:00:00Z

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -32,7 +32,7 @@
       version: 0.7.0
     - name: cluster-operator
       provider: kvm
-      version: 0.23.0
+      version: 0.23.1
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator


### PR DESCRIPTION
Includes fix for regression, affecting nginx legacy deployments, introduced with move of app metadata from cluster-operator to releases repo as registry.