### PR TITLE
Add chart-operator 0.12.0 to WIP releases

### DIFF
--- a/app/changelog/chart-operator.yaml
+++ b/app/changelog/chart-operator.yaml
@@ -1,3 +1,13 @@
+- version: 0.12.0
+  description: Improvements to release and status resources. 
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/blob/master/CHANGELOG.md#v0120-2020-03-09
+- version: 0.11.5
+  description: Make Kubernetes domain configurable.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/pull/357
 - version: 0.11.4
   description: Handle timeouts pulling chart tarballs.
   kind: changed

--- a/aws.yaml
+++ b/aws.yaml
@@ -9,7 +9,7 @@
       componentVersion: 0.9.0
       version: 1.0.5
     - app: chart-operator
-      version: 0.11.4
+      version: 0.12.0
     - app: cluster-autoscaler
       componentVersion: 1.16.2
       version: 1.1.4

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,3 +1,53 @@
+- version: 11.2.1
+  state: wip
+  active: false
+  date: 2020-03-10T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.12.0
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: external-dns
+      componentVersion: 0.5.18
+      version: 1.2.0
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.2
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.29.0
+      version: 1.5.0
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 2.9.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: azure
+      version: 0.23.1
+  components:
+    - name: kubernetes
+      version: 1.16.3
+    - name: containerlinux
+      version: 2191.5.0
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
 - version: 11.2.0
   state: active
   active: true

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,3 +1,52 @@
+- version: 11.2.1
+  state: wip
+  active: false
+  date: 2020-03-10T12:00:00Z
+  apps:
+    - app: cert-exporter
+      version: 1.2.1
+    - app: chart-operator
+      version: 0.12.0
+    - app: coredns
+      componentVersion: 1.6.5
+      version: 1.1.3
+    - app: kube-state-metrics
+      componentVersion: 1.9.2
+      version: 1.0.2
+    - app: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - app: net-exporter
+      version: 1.6.0
+    - app: nginx-ingress-controller
+      componentVersion: 0.29.0
+      version: 1.5.0
+    - app: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  authorities:
+    - name: app-operator
+      version: 1.0.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      provider: kvm
+      version: 0.23.1
+    - name: flannel-operator
+      version: 0.2.0
+    - name: kvm-operator
+      version: 3.10.0
+  components:
+    - name: kubernetes
+      version: 1.16.3
+    - name: containerlinux
+      version: 2247.6.0
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
 - version: 11.2.0
   state: active
   active: true


### PR DESCRIPTION
- Adds to existing AWS WIP 11.0.2
- Creates new 11.2.1 Azure and KVM as there wasn't a WIP release.
