### PR TITLE
Release cluster-operator 0.23.9 patch version for aws installation

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -301,9 +301,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.3.0
+  name: v9.3.1
 spec:
   state: active
+  date: 2020-05-12T11:00:00Z
+  apps:
+    - name: cert-exporter
+      version: 1.2.1
+    - name: chart-operator
+      version: 0.13.0
+    - name: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - name: coredns
+      componentVersion: 1.6.5
+      version: 1.1.8
+    - name: kube-state-metrics
+      componentVersion: 1.9.5
+      version: 1.0.5
+    - name: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - name: net-exporter
+      version: 1.7.0
+    - name: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.9
+    - name: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  components:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.7.1
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      version: 0.23.9
+    - name: kubernetes
+      version: 1.16.9
+    - name: containerlinux
+      version: 2345.3.1
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.3.0
+spec:
+  state: deprecated
   date: 2020-05-07T12:00:00Z
   apps:
   - name: cert-exporter
@@ -561,9 +613,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.0.4
+  name: v9.0.5
 spec:
   state: active
+  date: 2020-05-12T11:00:00Z
+  apps:
+    - name: cert-exporter
+      version: 1.2.1
+    - name: chart-operator
+      version: 0.13.0
+    - name: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - name: coredns
+      componentVersion: 1.6.5
+      version: 1.1.8
+    - name: kube-state-metrics
+      componentVersion: 1.9.5
+      version: 1.0.5
+    - name: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - name: net-exporter
+      version: 1.7.0
+    - name: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.9
+    - name: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  components:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.5.2
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      version: 0.23.9
+    - name: kubernetes
+      version: 1.15.11
+    - name: containerlinux
+      version: 2191.5.0
+    - name: calico
+      version: 3.9.1
+    - name: etcd
+      version: 3.3.15
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.0.4
+spec:
+  state: deprecated
   date: 2020-05-06T13:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -307,7 +307,7 @@ spec:
   date: 2020-05-12T11:00:00Z
   apps:
     - name: cert-exporter
-      version: 1.2.1
+      version: 1.2.2
     - name: chart-operator
       version: 0.13.0
     - name: cluster-autoscaler
@@ -323,7 +323,7 @@ spec:
       componentVersion: 0.3.3
       version: 1.0.0
     - name: net-exporter
-      version: 1.7.0
+      version: 1.7.1
     - name: nginx-ingress-controller
       componentVersion: 0.30.0
       version: 1.6.9
@@ -619,7 +619,7 @@ spec:
   date: 2020-05-12T11:00:00Z
   apps:
     - name: cert-exporter
-      version: 1.2.1
+      version: 1.2.2
     - name: chart-operator
       version: 0.13.0
     - name: cluster-autoscaler
@@ -635,7 +635,7 @@ spec:
       componentVersion: 0.3.3
       version: 1.0.0
     - name: net-exporter
-      version: 1.7.0
+      version: 1.7.1
     - name: nginx-ingress-controller
       componentVersion: 0.30.0
       version: 1.6.9

--- a/release-notes/aws/v9.0.5.md
+++ b/release-notes/aws/v9.0.5.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v9.0.5 for AWS :zap:
+
+This release fixes a problem in user values migration logic for apps
+
+## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
+
+- Fix a bug in user values migration logic for apps.

--- a/release-notes/aws/v9.0.5.md
+++ b/release-notes/aws/v9.0.5.md
@@ -1,6 +1,10 @@
 # :zap: Giant Swarm Release v9.0.5 for AWS :zap:
 
-This release fixes a bug causing the NGINX IC app to be removed from a cluster.
+This release fixes a rare bug that would prevent the NGINX IC from being installed on a new cluster. 
+
+This bug would only occur on cluster creation if you had a nginx-ingress-controller-user-values configmap in the kube-system namespace while the cluster was still initialising.
+
+Solution Engineers have already done the manual fix for affected customers.
 
 It also modifies release templates to support the coming upgrade to Helm 3.
 

