### PR TITLE
Deprecate AWS 9.3.1 release

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -303,7 +303,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v9.3.1
 spec:
-  state: active
+  state: deprecated
   date: 2020-05-12T11:00:00Z
   apps:
     - name: cert-exporter


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10850

This is to prevent any further outages with upgrade to 9.3.1.
Chiara is working on announcement/warning about 9.3.1 deactivation.

Simon is working on 9.3.2 with labels synced in nginx app to match selector in LB service managed by legacy aws-operator.