### PR TITLE
Add AWS release v9.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Swarm Control Planes.
     - [v10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
 - v9
   - v9.2
+    - [v9.2.6](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.6.md)
     - [v9.2.5](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.5.md)
     - [v9.2.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.4.md)
     - [v9.2.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.2.3.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -235,9 +235,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.2.5
+  name: v9.2.6
 spec:
   state: active
+  date: 2020-05-07T12:00:00Z
+  apps:
+  - name: cert-exporter
+    version: 1.2.1
+  - name: chart-operator
+    version: 0.13.0
+  - name: cluster-autoscaler
+    componentVersion: 1.16.2
+    version: 1.1.4
+  - name: coredns
+    componentVersion: 1.6.5
+    version: 1.1.8
+  - name: kube-state-metrics
+    componentVersion: 1.9.5
+    version: 1.0.5
+  - name: metrics-server
+    componentVersion: 0.3.3
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.0
+  - name: nginx-ingress-controller
+    componentVersion: 0.30.0
+    version: 1.6.9
+  - name: node-exporter
+    componentVersion: 0.18.1
+    version: 1.2.0
+  components:
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.6.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.8
+  - name: kubernetes
+    version: 1.16.3
+  - name: containerlinux
+    version: 2191.5.0
+  - name: calico
+    version: 3.10.1
+  - name: etcd
+    version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.2.5
+spec:
+  state: deprecated
   date: 2020-04-24T12:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -268,7 +268,7 @@ spec:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
-    version: 5.6.1
+    version: 5.6.1-dev
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -268,7 +268,7 @@ spec:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
-    version: 5.6.1-dev
+    version: 5.6.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator

--- a/release-notes/aws/v9.2.6.md
+++ b/release-notes/aws/v9.2.6.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v9.2.6 for AWS :zap:
+
+This release fixes a problem in aws-operator communicating to the Control Plane Kubernetes API.
+
+## aws-operator [v5.6.1](https://github.com/giantswarm/aws-operator/releases/tag/v5.6.1)
+
+- Relax error matching for Kubernetes API connection errors


### PR DESCRIPTION
Changes with respect to v9.2.5:

- Upgrade aws-operator v5.6.1