### PR TITLE
Fix kube-state-metrics versions in AWS releases

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -28,8 +28,8 @@ spec:
     componentVersion: 3.5.0
     version: 1.2.2
   - name: kube-state-metrics
-    componentVersion: 1.9.2
-    version: 1.0.4
+    componentVersion: 1.9.5
+    version: 1.0.5
   - name: metrics-server
     componentVersion: 0.3.3
     version: 1.0.0
@@ -86,8 +86,8 @@ spec:
     componentVersion: 3.5.0
     version: 1.2.2
   - name: kube-state-metrics
-    componentVersion: 1.9.5
-    version: 1.0.5
+    componentVersion: 1.9.2
+    version: 1.0.4
   - name: metrics-server
     componentVersion: 0.3.3
     version: 1.0.0


### PR DESCRIPTION
Follow-up to https://github.com/giantswarm/releases/pull/231

This fixes an error in the kube-state-metrics versions of v11.1.4 and 11.2.0.