### PR TITLE
Register chart-operator v0.12.0

### DIFF
--- a/app/changelog/chart-operator.yaml
+++ b/app/changelog/chart-operator.yaml
@@ -1,3 +1,15 @@
+
+
+- version: 0.12.0
+  description: Improvements to release and status resources.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/blob/master/CHANGELOG.md#v0120-2020-03-09
+- version: 0.11.5
+  description: Make Kubernetes domain configurable.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/chart-operator/pull/357
 - version: 0.11.4
   description: Handle timeouts pulling chart tarballs.
   kind: changed

--- a/app/changelog/chart-operator.yaml
+++ b/app/changelog/chart-operator.yaml
@@ -1,5 +1,3 @@
-
-
 - version: 0.12.0
   description: Improvements to release and status resources.
   kind: changed


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/chart-operator/releases/tag/v0.12.0.

Also adds `v0.11.5` release that didn't get registered for the history.

Will be used in.

- AWS 9.0.1
- AWS 9.2.1
- Azure 11.2.1
- KVM 11.2.1