### PR TITLE
Use kiam-app v1.1.1 in next AWS node pools WIP

### DIFF
--- a/app/changelog/kiam.yaml
+++ b/app/changelog/kiam.yaml
@@ -1,3 +1,9 @@
+- version: 1.1.1
+  componentVersion: 3.5.0
+  description: Use global image registry for parent and subchart.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/kiam-app/blob/master/CHANGELOG.md#v111-2020-02-21
 - version: 1.1.0
   componentVersion: 3.5.0
   description: Updated kiam app version to v3.5.

--- a/aws.yaml
+++ b/aws.yaml
@@ -20,7 +20,7 @@
       version: 1.2.0
     - app: kiam
       componentVersion: 3.5.0
-      version: 1.1.0
+      version: 1.1.1
     - app: kube-state-metrics
       componentVersion: 1.9.0
       version: 1.0.0


### PR DESCRIPTION
kiam-app v1.1.1 includes internal improvement, globally configurable image registry for parent and subchart, in China installations to use aliyun registry instead of quay https://github.com/giantswarm/kiam-app/pull/15

Registry to be used is already configured in default app catalog, axolotl and giraffe specific overrides, and app catalogs ensured/updated.