### PR TITLE
Define and activate AWS 11.0.2 release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1,15 +1,15 @@
-- version: 11.0.2
+- version: 11.0.3
   state: wip
   active: false
-  date: 2020-02-21T12:00:00Z
+  date: 2020-04-01T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
     - app: cert-manager
       componentVersion: 0.9.0
-      version: 1.0.5
+      version: 1.0.6
     - app: chart-operator
-      version: 0.11.4
+      version: 0.12.1
     - app: cluster-autoscaler
       componentVersion: 1.16.2
       version: 1.1.4
@@ -42,12 +42,68 @@
       version: 0.1.0
     - name: cluster-operator
       provider: aws
-      version: 2.1.1
+      version: 2.1.4
   components:
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+- version: 11.0.2
+  state: active
+  active: true
+  date: 2020-03-12T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: cert-manager
+      componentVersion: 0.9.0
+      version: 1.0.6
+    - app: chart-operator
+      version: 0.12.1
+    - app: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: external-dns
+      componentVersion: 0.5.18
+      version: 1.2.0
+    - app: kiam
+      componentVersion: 3.5.0
+      version: 1.1.1
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.4
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.5.1
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 8.1.1
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: aws
+      version: 2.1.4
+  components:
+    - name: kubernetes
+      version: 1.16.3
+    - name: containerlinux
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico
@@ -55,8 +111,8 @@
     - name: etcd
       version: 3.3.17
 - version: 11.0.1
-  state: active
-  active: true
+  state: deprecated
+  active: false
   date: 2020-02-05T12:00:00Z
   apps:
     - app: cert-exporter
@@ -103,7 +159,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico
@@ -130,7 +186,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico


### PR DESCRIPTION
This also deactivates 11.0.1

PR should be approved only once release notes are prepared and ready to share.