### PR TITLE
Define and activate AWS 9.0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swarm Control Planes.
 - [9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
 - [9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
 - [9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
+- [9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)
 - [9.0.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.2.md)
 - [9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.1.md)
 - [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -655,9 +655,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.0.2
+  name: v9.0.3
 spec:
   state: active
+  date: 2020-04-23T12:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.13.0
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.9
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.5.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.15.11
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.9.1
+  - name: etcd
+    version: 3.3.15
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.0.2
+spec:
+  state: deprecated
   date: 2020-04-14T12:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/aws/v9.0.3.md
+++ b/release-notes/aws/v9.0.3.md
@@ -1,0 +1,31 @@
+## :zap: Giant Swarm Release 9.0.3 for AWS :zap:
+
+**If you are upgrading from 9.0.2, upgrading to this release will not roll your nodes. It will only update the apps.**
+
+This release improves the reliability of NGINX Ingress Controller. Most importantly, kernel and app settings have been tuned to increase out-of-the-box performance. The app's Helm chart was also adjusted to improve its availability when rolling out configuration changes.
+
+This version also includes improvements to other components (chart-operator) as detailed in the changelog.
+
+Below, you can find more details on components that were changed with this release.
+
+### chart-operator [v0.13.0](https://github.com/giantswarm/chart-operator/blob/master/CHANGELOG.md#v0130-2020-04-21)
+
+- Fix update state calculation and status resource for long running deployments.
+- Handle 503 responses when GitHub Pages is unavailable.
+- Make HTTP client timeout configurable for pulling chart tarballs in AWS China.
+- Switch from dep to go modules.
+- Fix problem pushing chart to default app catalog.
+- Always set chart CR annotations so update state calculation is accurate.
+- Only update failed Helm releases if the chart values or version has changed.
+- Deploy as a unique app in app collection in control plane clusters.
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.9](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v169-2020-04-22))
+
+- Restricted PodSecurityPolicy volumes to only those required (removes wildcard).
+- Tuned `net.ipv4.ip_local_port_range` to `1024 65535` as a safe sysctl.
+- Tuned `net.core.somaxconn` to `32768` via an initContainer with privilege escalation.
+- Default `worker-processes` to `4`.
+- Default `max-worker-connections` to upstream default (currently `16384`).
+- Ignore NGINX IC Deployment replica count configuration when HorizontalPodAutoscaler is enabled.
+- Dropped unnecessary Helm release revision annotation from NGINX IC Deployment.
+- Adjusted README for display in the web interface context.


### PR DESCRIPTION
Upgrades:
- nginx from 1.6.8 to 1.6.9
- chart-operator from 0.12.1 to 0.13.0