### PR TITLE
Add AWS release v11.2.1

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -3,9 +3,67 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v11.2.0
+  name: v11.2.1
 spec:
   state: active
+  date: 2020-04-28T15:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: cert-manager
+    componentVersion: 0.9.0
+    version: 1.0.7
+  - name: chart-operator
+    version: 0.12.4
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: external-dns
+    componentVersion: 0.5.18
+    version: 1.2.0
+  - name: kiam
+    componentVersion: 3.5.0
+    version: 1.2.2
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 8.4.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 2.1.10
+  - name: kubernetes
+    version: 1.16.3
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v11.2.0
+spec:
+  state: deprecated
   date: 2020-04-23T15:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/aws/v11.2.1.md
+++ b/release-notes/aws/v11.2.1.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v11.2.1 for AWS :zap:
+
+This release fixes a problem that could occur when upgrading from an older release to a v11.2.x release.
+
+## cluster-operator [v2.1.10](https://github.com/giantswarm/cluster-operator/releases/tag/v2.1.10)
+
+- Fix cluster upgrade by fetching release versions in Control Plane controller.


### PR DESCRIPTION
- Add release v11.2.1 for AWS, updating cluster-operator.
- Deprecate release v11.2.0 for AWS