### PR TITLE
Remove unused active field for all releases

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1,6 +1,5 @@
 - version: 11.1.1
   state: wip
-  active: false
   date: 2020-03-17T12:00:00Z
   apps:
     - app: cert-exporter
@@ -108,7 +107,6 @@
       version: 3.3.17
 - version: 11.0.0
   state: deprecated
-  active: false
   date: 2020-01-29T12:00:00Z
   authorities:
     - name: app-operator
@@ -135,7 +133,6 @@
       version: 3.3.17
 - version: 10.1.2
   state: deprecated
-  active: false
   date: 2020-02-06T08:00:00Z
   authorities:
     - name: app-operator
@@ -162,7 +159,6 @@
       version: 3.3.15
 - version: 10.1.1
   state: deprecated
-  active: false
   date: 2020-01-10T08:00:00Z
   authorities:
     - name: app-operator
@@ -189,7 +185,6 @@
       version: 3.3.15
 - version: 10.1.0
   state: deprecated
-  active: false
   date: 2019-12-18T14:00:00Z
   authorities:
     - name: app-operator
@@ -216,7 +211,6 @@
       version: 3.3.15
 - version: 9.2.1
   state: active
-  active: true
   date: 2020-03-18T12:00:00Z
   apps:
     - app: cert-exporter
@@ -266,7 +260,6 @@
       version: 3.3.17
 - version: 9.2.0
   state: deprecated
-  active: false
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter
@@ -314,7 +307,6 @@
       version: 3.3.17
 - version: 9.1.0
   state: deprecated
-  active: false
   date: 2020-01-28T12:00:00Z
   authorities:
     - name: app-operator
@@ -341,7 +333,6 @@
       version: 3.3.17
 - version: 9.0.0
   state: active
-  active: true
   date: 2019-10-28T12:00:00Z
   authorities:
     - name: app-operator
@@ -368,7 +359,6 @@
       version: 3.3.15
 - version: 8.5.0
   state: active
-  active: true
   date: 2019-09-02T13:30:00Z
   authorities:
     - name: app-operator
@@ -395,7 +385,6 @@
       version: 3.3.13
 - version: 8.4.1
   state: deprecated
-  active: false
   date: 2019-09-24T11:00:00Z
   authorities:
     - name: app-operator
@@ -422,7 +411,6 @@
       version: 3.3.13
 - version: 8.4.0
   state: deprecated
-  active: false
   date: 2019-08-19T16:30:00Z
   authorities:
     - name: app-operator
@@ -449,7 +437,6 @@
       version: 3.3.13
 - version: 8.3.0
   state: deprecated
-  active: false
   date: 2019-08-19T10:00:00Z
   authorities:
     - name: aws-operator
@@ -474,7 +461,6 @@
       version: 3.3.13
 - version: 8.2.1
   state: deprecated
-  active: false
   date: 2019-08-09T10:00:00Z
   authorities:
     - name: aws-operator
@@ -499,7 +485,6 @@
       version: 3.3.13
 - version: 8.2.0
   state: deprecated
-  active: false
   date: 2019-06-03T10:00:00Z
   authorities:
     - name: aws-operator
@@ -524,7 +509,6 @@
       version: 3.3.13
 - version: 8.1.0
   state: deprecated
-  active: false
   date: 2019-06-04T16:00:00Z
   authorities:
     - name: aws-operator
@@ -549,7 +533,6 @@
       version: 3.3.12
 - version: 8.0.0
   state: deprecated
-  active: false
   date: 2019-04-17T08:00:00Z
   authorities:
     - name: aws-operator

--- a/azure.yaml
+++ b/azure.yaml
@@ -1,6 +1,5 @@
 - version: 11.2.0
   state: active
-  active: true
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter
@@ -48,7 +47,6 @@
       version: 3.3.17
 - version: 11.1.0
   state: deprecated
