### PR TITLE
Define Azure 11.2.1 WIP release

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -35,7 +35,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: azure
-      version: 0.23.7
+      version: 0.23.8
   components:
     - name: kubernetes
       version: 1.16.7

--- a/azure.yaml
+++ b/azure.yaml
@@ -9,7 +9,7 @@
       version: 0.12.1
     - app: coredns
       componentVersion: 1.6.5
-      version: 1.1.3
+      version: 1.1.7
     - app: external-dns
       componentVersion: 0.5.18
       version: 1.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,7 +6,7 @@
     - app: cert-exporter
       version: 1.2.1
     - app: chart-operator
-      version: 0.11.4
+      version: 0.12.1
     - app: coredns
       componentVersion: 1.6.5
       version: 1.1.3

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,7 +1,7 @@
 - version: 11.2.1
-  state: active
-  active: true
-  date: 2020-03-17T12:00:00Z
+  state: wip
+  active: false
+  date: 2020-03-18T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -49,8 +49,8 @@
     - name: etcd
       version: 3.3.17
 - version: 11.2.0
-  state: deprecated
-  active: false
+  state: active
+  active: true
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter

--- a/azure.yaml
+++ b/azure.yaml
@@ -23,7 +23,7 @@
       version: 1.6.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.3
+      version: 1.6.4
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,7 +1,7 @@
 - version: 11.2.1
   state: active
   active: true
-  date: 2020-03-12T12:00:00Z
+  date: 2020-03-17T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -23,7 +23,7 @@
       version: 1.6.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.2
+      version: 1.6.3
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0
@@ -36,7 +36,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: azure
-      version: 0.23.5
+      version: 0.23.6
   components:
     - name: kubernetes
       version: 1.16.7

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,56 @@
-- version: 11.2.0
+- version: 11.2.1
   state: active
   active: true
+  date: 2020-03-11T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.11.4
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: external-dns
+      componentVersion: 0.5.18
+      version: 1.2.0
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.4
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.1
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 3.0.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.23.5
+  components:
+    - name: kubernetes
+      version: 1.16.7
+    - name: containerlinux
+      version: 2191.5.0
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+- version: 11.2.0
+  state: deprecated
+  active: false
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,7 +1,7 @@
 - version: 11.2.1
   state: active
   active: true
-  date: 2020-03-11T12:00:00Z
+  date: 2020-03-12T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -23,7 +23,7 @@
       version: 1.6.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.1
+      version: 1.6.2
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,6 @@
 - version: 11.2.1
   state: wip
-  date: 2020-03-23T12:00:00Z
+  date: 2020-03-30T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -8,7 +8,7 @@
       version: 0.12.1
     - app: coredns
       componentVersion: 1.6.5
-      version: 1.1.7
+      version: 1.1.8
     - app: external-dns
       componentVersion: 0.5.18
       version: 1.2.0
@@ -19,7 +19,7 @@
       componentVersion: 0.3.3
       version: 1.0.0
     - app: net-exporter
-      version: 1.6.0
+      version: 1.7.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
       version: 1.6.5

--- a/azure.yaml
+++ b/azure.yaml
@@ -38,7 +38,7 @@
       version: 0.23.8
   components:
     - name: kubernetes
-      version: 1.16.7
+      version: 1.16.8
     - name: containerlinux
       version: 2191.5.0
     - name: coredns

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,7 +1,6 @@
 - version: 11.2.1
   state: wip
-  active: false
-  date: 2020-03-18T12:00:00Z
+  date: 2020-03-23T12:00:00Z
   apps:
     - app: cert-exporter
       version: 1.2.1
@@ -23,7 +22,7 @@
       version: 1.6.0
     - app: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.4
+      version: 1.6.5
     - app: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0
@@ -36,7 +35,7 @@
       version: 0.1.0
     - name: cluster-operator
       provider: azure
-      version: 0.23.6
+      version: 0.23.7
   components:
     - name: kubernetes
       version: 1.16.7


### PR DESCRIPTION
~This also deactivates 11.2.0~

~PR should be approved only once release notes are prepared and ready to share.~

Since @giantswarm/team-celestial is taking over as lead for Azure 11.2.1 release, this PR just defines a WIP without activating it or deactivating previous release.