### PR TITLE
Disable AWS 11.4.0

### DIFF
--- a/aws/v11.4.0/release.yaml
+++ b/aws/v11.4.0/release.yaml
@@ -5,7 +5,7 @@ metadata:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
   name: v11.4.0
 spec:
-  state: active
+  state: deprecated
   date: 2020-06-17T13:00:00Z
   apps:
   - name: cert-exporter


### PR DESCRIPTION
Due to certificate issues affecting OIDC in clusters using `kube-apiserver` image instead of `hyperkube` (k8s 1.16.9+), I am disabling AWS 11.4.0. It will be fixed in a patch release soon, hopefully today. FYI @giantswarm/chapter-se 