### PR TITLE
Activate kvm 11.2.1 release

### DIFF
--- a/kvm.yaml
+++ b/kvm.yaml
@@ -1,5 +1,5 @@
 - version: 11.2.1
-  state: wip
+  state: active
   date: 2020-03-23T12:00:00Z
   apps:
     - app: cert-exporter
@@ -45,7 +45,7 @@
     - name: etcd
       version: 3.3.17
 - version: 11.2.0
-  state: active
+  state: deprecated
   date: 2020-02-26T12:00:00Z
   apps:
     - app: cert-exporter


### PR DESCRIPTION
This also deactivates 11.2.0 release.

This PR should be approved only when 11.2.1 release notes are ready to be announced to customer.