### PR TITLE
New app changelog entries

### DIFF
--- a/app/changelog/cert-manager.yaml
+++ b/app/changelog/cert-manager.yaml
@@ -1,3 +1,9 @@
+- version: 1.0.6
+  componentVersion: 0.9.0
+  description: Configured app icon.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/cert-manager-app/blob/master/CHANGELOG.md#v106-2020-02-28
 - version: 1.0.5
   componentVersion: 0.9.0
   description: Updated helm chart to use a same image registry for parent and cluster-issuer subchart.

--- a/app/changelog/nginx-ingress-controller.yaml
+++ b/app/changelog/nginx-ingress-controller.yaml
@@ -1,3 +1,11 @@
+- version: 1.6.0
+  componentVersion: 0.30.0
+  description: Upgraded to nginx-ingress-controller 0.30.0, enabled HPA by default, and configured app icon.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/nginx-ingress-controller-app/pull/27
+    - https://github.com/giantswarm/nginx-ingress-controller-app/pull/31
+    - https://github.com/giantswarm/nginx-ingress-controller-app/pull/32
 - version: 1.5.0
   componentVersion: 0.29.0
   description: Upgrade to nginx-ingress-controller 0.29.0.


### PR DESCRIPTION
This PR adds changelog entries for:
- cert-manager app 1.0.6
- nginx IC app 1.6.0

so they can be referenced in releases (release definition/activation/notes PRs will follow).