### PR TITLE
Activate aws 9 0 1 and 9 2 2

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -412,7 +412,7 @@
     - name: app-operator
       version: 1.0.0
     - name: aws-operator
-      version: 5.5.1-dev
+      version: 5.5.1
     - name: cert-operator
       version: 0.1.0
     - name: cluster-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -381,7 +381,7 @@
     - name: etcd
       version: 3.3.17
 - version: 9.0.1
-  state: wip
+  state: active
   date: 2020-03-27T19:00:00Z
   apps:
     - app: cert-exporter
@@ -428,7 +428,7 @@
     - name: etcd
       version: 3.3.15
 - version: 9.0.0
-  state: active
+  state: deprecated
   date: 2019-10-28T12:00:00Z
   authorities:
     - name: app-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -210,7 +210,7 @@
     - name: etcd
       version: 3.3.15
 - version: 9.2.2
-  state: wip
+  state: active
   date: 2020-03-27T12:00:00Z
   apps:
     - app: cert-exporter
@@ -259,7 +259,7 @@
     - name: etcd
       version: 3.3.17
 - version: 9.2.1
-  state: active
+  state: deprecated
   date: 2020-03-18T12:00:00Z
   apps:
     - app: cert-exporter


### PR DESCRIPTION
This is not supposed to be merged. It supports testing upgrade from 9.0.0 to 9.0.1 to 9.2.2 for https://github.com/giantswarm/releases/pull/196 and should be deleted once testing is done.