### PR TITLE
add AWS 9.3.2 release for AWS & deprecate 9.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Swarm Control Planes.
     - [v10.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v10.1.0.md)
 - v9
   - v9.3
+    - [v9.3.2](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.3.2.md)
     - [v9.3.1](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.3.1.md)
     - [v9.3.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.3.0.md)
   - v9.2

--- a/aws.yaml
+++ b/aws.yaml
@@ -520,7 +520,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v9.2.6
 spec:
-  state: active
+  state: deprecated
   date: 2020-05-07T12:00:00Z
   apps:
   - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -364,7 +364,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v9.3.2
 spec:
-  state: avtive
+  state: active
   date: 2020-05-26T15:00:00Z
   apps:
     - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -362,6 +362,58 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.3.2
+spec:
+  state: avtive
+  date: 2020-05-26T15:00:00Z
+  apps:
+    - name: cert-exporter
+      version: 1.2.2
+    - name: chart-operator
+      version: 0.13.0
+    - name: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - name: coredns
+      componentVersion: 1.6.5
+      version: 1.1.8
+    - name: kube-state-metrics
+      componentVersion: 1.9.5
+      version: 1.0.5
+    - name: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - name: net-exporter
+      version: 1.7.1
+    - name: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.11
+    - name: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  components:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.7.1
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      version: 0.23.9
+    - name: kubernetes
+      version: 1.16.9
+    - name: containerlinux
+      version: 2345.3.1
+    - name: calico
+      version: 3.10.1
+    - name: etcd
+      version: 3.3.17
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v9.3.1
 spec:
   state: deprecated

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.22for AWS :zap:
+# :zap: Giant Swarm Release v9.3.22 for AWS :zap:
 
 This release fixes an issue where upgrading from an earlier release would cause the `nginx-ingress-controller` service to have no endpoints.
 

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -2,7 +2,7 @@
 
 This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would cause the `nginx-ingress-controller` service to have no endpoints.
 
-Solution Engineers have already applied a manual fix to affected clusters.
+Solution Engineers have already applied a manual fix to affected clusters (ones based on AWS 9.3.0 and 9.3.1 platform releases).
 
 ## nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v1611-2020-05-26))
 

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -2,8 +2,8 @@
 
 This release fixes an issue where upgrading from an earlier release would cause the `nginx-ingress-controller` service to have no endpoints.
 
-Solution Engineers have already done the manual fix for affected customers.
+Solution Engineers have already applied a manual fix to affected clusters.
 
-## nginx-ingress-controller [GS v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.11)
+## nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v1611-2020-05-26))
 
 - Align labels, using `app.kubernetes.io/name` instead of `k8s-app` where possible. `k8s-app` remains to be used for compatibility reasons.

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v9.3.22 for AWS :zap:
 
-This release fixes an issue where upgrading from an earlier release would cause the `nginx-ingress-controller` service to have no endpoints.
+This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would cause the `nginx-ingress-controller` service to have no endpoints.
 
 Solution Engineers have already applied a manual fix to affected clusters.
 

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -1,8 +1,8 @@
 # :zap: Giant Swarm Release v9.3.2 for AWS :zap:
 
-This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would cause the `nginx-ingress-controller` service to have no endpoints.
+This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would result in the `nginx-ingress-controller` service having no endpoints, causing the NGINX IC app to not work.
 
-Solution Engineers have already applied a manual fix to affected clusters (ones based on AWS 9.3.0 and 9.3.1 platform releases).
+Solution Engineers have applied a manual fix to affected clusters. This release provides a working upgrade path for clusters using AWS 9.x.x and older.
 
 ## nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v1611-2020-05-26))
 

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -1,0 +1,10 @@
+# :zap: Giant Swarm Release v9.3.22for AWS :zap:
+
+This release fixes an issue where upgrading from an earlier release would cause the `nginx-ingress-controller` service to have no endpoints.
+
+Solution Engineers have already done the manual fix for affected customers.
+
+## nginx-ingress-controller [GS v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.11)
+
+- Align labels, using `app.kubernetes.io/name` instead of `k8s-app` where possible. `k8s-app` remains to be used for compatibility reasons.
+- Make NGINX IC Service `externalTrafficPolicy` configurable and default to `Local`.

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.22 for AWS :zap:
+# :zap: Giant Swarm Release v9.3.2 for AWS :zap:
 
 This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would cause the `nginx-ingress-controller` service to have no endpoints.
 

--- a/release-notes/aws/v9.3.2.md
+++ b/release-notes/aws/v9.3.2.md
@@ -7,4 +7,3 @@ Solution Engineers have already done the manual fix for affected customers.
 ## nginx-ingress-controller [GS v1.6.11](https://github.com/giantswarm/nginx-ingress-controller-app/releases/tag/v1.6.11)
 
 - Align labels, using `app.kubernetes.io/name` instead of `k8s-app` where possible. `k8s-app` remains to be used for compatibility reasons.
-- Make NGINX IC Service `externalTrafficPolicy` configurable and default to `Local`.


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/10850

* updates `nginx-ingress-controller` from 1.6.9 to 1.6.11:
  * aligns labels with k8scloudconfig where possible.