### PR TITLE
Add Week of Jul 3 Releases

### DIFF
--- a/announcements/2020-Week-27/aws.md
+++ b/announcements/2020-Week-27/aws.md
@@ -1,7 +1,7 @@
-# This Week in AWS Releases (July 3, 2020)
+# :zap: This Week in AWS Releases (July 3, 2020):zap:
 
 **Optional Apps Releases**  
-Optional Apps can be installed from App Catalogs.
+(Can be installed from App Catalogs)
 
 1. [Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
 2. [NGINX IC v1.7.0](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v170-2020-06-29) is upgraded to the latest upstream version v0.33.0. (Note: NGINX is Optional and not Pre-Installed in AWS 10+ clusters)

--- a/announcements/2020-Week-27/aws.md
+++ b/announcements/2020-Week-27/aws.md
@@ -1,0 +1,11 @@
+# This Week in AWS Releases (July 3, 2020)
+
+**Optional Apps Releases**  
+Optional Apps can be installed from App Catalogs.
+
+1. [Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
+2. [NGINX IC v1.7.0](https://github.com/giantswarm/nginx-ingress-controller-app/blob/master/CHANGELOG.md#v170-2020-06-29) is upgraded to the latest upstream version v0.33.0. (Note: NGINX is Optional and not Pre-Installed in AWS 10+ clusters)
+
+---
+
+Please help us improve our communication. **Was this helpful?** :thumbsup: :thumbsdown:

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -1,0 +1,14 @@
+# This Week in Releases (July 3, 2020)
+
+1. [Azure v11.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.4.0.md) makes changes to NGINX IC and azure-operator, to **improve IP based security access control, increase concurrent connection capacity and reduce latency, as well as enable configurability of external traffic policy.**
+
+**Optional Apps Releases**
+Optional Apps can be installed from App Catalogs.
+
+1. NGINX IC
+2. Kong
+3. Prometheus Operator
+
+---
+
+Please help us improve our communication. **Was this helpful?** :thumbsup: :thumbsdown:

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -2,6 +2,8 @@
 
 [Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, and reduces latency. It also enables configurability of external traffic policy.**
 
+**Please read release notes carefully.** Manual actions are required after the upgrade and we recommend discussing cluster upgrades with your SE.
+
 **Optional Apps Releases**  
 (Can be installed from App Catalogs)
 

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -1,6 +1,6 @@
 # This Week in Releases (July 3, 2020)
 
-1. [Azure v11.4.0](https://github.com/giantswarm/releases/blob/master/release-notes/azure/v11.4.0.md) makes changes to NGINX IC and azure-operator, to **improve IP based security access control, increase concurrent connection capacity and reduce latency, as well as enable configurability of external traffic policy.**
+1. [Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator, to **improve IP based security access control, increase concurrent connection capacity and reduce latency, as well as enable configurability of external traffic policy.**
 
 **Optional Apps Releases**
 Optional Apps can be installed from App Catalogs.

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -1,6 +1,6 @@
 # :zap: This Week in Azure Releases (July 3, 2020):zap:
 
-[Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, ands reduce latency. It also enables configurability of external traffic policy.**
+[Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, and reduces latency. It also enables configurability of external traffic policy.**
 
 **Optional Apps Releases**  
 (Can be installed from App Catalogs)

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -1,13 +1,12 @@
-# This Week in Releases (July 3, 2020)
+# This Week in Azure Releases (July 3, 2020)
 
-1. [Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator, to **improve IP based security access control, increase concurrent connection capacity and reduce latency, as well as enable configurability of external traffic policy.**
+[Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, ands reduce latency. It also enables configurability of external traffic policy.**
 
-**Optional Apps Releases**
+**Optional Apps Releases**  
 Optional Apps can be installed from App Catalogs.
 
-1. NGINX IC
-2. Kong
-3. Prometheus Operator
+1. **[Azure AD Pod Identity App](https://github.com/giantswarm/azure-ad-pod-identity-app)** can now be installed from the Playground Catalog. This app enables Kubernetes applications to access cloud resources securely with Azure Active Directory.
+2. [Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
 
 ---
 

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -3,9 +3,9 @@
 [Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, ands reduce latency. It also enables configurability of external traffic policy.**
 
 **Optional Apps Releases**  
-Optional Apps can be installed from App Catalogs.
+(Can be installed from App Catalogs)
 
-1. **[Azure AD Pod Identity App](https://github.com/giantswarm/azure-ad-pod-identity-app)** can now be installed from the Playground Catalog. This app enables Kubernetes applications to access cloud resources securely with Azure Active Directory.
+1. [Azure AD Pod Identity App](https://github.com/giantswarm/azure-ad-pod-identity-app) can now be installed from the Playground Catalog. This app enables Kubernetes applications to access cloud resources securely with Azure Active Directory.
 2. [Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
 
 ---

--- a/announcements/2020-Week-27/azure.md
+++ b/announcements/2020-Week-27/azure.md
@@ -1,4 +1,4 @@
-# This Week in Azure Releases (July 3, 2020)
+# :zap: This Week in Azure Releases (July 3, 2020):zap:
 
 [Azure v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0) makes changes to NGINX IC and azure-operator. This **improves IP based security access control, increases concurrent connection capacity, ands reduce latency. It also enables configurability of external traffic policy.**
 

--- a/announcements/2020-Week-27/kvm.md
+++ b/announcements/2020-Week-27/kvm.md
@@ -1,0 +1,10 @@
+# This Week in KVM Releases (July 3, 2020)
+
+**Optional Apps Releases**  
+Optional Apps can be installed from App Catalogs.
+
+[Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
+
+---
+
+Please help us improve our communication. **Was this helpful?** :thumbsup: :thumbsdown:

--- a/announcements/2020-Week-27/kvm.md
+++ b/announcements/2020-Week-27/kvm.md
@@ -1,7 +1,7 @@
 # This Week in KVM Releases (July 3, 2020)
 
 **Optional Apps Releases**  
-Optional Apps can be installed from App Catalogs.
+(Can be installed from App Catalogs)
 
 [Aqua v4.6.2](https://github.com/giantswarm/aqua-app/blob/master/CHANGELOG.md#v462-2020-07-02) is upgraded to the latest version and configured to Aqua's recommended best practices.
 

--- a/announcements/2020-Week-27/kvm.md
+++ b/announcements/2020-Week-27/kvm.md
@@ -1,4 +1,4 @@
-# This Week in KVM Releases (July 3, 2020)
+# :zap: This Week in KVM Releases (July 3, 2020):zap:
 
 **Optional Apps Releases**  
 (Can be installed from App Catalogs)


### PR DESCRIPTION
I opened this one to include 
1. azure release https://github.com/giantswarm/releases/pull/290/files
2. in https://github.com/giantswarm/giantswarm/issues/11530, optional apps will be upgraded TBD which ones will make it this week cc @giantswarm/team-halo 

I will add the announcements for the apps in here. copy them over to aws and kvm when they are more final.

- [ ] Add Azure AD Pod Identity App https://github.com/giantswarm/giantswarm/issues/11902 [slack announcement](https://gigantic.slack.com/archives/C90BZMUJ1/p1593613853365900)