### PR TITLE
Register NGINX IC App v1.6.1

### DIFF
--- a/app/changelog/nginx-ingress-controller.yaml
+++ b/app/changelog/nginx-ingress-controller.yaml
@@ -1,3 +1,9 @@
+- version: 1.6.1
+  componentVersion: 0.30.0
+  description: Disable HPA, PDB and clear resource requests for extra small clusters.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/nginx-ingress-controller-app/pull/34
 - version: 1.6.0
   componentVersion: 0.30.0
   description: Upgraded to nginx-ingress-controller 0.30.0, enabled HPA by default, and configured app icon.


### PR DESCRIPTION
Follow up to releasing https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.1

In followup PRs this nginx IC App release is to be included in
- AWS 9.0.1
- AWS 9.2.1
- KVM 11.2.1
- Azure 11.2.1
together with cluster-operator 0.23.5