### PR TITLE
Fix coreos version for kvm releases

### DIFF
--- a/kvm.yaml
+++ b/kvm.yaml
@@ -39,7 +39,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -85,7 +85,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: calico
       version: 3.10.1
     - name: etcd
@@ -109,7 +109,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico
@@ -135,7 +135,7 @@
     - name: kubernetes
       version: 1.16.3
     - name: containerlinux
-      version: 2247.6.0
+      version: 2191.5.0
     - name: coredns
       version: 1.6.5
     - name: calico


### PR DESCRIPTION
This PR fixes invalid metadata about containerlinux version used in current and few deprecated kvm releases, 2247.6.0 -> 2191.5.0