### PR TITLE
Define and activate AWS 9.2.1 release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -214,9 +214,59 @@
       version: 3.9.1
     - name: etcd
       version: 3.3.15
-- version: 9.2.0
+- version: 9.2.1
   state: active
   active: true
+  date: 2020-03-18T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.12.1
+    - app: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.3
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.4
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.4
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.6.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: aws
+      version: 0.23.6
+  components:
+    - name: kubernetes
+      version: 1.16.3
+    - name: containerlinux
+      version: 2191.5.0
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+- version: 9.2.0
+  state: deprecated
+  active: false
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter


### PR DESCRIPTION
This also deactivates 9.2.0

PR should be approved only once release notes are prepared and ready to share.