--- a/release-notes/aws/v9.0.5.md
+++ b/release-notes/aws/v9.0.5.md
@@ -1,7 +1,17 @@
 # :zap: Giant Swarm Release v9.0.5 for AWS :zap:
 
-This release fixes a problem in user values migration logic for apps
+This release fixes a problem in user values migration logic for apps, and fixing release templates to support Helm 3.
 
 ## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
 
 - Fix a bug in user values migration logic for apps.
+
+## cert-exporter (GS [v1.2.2](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#v122-2020-04-01))
+
+- Change daemonset to use release revision not time for Helm 3 support.
+
+## net-exporter [v1.7.1](https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#v171-2020-04-01)
+
+- Change daemonset to use release revision not time for Helm 3 support.
+- Only set hosts arg if a value is present.
+- Remove label from role ref in cluster role binding.

--- a/release-notes/aws/v9.0.5.md
+++ b/release-notes/aws/v9.0.5.md
@@ -1,6 +1,8 @@
 # :zap: Giant Swarm Release v9.0.5 for AWS :zap:
 
-This release fixes a problem in user values migration logic for apps, and fixing release templates to support Helm 3.
+This release fixes a bug causing the NGINX IC app to be removed from a cluster.
+
+It also modifies release templates to support the coming upgrade to Helm 3.
 
 ## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
 

--- a/release-notes/aws/v9.3.1.md
+++ b/release-notes/aws/v9.3.1.md
@@ -1,6 +1,8 @@
 # :zap: Giant Swarm Release v9.3.1 for AWS :zap:
 
-This release fixes a problem in user values migration logic for apps, and fixing release templates to support Helm 3.
+This release fixes a bug causing the NGINX IC app to be removed from a cluster.
+
+It also modifies release templates to support the coming upgrade to Helm 3.
 
 ## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
 

--- a/release-notes/aws/v9.3.1.md
+++ b/release-notes/aws/v9.3.1.md
@@ -1,7 +1,17 @@
 # :zap: Giant Swarm Release v9.3.1 for AWS :zap:
 
-This release fixes a problem in user values migration logic for apps
+This release fixes a problem in user values migration logic for apps, and fixing release templates to support Helm 3.
 
 ## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
 
 - Fix a bug in user values migration logic for apps.
+
+## cert-exporter (GS [v1.2.2](https://github.com/giantswarm/cert-exporter/blob/master/CHANGELOG.md#v122-2020-04-01))
+
+- Change daemonset to use release revision not time for Helm 3 support.
+
+## net-exporter [v1.7.1](https://github.com/giantswarm/net-exporter/blob/master/CHANGELOG.md#v171-2020-04-01)
+
+- Change daemonset to use release revision not time for Helm 3 support.
+- Only set hosts arg if a value is present.
+- Remove label from role ref in cluster role binding.

--- a/release-notes/aws/v9.3.1.md
+++ b/release-notes/aws/v9.3.1.md
@@ -1,6 +1,10 @@
 # :zap: Giant Swarm Release v9.3.1 for AWS :zap:
 
-This release fixes a bug causing the NGINX IC app to be removed from a cluster.
+This release fixes a rare bug that would prevent the NGINX IC from being installed on a new cluster. 
+
+This bug would only occur on cluster creation if you had a nginx-ingress-controller-user-values configmap in the kube-system namespace while the cluster was still initialising.
+
+Solution Engineers have already done the manual fix for affected customers.
 
 It also modifies release templates to support the coming upgrade to Helm 3.
 

--- a/release-notes/aws/v9.3.1.md
+++ b/release-notes/aws/v9.3.1.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v9.3.1 for AWS :zap:
+
+This release fixes a problem in user values migration logic for apps
+
+## cluster-operator [v0.23.9](https://github.com/giantswarm/cluster-operator/releases/tag/v0.23.9)
+
+- Fix a bug in user values migration logic for apps.


### PR DESCRIPTION
Toward giantswarm/giantswarm#10211

Creating new patch release which would include cluster-operator 0.23.9. 

- 9.0.5
- 9.3.1