### PR TITLE
Add missing azure release states

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -153,6 +153,7 @@
     - name: etcd
       version: 3.3.13
 - version: 8.4.0
+  state: deprecated
   active: false
   date: 2019-08-14T10:00:00Z
   authorities:
@@ -179,6 +180,7 @@
     - name: etcd
       version: 3.3.13
 - version: 8.3.0
+  state: deprecated
   active: false
   date: 2019-07-11T10:00:00Z
   authorities:
@@ -203,6 +205,7 @@
     - name: etcd
       version: 3.3.13
 - version: 8.2.1
+  state: deprecated
   active: false
   date: 2019-03-30T10:00:00Z
   authorities:
@@ -227,6 +230,7 @@
     - name: etcd
       version: 3.3.13
 - version: 8.2.0
+  state: deprecated
   active: false
   date: 2019-03-30T10:00:00Z
   authorities:
@@ -251,6 +255,7 @@
     - name: etcd
       version: 3.3.13
 - version: 8.0.0
+  state: deprecated
   active: false
   date: 2019-03-21T10:00:00Z
   authorities:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8436

Some older releases are failing to deploy on Azure they don't have `state` https://github.com/giantswarm/releases/blob/master/azure.yaml#L253 I guess I missed them in https://github.com/giantswarm/releases/pull/147