### PR TITLE
cluster-operator 0.23.9 patch version for azure

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -3,9 +3,63 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v11.3.0
+  name: v11.3.1
 spec:
   state: active
+  date: 2020-05-12T11:00:00Z
+  apps:
+    - name: cert-exporter
+      version: 1.2.1
+    - name: chart-operator
+      version: 0.13.0
+    - name: coredns
+      componentVersion: 1.6.5
+      version: 1.1.8
+    - name: external-dns
+      componentVersion: 0.5.18
+      version: 1.2.0
+    - name: kube-state-metrics
+      componentVersion: 1.9.5
+      version: 1.0.5
+    - name: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - name: net-exporter
+      version: 1.7.0
+    - name: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.9
+    - name: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  components:
+    - name: app-operator
+      version: 1.0.0
+    - name: azure-operator
+      version: 4.0.0
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      version: 0.23.9
+    - name: kubernetes
+      version: 1.16.8
+    - name: containerlinux
+      version: 2345.3.1
+    - name: coredns
+      version: 1.6.5
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v11.3.0
+spec:
+  state: deprecated
   date: 2020-05-05T07:00:00Z
   apps:
   - name: cert-exporter


### PR DESCRIPTION
Toward giantswarm/giantswarm#10211

Creating new patch release which would include cluster-operator 0.23.9. 

- 11.3.1