### PR TITLE
Define and activate legacy AWS 9.2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains Giant Swarm releases and changelogs.
 - [10.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.2.md)
 - [10.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.1.md)
 - [10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
+- [9.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.3.md)
 - [9.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.2.md)
 - [9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
 - [9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -305,9 +305,63 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.2.2
+  name: v9.2.3
 spec:
   state: active
+  date: 2020-04-09T12:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.12.1
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.7
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.6.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.16.3
+  - name: containerlinux
+    version: 2191.5.0
+  - name: coredns
+    version: 1.6.5
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.2.2
+spec:
+  state: deprecated
   date: 2020-04-01T12:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -330,7 +330,7 @@ spec:
     version: 1.7.0
   - name: nginx-ingress-controller
     componentVersion: 0.30.0
-    version: 1.6.7
+    version: 1.6.8
   - name: node-exporter
     componentVersion: 0.18.1
     version: 1.2.0

--- a/release-notes/aws/v9.2.3.md
+++ b/release-notes/aws/v9.2.3.md
@@ -2,7 +2,7 @@
 
 **If you are upgrading from 9.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 
-This release includes an important change to NGINX Ingress Controller termination configuration so that active connections get drained gracefully.
+This release includes reliability improvements for NGINX Ingress Controller, most importantly termination configuration was adjusted so that active connections get drained gracefully.
 
 Below, you can find more details on components that were changed with this release.
 

--- a/release-notes/aws/v9.2.3.md
+++ b/release-notes/aws/v9.2.3.md
@@ -6,9 +6,15 @@ This release includes an important change to NGINX Ingress Controller terminatio
 
 Below, you can find more details on components that were changed with this release.
 
-### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.7](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v167-2020-04-08))
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.8](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v168-2020-04-09))
 
-- Align graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+- Aligned graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
   - Use `wait-shutdown` as preStop hook
   - Make `terminationGracePeriodSeconds` configurable
-  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`
+  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`.
+- Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
+  This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
+- HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.
+- Changed default `error-log-level` from `error` to `notice`.
+- Removed use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356).
+- Added a link to the README in the sources of Chart.yaml

--- a/release-notes/aws/v9.2.3.md
+++ b/release-notes/aws/v9.2.3.md
@@ -1,0 +1,14 @@
+## :zap: Giant Swarm Release 9.2.3 for AWS :zap:
+
+**If you are upgrading from 9.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
+
+This release includes an important change to NGINX Ingress Controller termination configuration so that active connections get drained gracefully.
+
+Below, you can find more details on components that were changed with this release.
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.7](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v167-2020-04-08))
+
+- Align graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+  - Use `wait-shutdown` as preStop hook
+  - Make `terminationGracePeriodSeconds` configurable
+  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`

--- a/release-notes/aws/v9.2.3.md
+++ b/release-notes/aws/v9.2.3.md
@@ -2,7 +2,7 @@
 
 **If you are upgrading from 9.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 
-This release includes reliability improvements for NGINX Ingress Controller, most importantly termination configuration was adjusted so that active connections get drained gracefully.
+This release improves the reliability of NGINX Ingress Controller. Most important, termination configuration was adjusted so that active connections now get drained gracefully.
 
 Below, you can find more details on components that were changed with this release.
 


### PR DESCRIPTION
Changes included:
- upgrade of nginx IC App from 1.6.5 to 1.6.8