### PR TITLE
Activate Azure 11.2.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository contains Giant Swarm releases and changelogs.
 ### Azure
 
 - [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
+- [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
 - [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.2.md)
 - [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.1.md)
 - [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.0.md)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains Giant Swarm releases and changelogs.
 
 ### Azure
 
-- [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
+- [11.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.4.md)
 - [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
 - [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.2.md)
 - [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.1.md)

--- a/azure.yaml
+++ b/azure.yaml
@@ -36,7 +36,7 @@ spec:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
-    version: 3.0.7-dev
+    version: 3.0.6
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator

--- a/azure.yaml
+++ b/azure.yaml
@@ -5,8 +5,8 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v11.2.4
 spec:
-  state: wip
-  date: 2020-04-09T14:00:00Z
+  state: active
+  date: 2020-04-14T14:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
@@ -19,8 +19,8 @@ spec:
     componentVersion: 0.5.18
     version: 1.2.0
   - name: kube-state-metrics
-    componentVersion: 1.9.2
-    version: 1.0.4
+    componentVersion: 1.9.5
+    version: 1.0.5
   - name: metrics-server
     componentVersion: 0.3.3
     version: 1.0.0
@@ -28,7 +28,7 @@ spec:
     version: 1.7.0
   - name: nginx-ingress-controller
     componentVersion: 0.30.0
-    version: 1.6.5
+    version: 1.6.8
   - name: node-exporter
     componentVersion: 0.18.1
     version: 1.2.0

--- a/azure.yaml
+++ b/azure.yaml
@@ -59,7 +59,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v11.2.3
 spec:
-  state: active
+  state: deprecated
   date: 2020-04-09T12:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/azure/v11.2.4.md
+++ b/release-notes/azure/v11.2.4.md
@@ -12,6 +12,10 @@ Below, you can find more details on components that were changed with this relea
 
 ### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.8](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v168-2020-04-09))
 
+- Aligned graceful termination configuration with changes done in upstream [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.0)
+  - Use `wait-shutdown` as preStop hook
+  - Make `terminationGracePeriodSeconds` configurable
+  - Set `terminationGracePeriodSeconds` by default to 5min, to align with 270 second default `worker-shutdown-timeout`.
 - Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
   This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
 - HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.

--- a/release-notes/azure/v11.2.4.md
+++ b/release-notes/azure/v11.2.4.md
@@ -1,0 +1,20 @@
+## ⚡️ Giant Swarm Release 11.2.4 for Azure ⚡️
+
+**If you are upgrading from 11.2.3, upgrading to this release will not roll your nodes. It will only update the apps.**
+
+The release includes reliability improvements to these pre-installed apps: NGINX Ingress Controller and kube-state-metrics.
+
+Below, you can find more details on components that were changed with this release.
+
+### kube-state-metrics v1.9.5 ([Giant Swarm app v1.0.5](https://github.com/giantswarm/kube-state-metrics-app/blob/master/CHANGELOG.md#v105))
+
+- Upgraded to kube-state-metrics [new release 1.9.5](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.9.5).
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.8](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v168-2020-04-09))
+
+- Default `max-worker-connections` to `0`, making it same as `max-worker-open-files` i.e. `max open files (system's limit) / worker-processes - 1024`.
+  This optimizes for high load conditions where it improves performance at the cost of increasing RAM utilization (even on idle).
+- HorizontalPodAutoscaler was tuned to use `targetMemoryUtilizationPercentage` of `80` due to increased RAM utilization with new default for `max-worker-connections` of `0`.
+- Changed default `error-log-level` from `error` to `notice`.
+- Removed use of `enable-dynamic-certificates` CLI flag, it has been deprecated since [ingress-nginx 0.26.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0260) via [ingress-nginx PR #4356](https://github.com/kubernetes/ingress-nginx/pull/4356).
+- Added a link to the README in the sources of Chart.yaml


### PR DESCRIPTION
Includes:
- nginx IC App upgrade from 1.6.5 to 1.6.8
- ksm App upgrade from 1.0.4 to 1.0.5

We already released nginx upgrade from 1.6.5 to 1.6.7 and ksm from 1.0.4 to 1.0.5, in azure 11.2.2 release, but 11.2.3 reverted those changes by mistake.

To prevent such mistake to be repeated, this PR does not define a new 11.2.5 WIP, it has to be defined in a separate PR after 11.2.4 gets released.