### PR TITLE
Add AWS release v9.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Swarm Control Planes.
   - v9.1
     - [v9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
   - v9.0
+    - [v9.0.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.4.md)
     - [v9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)
     - [v9.0.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.2.md)
     - [v9.0.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.1.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -391,9 +391,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.0.3
+  name: v9.0.4
 spec:
   state: active
+  date: 2020-05-06T13:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.13.0
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.9
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.5.2
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.15.11
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.9.1
+  - name: etcd
+    version: 3.3.15
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.0.3
+spec:
+  state: deprecated
   date: 2020-04-23T12:00:00Z
   apps:
   - name: cert-exporter

--- a/release-notes/aws/v11.0.0.md
+++ b/release-notes/aws/v11.0.0.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.0.0 for AWS :zap:
+# :zap: Giant Swarm Release 11.0.0 for AWS :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition to this update, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/release-notes/aws/v8.5.0.md
+++ b/release-notes/aws/v8.5.0.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 8.5.0 for AWS :zap:
+# :zap:  Giant Swarm Release 8.5.0 for AWS :zap:
 
 **IMPORTANT**: Due to cgroup restructure (change can be found [here](https://github.com/giantswarm/k8scloudconfig/pull/564)) and more resource reservation for core components, we are now switching to bigger master instance types (from m4.large to m4.xlarge). This adds some room for additional workload scheduling on master.
 This release also contains multiple fixes to the private/public hosted zones which were altered in the previous release. In-Cluster communication between services and the Kubernetes API should now stay inside the VPC without issues.

--- a/release-notes/aws/v9.0.0.md
+++ b/release-notes/aws/v9.0.0.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 9.0.0 for AWS :zap:
+# :zap:  Giant Swarm Release 9.0.0 for AWS :zap:
 
 ### Kubernetes v1.15.5
 - Updated from v1.14.6 - [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes)

--- a/release-notes/aws/v9.0.1.md
+++ b/release-notes/aws/v9.0.1.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.1 for AWS :zap:
+# :zap: Giant Swarm Release 9.0.1 for AWS :zap:
 
 This release includes Kubernetes v1.15.11 as well as some reliability and user experience improvements.
 We highly recommend you to upgrade to this release if you want to continue running on Kubernetes 1.15 for now.

--- a/release-notes/aws/v9.0.2.md
+++ b/release-notes/aws/v9.0.2.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.2 for AWS :zap:
+# :zap: Giant Swarm Release 9.0.2 for AWS :zap:
 
 **If you are upgrading from 9.0.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/release-notes/aws/v9.0.3.md
+++ b/release-notes/aws/v9.0.3.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.3 for AWS :zap:
+# :zap: Giant Swarm Release 9.0.3 for AWS :zap:
 
 **If you are upgrading from 9.0.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/release-notes/aws/v9.0.4.md
+++ b/release-notes/aws/v9.0.4.md
@@ -1,0 +1,5 @@
+# :zap: Giant Swarm Release 9.0.4 for AWS :zap:
+
+## aws-operator [v5.5.2](https://github.com/giantswarm/aws-operator/releases/tag/v5.5.2)
+
+- Relax error matching for Kubernetes API connection errors

--- a/release-notes/aws/v9.1.0.md
+++ b/release-notes/aws/v9.1.0.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.1.0 for AWS :zap:
+# :zap: Giant Swarm Release 9.1.0 for AWS :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition to this update, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/release-notes/aws/v9.2.0.md
+++ b/release-notes/aws/v9.2.0.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.0 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.0 for AWS :zap:
 
 **If you are upgrading from 9.1.0, upgrading to this release merely updates the app. It will *not* roll your nodes.**
 

--- a/release-notes/aws/v9.2.1.md
+++ b/release-notes/aws/v9.2.1.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.1 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.1 for AWS :zap:
 
 **With this release, horizontal pod autoscaling (HPA) is enabled by default for NGINX Ingress Controller (NGINX IC) on selected cluster profiles.**
 

--- a/release-notes/aws/v9.2.2.md
+++ b/release-notes/aws/v9.2.2.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.2 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.2 for AWS :zap:
 
 **If you are upgrading from 9.2.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/release-notes/aws/v9.2.3.md
+++ b/release-notes/aws/v9.2.3.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.3 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.3 for AWS :zap:
 
 **If you are upgrading from 9.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/release-notes/aws/v9.2.4.md
+++ b/release-notes/aws/v9.2.4.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.4 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.4 for AWS :zap:
 
 **If you are upgrading from 9.2.3, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/release-notes/aws/v9.2.5.md
+++ b/release-notes/aws/v9.2.5.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.2.5 for AWS :zap:
+# :zap: Giant Swarm Release 9.2.5 for AWS :zap:
 
 **If you are upgrading from 9.2.4, upgrading to this release will not roll your nodes. It will only update the apps.**
 


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/10639

- Updates aws-operator
- deprecates v9.0.3