### PR TITLE
Fix release index, AWS 9.1.1 to 9.2.0 rename leftover

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains Giant Swarm releases and changelogs.
  - [10.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.2.md)
  - [10.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.1.md)
  - [10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
- - [9.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.1.md)
+ - [9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
  - [9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
  - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)
  - [8.5.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v8.5.0.md)


### PR DESCRIPTION
Forgot to update README.md / release index in https://github.com/giantswarm/releases/pull/120
This PR fixes it.