### PR TITLE
Move KVM release notes 11.1.1 to 11.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains Giant Swarm releases and changelogs.
  - [8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.0.md)
 
 ### KVM
- - [11.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.1.1.md)
+ - [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.0.md)
  - [11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.1.0.md)
  - [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.0.0.md)
  - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v9.0.0.md)

--- a/release-notes/kvm/v11.2.0.md
+++ b/release-notes/kvm/v11.2.0.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.1.1 for KVM is now active for you! :zap:
+## :zap: Giant Swarm Release 11.2.0 for KVM is now active for you! :zap:
 
 This release upgrades the NGINX Ingress Controller app to upstream ingress-nginx v0.29.0. Among multiple improvements, this upgrade comes with a **breaking change** - default SSL ciphers no longer include AES-CBC based ciphers since they are considered weak. As a side effect, this also drops SSL support for old browsers and clients which do not support AES-GCM ciphers (e.g. Safari 9). At your own risk, weak ciphers can still be enabled on demand independently for each cluster.
 


### PR DESCRIPTION
Due to breaking change in the next KVM WIP release, instead of bumping patch we're bumping minor version number. This PR renames release version in release notes accordingly.