### PR TITLE
Define KVM 11.2.1 WIP release

### DIFF
--- a/kvm.yaml
+++ b/kvm.yaml
@@ -19,7 +19,7 @@
       version: 1.6.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.4
+      version: 1.6.5
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -30,7 +30,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: kvm
-      version: 0.23.6
+      version: 0.23.7
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -36,8 +36,17 @@
       version: 0.2.0
     - name: kvm-operator
       version: 3.10.0
+  components:
+    - name: kubernetes
+      version: 1.16.3
+    - name: containerlinux
+      version: 2247.6.0
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
 - version: 11.2.0
-  state: active
+  state: deprecated
   active: false
   date: 2020-02-26T12:00:00Z
   apps:

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,6 +1,6 @@
 - version: 11.2.1
   state: active
-  date: 2020-03-20T12:00:00Z
+  date: 2020-03-23T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,6 +1,44 @@
-- version: 11.2.0
+- version: 11.2.1
   state: active
   active: true
+  date: 2020-03-17T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.12.1
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.4
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.4
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: kvm
+      version: 0.23.6
+    - name: flannel-operator
+      version: 0.2.0
+    - name: kvm-operator
+      version: 3.10.0
+- version: 11.2.0
+  state: active
+  active: false
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter
@@ -48,8 +86,8 @@
     - name: etcd
       version: 3.3.17
 - version: 11.1.0
-  state: active
-  active: true
+  state: deprecated
+  active: false
   date: 2020-01-29T12:00:00Z
   authorities:
     - name: app-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,7 +1,6 @@
 - version: 11.2.1
   state: active
-  active: true
-  date: 2020-03-17T12:00:00Z
+  date: 2020-03-19T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -30,7 +30,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: kvm
-      version: 0.23.7-dev
+      version: 0.23.6
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -8,7 +8,7 @@
       version: 0.12.1
     - app: coredns
       componentVersion: 1.6.5
-      version: 1.1.7
+      version: 1.1.8
     - app: kube-state-metrics
       componentVersion: 1.9.2
       version: 1.0.4

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -16,7 +16,7 @@
       componentVersion: 0.3.3
       version: 1.0.0
     - app: net-exporter
-      version: 1.6.0
+      version: 1.7.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
       version: 1.6.5

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,5 +1,5 @@
 - version: 11.2.1
-  state: active
+  state: wip
   date: 2020-03-23T12:00:00Z
   apps:
     - app: cert-exporter
@@ -45,7 +45,7 @@
     - name: etcd
       version: 3.3.17
 - version: 11.2.0
-  state: deprecated
+  state: active
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -31,7 +31,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: kvm
-      version: 0.23.6
+      version: 0.23.7-dev
     - name: flannel-operator
       version: 0.2.0
     - name: kvm-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -8,7 +8,7 @@
       version: 0.12.1
     - app: coredns
       componentVersion: 1.6.5
-      version: 1.1.3
+      version: 1.1.7
     - app: kube-state-metrics
       componentVersion: 1.9.2
       version: 1.0.4

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,6 +1,6 @@
 - version: 11.2.1
   state: active
-  date: 2020-03-19T12:00:00Z
+  date: 2020-03-20T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1


### PR DESCRIPTION
This also deactivates 11.1.0, which should have been deactivated with 11.2.0 release.