### PR TITLE
Add aws-cni component info

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -41,6 +41,8 @@ spec:
   components:
   - name: app-operator
     version: 1.0.0
+  - name: aws-cni
+    version: 1.6.0
   - name: aws-operator
     version: 8.4.0
   - name: cert-operator
@@ -99,6 +101,8 @@ spec:
   components:
   - name: app-operator
     version: 1.0.0
+  - name: aws-cni
+    version: 1.6.0
   - name: aws-operator
     version: 8.4.0
   - name: cert-operator
@@ -157,6 +161,8 @@ spec:
   components:
   - name: app-operator
     version: 1.0.0
+  - name: aws-cni
+    version: 1.6.0
   - name: aws-operator
     version: 8.3.0
   - name: cert-operator


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10700

This adds info on a component that was part of the releases, but not contained as such. To show more complete information to end users, we add it here in retrospect.

FYI: `aws-cni` is a name we made up and put up here for discussion. An alternative would be the default image name when buildig the original image from [source](https://github.com/aws/amazon-vpc-cni-k8s): `amazon-k8s-cni`.