### PR TITLE
Define and activate aws 9.0.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains Giant Swarm releases and changelogs.
 - [9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
 - [9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
 - [9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
+- [9.0.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.2.md)
 - [9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.1.md)
 - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)
 - [8.5.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v8.5.0.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -551,9 +551,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.0.1
+  name: v9.0.2
 spec:
   state: active
+  date: 2020-04-09T19:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.12.1
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.8
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.5.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.15.11
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.9.1
+  - name: etcd
+    version: 3.3.15
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.0.1
+spec:
+  state: deprecated
   date: 2020-03-27T19:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -554,7 +554,7 @@ metadata:
   name: v9.0.2
 spec:
   state: active
-  date: 2020-04-09T19:00:00Z
+  date: 2020-04-14T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1

--- a/release-notes/aws/v9.0.2.md
+++ b/release-notes/aws/v9.0.2.md
@@ -1,0 +1,18 @@
+## :zap: Giant Swarm Release 9.0.2 for AWS :zap:
+
+This release improves the reliability of NGINX Ingress Controller. Most important, termination configuration was adjusted so that active connections now get drained gracefully.
+
+Below, you can find more details on components that were changed with this release.
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.8](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v168-2020-04-09))
+
+- Aligned graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+  - Use `wait-shutdown` as preStop hook
+  - Make `terminationGracePeriodSeconds` configurable
+  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`.
+- Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
+  This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
+- HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.
+- Changed default `error-log-level` from `error` to `notice`.
+- Removed use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356).
+- Added a link to the README in the sources of Chart.yaml

--- a/release-notes/aws/v9.0.2.md
+++ b/release-notes/aws/v9.0.2.md
@@ -1,5 +1,7 @@
 ## :zap: Giant Swarm Release 9.0.2 for AWS :zap:
 
+**If you are upgrading from 9.0.1, upgrading to this release will not roll your nodes. It will only update the apps.**
+
 This release improves the reliability of NGINX Ingress Controller. Most important, termination configuration was adjusted so that active connections now get drained gracefully.
 
 Below, you can find more details on components that were changed with this release.


### PR DESCRIPTION
Changes included:
- upgrade of nginx IC App from 1.6.5 to 1.6.8