### PR TITLE
deactivate AWS v11.0.1

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -121,7 +121,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v11.0.1
 spec:
-  state: active
+  state: deprecated
   date: 2020-02-05T12:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -245,7 +245,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v11.0.1
 spec:
-  state: active
+  state: deprecated
   date: 2020-02-05T12:00:00Z
   apps:
   - name: cert-exporter
@@ -496,7 +496,6 @@ spec:
   - name: cluster-operator
     version: 0.23.8
   - name: kubernetes
-  
     version: 1.16.3
   - name: containerlinux
     version: 2191.5.0


### PR DESCRIPTION
As discussed in https://gigantic.slack.com/archives/C7865GLSY/p1586723962074000 it looks like we can certainly deprecate `v11.0.1` since it does not make much sense to let users still create Tenant Clusters using the Calico CNI. There are stable releases using the AWS CNI. 