### PR TITLE
Deprecate AWS release v8.5.0

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -1013,7 +1013,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v8.5.0
 spec:
-  state: active
+  state: deprecated
   date: 2019-09-02T13:30:00Z
   apps: []
   components:


### PR DESCRIPTION
This marks 8.5.0 on AWS as deprecated