### PR TITLE
Define and activate Azure 11.2.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Swarm Control Planes.
 
 ### Azure
 
+- [11.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.5.md)
 - [11.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.4.md)
 - [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
 - [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.2.md)

--- a/azure.yaml
+++ b/azure.yaml
@@ -11,7 +11,7 @@ spec:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
-    version: 0.12.1
+    version: 0.13.0
   - name: coredns
     componentVersion: 1.6.5
     version: 1.1.8

--- a/azure.yaml
+++ b/azure.yaml
@@ -3,9 +3,63 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v11.2.4
+  name: v11.2.5
 spec:
   state: active
+  date: 2020-04-22T17:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.12.1
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: external-dns
+    componentVersion: 0.5.18
+    version: 1.2.0
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.9
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: azure-operator
+    version: 3.0.6
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.16.8
+  - name: containerlinux
+    version: 2303.4.0
+  - name: coredns
+    version: 1.6.5
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v11.2.4
+spec:
+  state: deprecated
   date: 2020-04-14T14:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/azure/v11.2.5.md
+++ b/release-notes/azure/v11.2.5.md
@@ -1,0 +1,18 @@
+## ⚡️ Giant Swarm Release 11.2.5 for Azure ⚡️
+
+**If you are upgrading from 11.2.4, upgrading to this release will not roll your nodes. It will only update the apps.**
+
+This release improves the reliability of NGINX Ingress Controller. Most importantly, kernel and app settings have been tuned to increase out-of-the-box performance. The app's Helm chart was also adjusted to improve its availability when rolling out configuration changes.
+
+Below, you can find more details on components that were changed with this release.
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.9](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v169-2020-04-22))
+
+- Restricted PodSecurityPolicy volumes to only those required (removes wildcard).
+- Tuned `net.ipv4.ip_local_port_range` to `1024 65535` as a safe sysctl.
+- Tuned `net.core.somaxconn` to `32768` via an initContainer with privilege escalation.
+- Default `worker-processes` to `4`.
+- Default `max-worker-connections` to upstream default (currently `16384`).
+- Ignore NGINX IC Deployment replica count configuration when HorizontalPodAutoscaler is enabled.
+- Dropped unnecessary Helm release revision annotation from NGINX IC Deployment.
+- Adjusted README for display in the web interface context.

--- a/release-notes/azure/v11.2.5.md
+++ b/release-notes/azure/v11.2.5.md
@@ -4,7 +4,20 @@
 
 This release improves the reliability of NGINX Ingress Controller. Most importantly, kernel and app settings have been tuned to increase out-of-the-box performance. The app's Helm chart was also adjusted to improve its availability when rolling out configuration changes.
 
+This version also includes improvements to other components (chart-operator) as detailed in the changelog.
+
 Below, you can find more details on components that were changed with this release.
+
+### chart-operator [v0.13.0](https://github.com/giantswarm/chart-operator/blob/master/CHANGELOG.md#v0130-2020-04-21)
+
+- Fix update state calculation and status resource for long running deployments.
+- Handle 503 responses when GitHub Pages is unavailable.
+- Make HTTP client timeout configurable for pulling chart tarballs in AWS China.
+- Switch from dep to go modules.
+- Fix problem pushing chart to default app catalog.
+- Always set chart CR annotations so update state calculation is accurate.
+- Only update failed Helm releases if the chart values or version has changed.
+- Deploy as a unique app in app collection in control plane clusters.
 
 ### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.9](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v169-2020-04-22))
 


### PR DESCRIPTION
Upgrades:
- nginx from 1.6.8 to 1.6.9
- chart-operator from 0.12.1 to 0.13.0