### PR TITLE
Activate aws 9.2.6

### DIFF
--- a/aws.yaml
+++ b/aws.yaml
@@ -468,7 +468,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v9.2.6
 spec:
-  state: deprecated
+  state: active
   date: 2020-05-07T12:00:00Z
   apps:
   - name: cert-exporter


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10850

This is follow up to https://github.com/giantswarm/releases/pull/288 which deactivated aws 9.3.1
Both 9.3.0 and 9.3.1 releases have issue https://github.com/giantswarm/giantswarm/issues/10850, to be fixed with release 9.3.2.
Still 9.2.6 is last known good legacy release and should be made available until 9.3.2 is out and replaces it.