### PR TITLE
Fix NGINX IC app release ref in Azure 11.2.1 release notes

### DIFF
--- a/release-notes/azure/v11.2.1.md
+++ b/release-notes/azure/v11.2.1.md
@@ -47,7 +47,7 @@ Below, you can find more details on components that were changed with this relea
 
 - Removed CPU and memory limits to improve reliability.
 
-### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.4](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v164-2020-03-17))
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.5](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v165-2020-03-23))
 
 - Enabled HorizontalPodAutoscaler by default for selected cluster profiles.
 - Updated from upstream `ingress-nginx` v0.29.0 - for details see the [changelog](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.30.0).

--- a/release-notes/kvm/v11.2.1.md
+++ b/release-notes/kvm/v11.2.1.md
@@ -42,7 +42,7 @@ Below, you can find more details on components that were changed with this relea
 
 - Ignore dial error if the Pod doesn't exist anymore.
 
-### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.4](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v164-2020-03-17))
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.5](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v165-2020-03-23))
 
 - Enabled HorizontalPodAutoscaler by default for selected cluster profiles.
 - Updated from upstream `ingress-nginx` v0.29.0 - for details see the [changelog](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.30.0).


### PR DESCRIPTION
Azure and KVM 11.2.1 release notes were updated to include details about nginx 1.6.5 release, but the link/reference was still pointing to nginx 1.6.4 release. This PR fixes it.