### PR TITLE
Revert accidental chart version hardcoding

### DIFF
--- a/helm/releases-aws/Chart.yaml
+++ b/helm/releases-aws/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: releases-aws
-version: 1.0.0
+version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for aws.
 home: https://github.com/giantswarm/releases

--- a/helm/releases-azure/Chart.yaml
+++ b/helm/releases-azure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: releases-azure
-version: 1.0.0
+version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for azure.
 home: https://github.com/giantswarm/releases

--- a/helm/releases-kvm/Chart.yaml
+++ b/helm/releases-kvm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: releases-kvm
-version: 1.0.0
+version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for kvm.
 home: https://github.com/giantswarm/releases


### PR DESCRIPTION
In [my previous PR](https://github.com/giantswarm/releases/pull/176), I created new release helm charts for each platform and accidentally hardcoded versions to 1.0.0 instead of allowing them to be templated by architect.