### PR TITLE
circleci: Fix catalog name for collection job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
             - prepare-helm-chart-kvm
       - architect/push-to-app-collection:
           name: push-releases-to-kvm-app-collection
-          app_catalog: releases-catalog
+          app_catalog: releases
           app_name: releases-kvm
           app_collection_repo: kvm-app-collection
           unique: "true"
@@ -112,7 +112,7 @@ workflows:
             - push-releases-kvm-to-releases-catalog
       - architect/push-to-app-collection:
           name: push-releases-to-aws-app-collection
-          app_catalog: releases-catalog
+          app_catalog: releases
           app_name: releases-aws
           app_collection_repo: aws-app-collection
           unique: "true"
@@ -142,7 +142,7 @@ workflows:
             - push-releases-aws-to-releases-catalog
       - architect/push-to-app-collection:
           name: push-releases-to-azure-app-collection
-          app_catalog: releases-catalog
+          app_catalog: releases
           app_name: releases-azure
           app_collection_repo: azure-app-collection
           unique: "true"

--- a/aws.yaml
+++ b/aws.yaml
@@ -48,8 +48,6 @@
       version: 1.16.3
     - name: containerlinux
       version: 2247.6.0
-    - name: coredns
-      version: 1.6.5
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -104,8 +102,6 @@
       version: 1.16.3
     - name: containerlinux
       version: 2247.6.0
-    - name: coredns
-      version: 1.6.5
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -262,8 +258,6 @@
       version: 1.16.3
     - name: containerlinux
       version: 2247.6.0
-    - name: coredns
-      version: 1.6.5
     - name: calico
       version: 3.10.1
     - name: etcd

--- a/azure.yaml
+++ b/azure.yaml
@@ -42,8 +42,6 @@
       version: 1.16.3
     - name: containerlinux
       version: 2191.5.0
-    - name: coredns
-      version: 1.6.5
     - name: calico
       version: 3.10.1
     - name: etcd

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -41,8 +41,6 @@
       version: 1.16.3
     - name: containerlinux
       version: 2247.6.0
-    - name: coredns
-      version: 1.6.5
     - name: calico
       version: 3.10.1
     - name: etcd


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8436 and related to https://github.com/giantswarm/installations/pull/1116

For `architect/push-to-app-catalog`, `app_catalog` refers to the name of the repository to push to but in `architect/push-to-app-collection` it refers to name of the `appcatalog` CR on the CP. In this case, these values are `releases-catalog` and `releases` respectively so `architect/push-to-app-collection` must be changed to reflect this difference.

While testing I noticed that newer releases (those with `apps`) have `coredns` defined in two places so I'm taking this opportunity to remove them from `components` as well.