### PR TITLE
Remove coredns from components list of aws legacy releases

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -405,8 +405,6 @@ spec:
     version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: coredns
-    version: 1.6.5
   - name: calico
     version: 3.10.1
   - name: etcd
@@ -459,8 +457,6 @@ spec:
     version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: coredns
-    version: 1.6.5
   - name: calico
     version: 3.10.1
   - name: etcd
@@ -513,8 +509,6 @@ spec:
     version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: coredns
-    version: 1.6.5
   - name: calico
     version: 3.10.1
   - name: etcd


### PR DESCRIPTION
CoreDNS gets listed twice in Happa for few aws legacy releases, due to duplicate listing of it in both apps and components sections of release definitions.

This PR removes coredns from components list of these existing (active and deprecated) affected aws legacy release definitions.

See #support thread https://gigantic.slack.com/archives/C02EVLE9W/p1587381758125800
See #sig-releng thread https://gigantic.slack.com/archives/C3C7ZQXC1/p1587467963162600