### PR TITLE
Define and activate AWS release 9.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Swarm Control Planes.
   - v9.1
     - [v9.1.0](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.1.0.md)
   - v9.0
+    - [v9.0.6](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.6.md)
     - [v9.0.5](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.5.md)
     - [v9.0.4](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.4.md)
     - [v9.0.3](https://github.com/giantswarm/releases/blob/master/release-notes/aws/v9.0.3.md)

--- a/aws.yaml
+++ b/aws.yaml
@@ -726,9 +726,61 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-  name: v9.0.5
+  name: v9.0.6
 spec:
   state: active
+  date: 2020-06-01T11:00:00Z
+  apps:
+    - name: cert-exporter
+      version: 1.2.2
+    - name: chart-operator
+      version: 0.13.0
+    - name: cluster-autoscaler
+      componentVersion: 1.16.2
+      version: 1.1.4
+    - name: coredns
+      componentVersion: 1.6.5
+      version: 1.1.8
+    - name: kube-state-metrics
+      componentVersion: 1.9.5
+      version: 1.0.5
+    - name: metrics-server
+      componentVersion: 0.3.3
+      version: 1.0.0
+    - name: net-exporter
+      version: 1.7.1
+    - name: nginx-ingress-controller
+      componentVersion: 0.30.0
+      version: 1.6.9
+    - name: node-exporter
+      componentVersion: 0.18.1
+      version: 1.2.0
+  components:
+    - name: app-operator
+      version: 1.0.0
+    - name: aws-operator
+      version: 5.5.3-dev
+    - name: cert-operator
+      version: 0.1.0
+    - name: cluster-operator
+      version: 0.23.9
+    - name: kubernetes
+      version: 1.15.11
+    - name: containerlinux
+      version: 2345.3.1
+    - name: calico
+      version: 3.9.1
+    - name: etcd
+      version: 3.3.15
+---
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  name: v9.0.5
+spec:
+  state: deprecated
   date: 2020-05-12T11:00:00Z
   apps:
     - name: cert-exporter

--- a/aws.yaml
+++ b/aws.yaml
@@ -810,7 +810,7 @@ spec:
       version: 1.7.1
     - name: nginx-ingress-controller
       componentVersion: 0.30.0
-      version: 1.6.9
+      version: 1.6.12
     - name: node-exporter
       componentVersion: 0.18.1
       version: 1.2.0

--- a/aws.yaml
+++ b/aws.yaml
@@ -759,7 +759,7 @@ spec:
     - name: app-operator
       version: 1.0.0
     - name: aws-operator
-      version: 5.5.3-dev
+      version: 5.5.3
     - name: cert-operator
       version: 0.1.0
     - name: cluster-operator

--- a/aws.yaml
+++ b/aws.yaml
@@ -729,7 +729,7 @@ metadata:
   name: v9.0.6
 spec:
   state: active
-  date: 2020-06-01T11:00:00Z
+  date: 2020-06-02T11:00:00Z
   apps:
     - name: cert-exporter
       version: 1.2.2
@@ -765,11 +765,11 @@ spec:
     - name: cluster-operator
       version: 0.23.9
     - name: kubernetes
-      version: 1.15.11
+      version: 1.15.12
     - name: containerlinux
-      version: 2345.3.1
+      version: 2512.2.0
     - name: calico
-      version: 3.9.1
+      version: 3.9.6
     - name: etcd
       version: 3.3.15
 ---

--- a/release-notes/aws/v9.0.6.md
+++ b/release-notes/aws/v9.0.6.md
@@ -7,9 +7,16 @@ To continue receiving security updates and to minimize the effort needed to migr
 
 Below, you can find more details on components that were changed with this release.
 
-### aws-operator [v5.5.3](https://github.com/giantswarm/aws-operator/releases/tag/v5.7.1)
-- Fixed issue with kube-proxy's `conntrackMaxPerCore` parameter.
+### aws-operator [v5.5.3](https://github.com/giantswarm/aws-operator/releases/tag/v5.5.3)
+- Fixed issue with kube-proxy's `conntrackMaxPerCore` parameter not taking effect.
 
-### Flatcar Linux [2345.3.1](https://www.flatcar-linux.org/releases/#release-2345.3.1)
-- Updated from CoreOS 2191.5.0.
-- Updated Linux Kernel to 4.19.107.
+### Calico [v3.9.6](https://docs.projectcalico.org/archive/v3.9/release-notes/)
+- Updated from Calico v3.9.1.
+- Fixed IPv6 rogue router advertisement vulnerability CVE-2020-13597. See [security bulletin](https://www.projectcalico.org/security-bulletins/) for more information.
+
+### Flatcar Container Linux [v2512.2.0](https://www.flatcar-linux.org/releases/#release-2512.2.0)
+- Updated from CoreOS Container Linux 2191.5.0.
+- Updated Linux Kernel to 4.19.124.
+
+### Kubernetes [v1.15.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#changelog-since-v11511)
+- Updated from v1.15.11.

--- a/release-notes/aws/v9.0.6.md
+++ b/release-notes/aws/v9.0.6.md
@@ -20,3 +20,9 @@ Below, you can find more details on components that were changed with this relea
 
 ### Kubernetes [v1.15.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.15.md#changelog-since-v11511)
 - Updated from v1.15.11.
+
+### nginx-ingress-controller v0.30.0 ([Giant Swarm app v1.6.12](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v1612-2020-06-04))
+
+- Made healthcheck probes configurable.
+- Made liveness probe more resilient.
+- Aligned labels using `app.kubernetes.io/name` instead of `k8s-app` where possible. `k8s-app` remains to be used for compatibility reasons as selectors are not modifiable without recreating the Deployment.

--- a/release-notes/aws/v9.0.6.md
+++ b/release-notes/aws/v9.0.6.md
@@ -1,0 +1,15 @@
+## :zap: Giant Swarm Release 9.0.6 for AWS :zap:
+
+This release [replaces CoreOS with Flatcar Container Linux](https://www.giantswarm.io/blog/time-to-catch-a-new-train-flatcar-linux).
+CoreOS has gone [end-of-life](https://coreos.com/os/eol/) and is being rapidly phased out.
+Flatcar is a compatible fork of CoreOS which receives ongoing support.
+To continue receiving security updates and to minimize the effort needed to migrate in the future, we recommend upgrading to this release.
+
+Below, you can find more details on components that were changed with this release.
+
+### aws-operator [v5.5.3](https://github.com/giantswarm/aws-operator/releases/tag/v5.7.1)
+- Fixed issue with kube-proxy's `conntrackMaxPerCore` parameter.
+
+### Flatcar Linux [2345.3.1](https://www.flatcar-linux.org/releases/#release-2345.3.1)
+- Updated from CoreOS 2191.5.0.
+- Updated Linux Kernel to 4.19.107.


### PR DESCRIPTION
Mainly upgrading to Flatcar v2512.2.0 for https://github.com/giantswarm/giantswarm/issues/10393 Also upgrading Calico to get the CVE fix, Kubernetes to get some minor fixes, and fixing some kube-proxy issues in aws-operator.