### PR TITLE
Inform about the consequence of app cr migration

### DIFF
--- a/release-notes/aws/v9.0.1.md
+++ b/release-notes/aws/v9.0.1.md
@@ -2,7 +2,19 @@
 
 This release includes Kubernetes v1.15.11 as well as some reliability and user experience improvements.
 We highly recommend you to upgrade to this release if you want to continue running on Kubernetes 1.15 for now.
+
 This is also the first release which is internally represented by our [Release CRD](https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/). This is done in preparation of opening up the control plane to you.
+
+---
+
+**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+
+If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
+configmap now in a namespace called `e05c8` on the Control Plane.
+
+If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+
+---
 
 This release includes multiple improvements to the NGINX Ingress Controller app:
 1. It upgrades to upstream ingress-nginx `v0.30.0`.

--- a/release-notes/aws/v9.0.1.md
+++ b/release-notes/aws/v9.0.1.md
@@ -7,12 +7,22 @@ This is also the first release which is internally represented by our [Release C
 
 ---
 
-**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+**Note** If you are upgrading from 8.5.0 or 9.0.0:
 
-If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
-configmap now in a namespace called `e05c8` on the Control Plane.
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
 
-If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
 
 ---
 

--- a/release-notes/aws/v9.0.2.md
+++ b/release-notes/aws/v9.0.2.md
@@ -2,6 +2,17 @@
 
 **If you are upgrading from 9.0.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 
+---
+
+**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+
+If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
+configmap now in a namespace called `e05c8` on the Control Plane.
+
+If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+
+---
+
 This release improves the reliability of NGINX Ingress Controller. Most important, termination configuration was adjusted so that active connections now get drained gracefully.
 
 Below, you can find more details on components that were changed with this release.

--- a/release-notes/aws/v9.0.2.md
+++ b/release-notes/aws/v9.0.2.md
@@ -4,12 +4,22 @@
 
 ---
 
-**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+**Note** If you are upgrading from 8.5.0 or 9.0.0:
 
-If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
-configmap now in a namespace called `e05c8` on the Control Plane.
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
 
-If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
 
 ---
 

--- a/release-notes/aws/v9.0.3.md
+++ b/release-notes/aws/v9.0.3.md
@@ -4,12 +4,22 @@
 
 ---
 
-**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+**Note** If you are upgrading from 8.5.0 or 9.0.0:
 
-If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
-configmap now in a namespace called `e05c8` on the Control Plane.
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
 
-If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
 
 ---
 

--- a/release-notes/aws/v9.0.3.md
+++ b/release-notes/aws/v9.0.3.md
@@ -2,6 +2,17 @@
 
 **If you are upgrading from 9.0.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 
+---
+
+**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+
+If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
+configmap now in a namespace called `e05c8` on the Control Plane.
+
+If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+
+---
+
 This release improves the reliability of NGINX Ingress Controller. Most importantly, kernel and app settings have been tuned to increase out-of-the-box performance. The app's Helm chart was also adjusted to improve its availability when rolling out configuration changes.
 
 This version also includes improvements to other components (chart-operator) as detailed in the changelog.

--- a/release-notes/aws/v9.0.4.md
+++ b/release-notes/aws/v9.0.4.md
@@ -1,11 +1,23 @@
 # :zap: Giant Swarm Release 9.0.4 for AWS :zap:
 
-**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+**Note** If you are upgrading from 8.5.0 or 9.0.0:
 
-If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
-configmap now in a namespace called `e05c8` on the Control Plane.
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
 
-If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
+
+---
 
 ## aws-operator [v5.5.2](https://github.com/giantswarm/aws-operator/releases/tag/v5.5.2)
 

--- a/release-notes/aws/v9.0.4.md
+++ b/release-notes/aws/v9.0.4.md
@@ -1,5 +1,12 @@
 # :zap: Giant Swarm Release 9.0.4 for AWS :zap:
 
+**Note** If you are upgrading from 8.5.0 or 9.0.0: The `nginx-ingress-controller-user-values` configmap has been migrated from the `kube-system` namespace of your Tenant Cluster to a namespace on the Control Plane.
+
+If you had a cluster with id `e05c8`, then you'll find your `nginx-ingress-controller-user-values`
+configmap now in a namespace called `e05c8` on the Control Plane.
+
+If you do not yet have access to the Control Plane API you will not be able to manually configure your ingress anymore. Please contact your Solution Engineer for more information.
+
 ## aws-operator [v5.5.2](https://github.com/giantswarm/aws-operator/releases/tag/v5.5.2)
 
 - Relax error matching for Kubernetes API connection errors

--- a/release-notes/azure/v11.3.0.md
+++ b/release-notes/azure/v11.3.0.md
@@ -9,7 +9,7 @@ The migration process requires replacing the VMSS CoreOS Container Linux image w
 ### Warning
 The following steps will be undertaken during the upgrade procedure:
 1. Once you start the upgrade, we will be notified in order to be hands on during the procedure.
-2. The upgrade will start by replacing the master. The old master will be stopped as we need the final state of the ETCD data to be frozen for the migration. Once this is done, the new VMSS for the master instance will be created (:information_source: Due to the recent Azure disk provisioning performance,  this can take several tries, hence extend the upgrade time). 
+2. The upgrade will start by replacing the master. The old master will be stopped as we need the final state of the ETCD data to be frozen for the migration. Once this is done, the new VMSS for the master instance will be created (:information_source: Due to the recent Azure disk provisioning performance,  this can take several tries, hence extend the upgrade time).
 It is important to remember that while the switch is in progress for the master instance, the workloads will be unaffected as long as the pods do not fail, as rescheduling will not be possible as long as the master is not up.
 3. When the new VMSS master instance is ready, the upgrade will be waiting for the GS staff to migrate the ETCD data manually from the old master instance to the new one. After the migration is done on our side, the old instance will be removed and the new instance will join the cluster.
 4. After the master is upgraded successfully, the upgrade will proceed with the worker instances. Here, the process is simpler. The Azure Operator will create a VMSS with Flatcar Container Linux images and migrate the workloads, as you are used to during the previous upgrades.
@@ -18,3 +18,22 @@ It is important to remember that while the switch is in progress for the master 
 Due to the additional steps in the upgrade process, the whole procedure will take more time. As it also requires a manual intervention on our side, could you please **schedule all the upgrades to 11.3.0 with your Solution Engineer at least a day in advance**. This will allow us to prepare and guarantee you the appropriate support throughout the upgrade process.
 
 Our initial tests showed up to 2% loss of incoming traffic over the time period of 5-10min. It was not reproduced in the following tests but because of the complexity of the process you should be aware that this may occur.
+
+### Workflow change notice
+
+If you are upgrading from 8.4.1 or 9.0.0:
+
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
+
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.

--- a/release-notes/kvm/v9.0.1.md
+++ b/release-notes/kvm/v9.0.1.md
@@ -1,5 +1,24 @@
 ## :zap: Giant Swarm Release 9.0.1 for KVM :zap:
 
+**Note** If you are upgrading from 8.4.0 or 9.0.0:
+
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
+
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
+
+---
+
 This release includes Kubernetes v1.15.11 as well as some reliability and user experience improvements.
 We highly recommend you to upgrade to this release if you want to continue running on Kubernetes 1.15 for now.
 This is also the first release which is internally represented by our [Release CRD](https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/). This is done in preparation of opening up the control plane to you.

--- a/release-notes/kvm/v9.0.2.md
+++ b/release-notes/kvm/v9.0.2.md
@@ -1,5 +1,24 @@
 ## :zap: Giant Swarm Release 9.0.2 for KVM :zap:
 
+**Note** If you are upgrading from 8.4.0 or 9.0.0:
+
+Configuration that used to be on the Tenant Cluster has been moved to the Control Plane.
+
+Services like the `nginx-ingress-controller`, `coredns`, and `cluster-autoscaler`
+are no longer configurable through ConfigMaps on the tenant cluster.
+
+Existing ConfigMaps will be automatically migrated when you upgrade, however if
+you do not have access to the Control Plane API you will not be able to
+manually configure these services.
+
+e.g: If you had a cluster with id `e05c8`, then you'll find your
+`nginx-ingress-controller-user-values` configmap now in a namespace called `e05c8`
+on the Control Plane.
+
+Please contact your Solution Engineer for more information.
+
+---
+
 This release fixes a problem that prevented clusters with OIDC user and group prefix settings to work as expected in `9.0.1`.
 
 ### kvm-operator [v3.9.2](https://github.com/giantswarm/kvm-operator/releases/tag/v3.9.2)


### PR DESCRIPTION
This informs people that their `nginx-ingress-controller-user-values` have moved to the control plane.

Towards: https://github.com/giantswarm/giantswarm/issues/10211

fyi @giantswarm/se this is something to keep in mind, I guess you all know it by now due to some of the threads and incidents, but I am currently trying to get this down on paper somewhere for people that either forget it or never heard about it.

I'm figuring out also where it happens for KVM and Azure. Took me a while to wrap my head around the releases and how it all worked, but I think I have a grasp on it now.