### PR TITLE
Add hierarchical structure to releases list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,56 +11,85 @@ Swarm Control Planes.
 
 ### AWS
 
-- [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.2.1.md)
-- [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.2.0.md)
-- [11.1.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.4.md)
-- [11.1.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.3.md)
-- [11.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.2.md)
-- [11.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.0.1.md)
-- [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.0.0.md)
-- [10.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.2.md)
-- [10.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.1.md)
-- [10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
-- [9.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.5.md)
-- [9.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.4.md)
-- [9.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.3.md)
-- [9.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.2.md)
-- [9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
-- [9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
-- [9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
-- [9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)
-- [9.0.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.2.md)
-- [9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.1.md)
-- [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)
-- [8.5.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v8.5.0.md)
+- v11
+  - v11.2
+    - [v11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.2.1.md)
+    - [v11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.2.0.md)
+  - v11.1
+    - [v11.1.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.4.md)
+    - [v11.1.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.3.md)
+    - [v11.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.1.2.md)
+  - v11.0
+    - [v11.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.0.1.md)
+    - [v11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v11.0.0.md)
+- v10
+  - v10.1
+    - [v10.1.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.2.md)
+    - [v10.1.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.1.md)
+    - [v10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
+- v9
+  - v9.2
+    - [v9.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.5.md)
+    - [v9.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.4.md)
+    - [v9.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.3.md)
+    - [v9.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.2.md)
+    - [v9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
+    - [v9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
+  - v9.9
+    - [v9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
+  - v9.0
+    - [v9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)
+    - [v9.0.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.2.md)
+    - [v9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.1.md)
+    - [v9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.0.md)
+- v8
+  - v8.5
+    - [v8.5.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v8.5.0.md)
 
 
 
 ### Azure
 
-- [11.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.5.md)
-- [11.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.4.md)
-- [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
-- [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.2.md)
-- [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.1.md)
-- [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.0.md)
-- [11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.1.0.md)
-- [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.0.0.md)
-- [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v9.0.0.md)
-- [8.4.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.1.md)
-- [8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.0.md)
+- v11
+  - v11.2
+    - [v11.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.5.md)
+    - [v11.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.4.md)
+    - [v11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.3.md)
+    - [v11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.2.md)
+    - [v11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.1.md)
+    - [v11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.2.0.md)
+  - v11.1
+    - [v11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.1.0.md)
+  - v11.0
+    - [v11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.0.0.md)
+- v9
+  - v9.0
+    - [v9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v9.0.0.md)
+- v8
+  - v8.4
+    - [v8.4.1](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.1.md)
+    - [v8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v8.4.0.md)
 
 
 
 ### KVM
 
-- [11.3.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.3.0.md)
-- [11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.3.md)
-- [11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.2.md)
-- [11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.1.md)
-- [11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.0.md)
-- [11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.1.0.md)
-- [11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.0.0.md)
-- [9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v9.0.1.md)
-- [9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v9.0.0.md)
-- [8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v8.4.0.md)
+- v11
+  - v11.3
+    - [v11.3.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.3.0.md)
+  - v11.2
+    - [v11.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.3.md)
+    - [v11.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.2.md)
+    - [v11.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.1.md)
+    - [v11.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.2.0.md)
+  - v11.1
+    - [v11.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.1.0.md)
+  - v11.0
+    - [v11.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.0.0.md)
+- v9
+  - v9.0
+    - [v9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v9.0.1.md)
+    - [v9.0.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v9.0.0.md)
+- v8
+  - v8.4
+    - [v8.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v8.4.0.md)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Swarm Control Planes.
     - [v9.2.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.2.md)
     - [v9.2.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.1.md)
     - [v9.2.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.0.md)
-  - v9.9
+  - v9.1
     - [v9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
   - v9.0
     - [v9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)


### PR DESCRIPTION
This should make the releases overview slightly more digestible by highlighting the hierarchical structure of the semver versions.