-  active: false
   date: 2020-02-20T12:00:00Z
   authorities:
     - name: app-operator
@@ -73,7 +71,6 @@
       version: 3.3.17
 - version: 11.0.0
   state: deprecated
-  active: false
   date: 2020-01-08T12:00:00Z
   authorities:
     - name: app-operator
@@ -100,7 +97,6 @@
       version: 3.3.17
 - version: 9.0.0
   state: active
-  active: true
   date: 2019-10-25T10:00:00Z
   authorities:
     - name: app-operator
@@ -127,7 +123,6 @@
       version: 3.3.15
 - version: 8.4.1
   state: deprecated
-  active: false
   date: 2019-09-26T17:00:00Z
   authorities:
     - name: app-operator
@@ -154,7 +149,6 @@
       version: 3.3.13
 - version: 8.4.0
   state: deprecated
-  active: false
   date: 2019-08-14T10:00:00Z
   authorities:
     - name: app-operator
@@ -181,7 +175,6 @@
       version: 3.3.13
 - version: 8.3.0
   state: deprecated
-  active: false
   date: 2019-07-11T10:00:00Z
   authorities:
     - name: azure-operator
@@ -206,7 +199,6 @@
       version: 3.3.13
 - version: 8.2.1
   state: deprecated
-  active: false
   date: 2019-03-30T10:00:00Z
   authorities:
     - name: azure-operator
@@ -231,7 +223,6 @@
       version: 3.3.13
 - version: 8.2.0
   state: deprecated
-  active: false
   date: 2019-03-30T10:00:00Z
   authorities:
     - name: azure-operator
@@ -256,7 +247,6 @@
       version: 3.3.13
 - version: 8.0.0
   state: deprecated
-  active: false
   date: 2019-03-21T10:00:00Z
   authorities:
     - name: azure-operator

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,6 +1,5 @@
 - version: 11.2.0
   state: active
-  active: true
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter
@@ -47,7 +46,6 @@
       version: 3.3.17
 - version: 11.1.0
   state: active
-  active: true
   date: 2020-01-29T12:00:00Z
   authorities:
     - name: app-operator
@@ -74,7 +72,6 @@
       version: 3.3.17
 - version: 11.0.0
   state: deprecated
-  active: false
   date: 2020-01-10T12:00:00Z
   authorities:
     - name: app-operator
@@ -101,7 +98,6 @@
       version: 3.3.17
 - version: 9.0.0
   state: active
-  active: true
   date: 2019-10-28T12:00:00Z
   authorities:
     - name: app-operator
@@ -128,7 +124,6 @@
       version: 3.3.15
 - version: 8.4.0
   state: deprecated
-  active: false
   date: 2019-08-20T17:00:00Z
   authorities:
     - name: app-operator
@@ -155,7 +150,6 @@
       version: 3.3.13
 - version: 8.3.0
   state: deprecated
-  active: false
   date: 2019-08-20T16:40:00Z
   authorities:
     - name: cert-operator
@@ -180,7 +174,6 @@
       version: 3.3.13
 - version: 8.2.1
   state: deprecated
-  active: false
   date: 2019-06-24T10:00:00Z
   authorities:
     - name: cert-operator
@@ -207,7 +200,6 @@
       version: 3.3.13
 - version: 8.2.0
   state: deprecated
-  active: false
   date: 2019-06-24T10:00:00Z
   authorities:
     - name: cert-operator
@@ -234,7 +226,6 @@
       version: 3.3.13
 - version: 8.1.0
   state: deprecated
-  active: false
   date: 2019-04-30T10:00:00Z
   authorities:
     - name: cert-operator
@@ -261,7 +252,6 @@
       version: 3.3.12
 - version: 8.0.0
   state: deprecated
-  active: false
   date: 2019-03-21T10:00:00Z
   authorities:
     - name: cert-operator


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8436

We no longer need the `active` field for releases now that `cluster-service` gets release information from Release CRs.