### PR TITLE
Define and active kvm 11.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Swarm Control Planes.
 ### KVM
 
 - v11
+  - v11.4
+    - [v11.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.4.0.md)
   - v11.3
     - [v11.3.1](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.3.1.md)
     - [v11.3.0](https://github.com/giantswarm/releases/blob/master/release-notes/kvm/v11.3.0.md)

--- a/kvm.yaml
+++ b/kvm.yaml
@@ -3,9 +3,60 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v11.3.1
+  name: v11.4.0
 spec:
   state: active
+  date: 2020-05-07T12:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.13.0
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.9
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kvm-operator
+    version: 3.12.0-dev
+  - name: kubernetes
+    version: 1.16.9
+  - name: containerlinux
+    version: 2345.3.1
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v11.3.1
+spec:
+  state: deprecated
   date: 2020-05-04T12:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/kvm/v11.4.0.md
+++ b/release-notes/kvm/v11.4.0.md
@@ -1,0 +1,1 @@
+## :zap: Giant Swarm Release 11.4.0 for KVM :zap:


### PR DESCRIPTION
Towards giantswarm/giantswarm#8877
Bumps minor since kvm-operator has dependencies (including k8scloudconfig) updated and with that includes https://github.com/giantswarm/giantswarm/issues/9963 too.