### PR TITLE
Define and activate KVM 11.2.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository contains Giant Swarm releases and changelogs.
 
 ### KVM
 
+- [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.2.md)
 - [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.1.md)
 - [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.0.md)
 - [11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.1.0.md)

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -25,7 +25,7 @@ spec:
     version: 1.7.0
   - name: nginx-ingress-controller
     componentVersion: 0.30.0
-    version: 1.6.7
+    version: 1.6.8
   - name: node-exporter
     componentVersion: 0.18.1
     version: 1.2.0

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -3,9 +3,60 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v11.2.1
+  name: v11.2.2
 spec:
   state: active
+  date: 2020-04-09T12:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.12.1
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.7
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kvm-operator
+    version: 3.10.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v11.2.1
+spec:
+  state: deprecated
   date: 2020-03-23T12:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/kvm/v11.2.2.md
+++ b/release-notes/kvm/v11.2.2.md
@@ -10,9 +10,15 @@ Below, you can find more details on components that were changed with this relea
 
 - Upgraded to kube-state-metrics [new release 1.9.5](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.5).
 
-### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.7](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v167-2020-04-08))
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.8](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v168-2020-04-09))
 
-- Align graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
-  - Use `wait-shutdown` as preStop hook,
-  - Make `terminationGracePeriodSeconds` configurable,
+- Aligned graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+  - Use `wait-shutdown` as preStop hook
+  - Make `terminationGracePeriodSeconds` configurable
   - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`.
+- Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
+  This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
+- HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.
+- Changed default `error-log-level` from `error` to `notice`.
+- Removed use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356).
+- Added a link to the README in the sources of Chart.yaml

--- a/release-notes/kvm/v11.2.2.md
+++ b/release-notes/kvm/v11.2.2.md
@@ -1,0 +1,18 @@
+## :zap: Giant Swarm Release 11.2.2 for KVM :zap:
+
+**If you are upgrading from 11.2.1, upgrading to this release will not roll your nodes. It will only update the apps.**
+
+This release includes couple reliability improvements to pre-installed apps such as NGINX Ingress Controller and kube-state-metrics.
+
+Below, you can find more details on components that were changed with this release.
+
+### kube-state-metrics v1.9.5 ([Giant Swarm app v1.0.5](https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v105))
+
+- Upgraded to kube-state-metrics [new release 1.9.5](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.5).
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.7](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v167-2020-04-08))
+
+- Align graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+  - Use `wait-shutdown` as preStop hook,
+  - Make `terminationGracePeriodSeconds` configurable,
+  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`.

--- a/release-notes/kvm/v11.2.2.md
+++ b/release-notes/kvm/v11.2.2.md
@@ -2,7 +2,7 @@
 
 **If you are upgrading from 11.2.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 
-This release includes couple reliability improvements to pre-installed apps such as NGINX Ingress Controller and kube-state-metrics.
+The release includes reliability improvements to these pre-installed apps: NGINX Ingress Controller and kube-state-metrics.
 
 Below, you can find more details on components that were changed with this release.
 


### PR DESCRIPTION
Changes included:
- upgrade of nginx IC App from 1.6.5 to 1.6.8
- kube-state-metrics app upgrade from 1.0.4 (1.9.2) to 1.0.5 (1.9.5)