### PR TITLE
Fix containerlinux version for aws releases

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -47,7 +47,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -101,7 +101,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -126,7 +126,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico
@@ -257,7 +257,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -282,7 +282,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9356

Checked this on gauss during aws 9.2.1 release testing.

They all had:
```
$ cat /etc/os-release 
NAME="Container Linux by CoreOS"
ID=coreos
VERSION=2191.5.0
VERSION_ID=2191.5.0
BUILD_ID=2019-09-04-0357
PRETTY_NAME="Container Linux by CoreOS 2191.5.0 (Rhyolite)"
ANSI_COLOR="38;5;75"
HOME_URL="https://coreos.com/"
BUG_REPORT_URL="https://issues.coreos.com"
COREOS_BOARD="amd64-usr"
```

As I mentioned in https://github.com/giantswarm/giantswarm/issues/9356#issuecomment-597078301, @tfussell fixed this same thing for azure already in https://github.com/giantswarm/releases/pull/148/files#diff-087dc004b9647ff961f3d6d8942a5e6a