### PR TITLE
update aws yml with coredns 117

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -14,7 +14,7 @@
       version: 1.1.4
     - app: coredns
       componentVersion: 1.6.5
-      version: 1.1.6
+      version: 1.1.7
     - app: external-dns
       componentVersion: 0.5.18
       version: 1.2.0


### PR DESCRIPTION
`azure.yaml` and `kvm.yaml` did not have any `WIP` releases to update. 