### PR TITLE
Register NGINX IC App v1.6.2

### DIFF
--- a/app/changelog/nginx-ingress-controller.yaml
+++ b/app/changelog/nginx-ingress-controller.yaml
@@ -1,3 +1,9 @@
+- version: 1.6.2
+  componentVersion: 0.30.0
+  description: Reintroduced config properties which should have been just deprecated but got dropped prematurely in v1.4.0.
+  kind: changed
+  urls:
+    - https://github.com/giantswarm/nginx-ingress-controller-app/pull/36
 - version: 1.6.1
   componentVersion: 0.30.0
   description: Disable HPA, PDB and clear resource requests for extra small clusters.


### PR DESCRIPTION
Follow up to releasing https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.2

In followup PRs this nginx IC App release is to be included in
- AWS 9.0.1
- AWS 9.2.1
- KVM 11.2.1
- Azure 11.2.1