### PR TITLE
Move AWS release notes 9.1.1 to 9.2.0

### DIFF
--- a/release-notes/aws/v9.2.0.md
+++ b/release-notes/aws/v9.2.0.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.1.1 for AWS is now active for you! :zap:
+## :zap: Giant Swarm Release 9.2.0 for AWS is now active for you! :zap:
 
 This release upgrades the NGINX Ingress Controller app to upstream ingress-nginx v0.29.0. Among multiple improvements, this upgrade comes with a **breaking change** - default SSL ciphers no longer include AES-CBC based ciphers since they are considered weak. As a side effect, this also drops SSL support for old browsers and clients which do not support AES-GCM ciphers (e.g. Safari 9). At your own risk, weak ciphers can still be enabled on demand independently for each cluster.
 


### PR DESCRIPTION
Since this WIP legacy releases includes a breaking change, we increment minor instead of just patch version number from previous active legacy AWS release.