### PR TITLE
Sort releases and kustomization.yaml resources

### DIFF
--- a/aws/archived/v10.1.1/release.yaml
+++ b/aws/archived/v10.1.1/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v10.1.1
 spec:
-  state: deprecated
-  date: 2020-01-10T08:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.0.2
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 2.0.1
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.5
+  date: "2020-01-10T08:00:00Z"
+  state: deprecated

--- a/aws/archived/v10.1.2/release.yaml
+++ b/aws/archived/v10.1.2/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v10.1.2
 spec:
-  state: deprecated
-  date: 2020-02-06T08:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.0.2
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 2.0.2
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.5
+  date: "2020-02-06T08:00:00Z"
+  state: deprecated

--- a/aws/archived/v11.0.0/release.yaml
+++ b/aws/archived/v11.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.0.0
 spec:
-  state: deprecated
-  date: 2020-01-29T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.1.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 2.0.2
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-01-29T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v11.1.2/release.yaml
+++ b/aws/archived/v11.1.2/release.yaml
@@ -1,55 +1,56 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.1.2
 spec:
-  state: deprecated
-  date: 2020-04-06T08:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.6
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.1
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.2.2
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.6
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-06T08:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.0.1/release.yaml
+++ b/aws/archived/v9.0.1/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.1
 spec:
-  state: deprecated
-  date: 2020-03-27T19:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.5
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.5.1
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.11
+  date: "2020-03-27T19:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.0.2/release.yaml
+++ b/aws/archived/v9.0.2/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.2
 spec:
-  state: deprecated
-  date: 2020-04-14T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.8
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.5.1
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.11
+  date: "2020-04-14T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.1.0/release.yaml
+++ b/aws/archived/v9.1.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.1.0
 spec:
-  state: deprecated
-  date: 2020-01-28T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.21.4
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-01-28T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.2.0/release.yaml
+++ b/aws/archived/v9.2.0/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.0
 spec:
-  state: deprecated
-  date: 2020-02-26T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.11.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.3
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.3
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.2
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.6.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.29.0
+  - componentVersion: 0.29.0
+    name: nginx-ingress-controller
     version: 1.5.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.1
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-02-26T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.2.1/release.yaml
+++ b/aws/archived/v9.2.1/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.1
 spec:
-  state: deprecated
-  date: 2020-03-18T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.3
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.3
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.6.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.4
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.6
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-03-18T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.2.3/release.yaml
+++ b/aws/archived/v9.2.3/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.3
 spec:
-  state: deprecated
-  date: 2020-04-09T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.8
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-09T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.2.6/release.yaml
+++ b/aws/archived/v9.2.6/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.6
 spec:
-  state: deprecated
-  date: 2020-05-07T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-05-07T12:00:00Z"
+  state: deprecated

--- a/aws/archived/v9.3.1/release.yaml
+++ b/aws/archived/v9.3.1/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.3.1
 spec:
-  state: deprecated
-  date: 2020-05-12T11:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.9.5
-      version: 1.0.5
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.9
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
+    version: 1.1.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
+    version: 1.0.5
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.9
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 5.7.1
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: kubernetes
-      version: 1.16.9
-    - name: containerlinux
-      version: 2345.3.1
-    - name: calico
-      version: 3.10.1
-    - name: etcd
-      version: 3.3.17
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.7.1
+  - name: calico
+    version: 3.10.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2345.3.1
+  - name: etcd
+    version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-05-12T11:00:00Z"
+  state: deprecated

--- a/aws/kustomization.yaml
+++ b/aws/kustomization.yaml
@@ -1,31 +1,29 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-
-transformers:
-  - releaseNotesTransformer.yaml
-
 resources:
-  - v8.2.0
-  - v8.5.0
-  - v9.0.0
-  - v9.0.3
-  - v9.0.4
-  - v9.0.5
-  - v9.0.6
-  - v9.2.2
-  - v9.2.4
-  - v9.2.5
-  - v9.3.0
-  - v9.3.2
-  - v9.3.3
-  - v10.1.0
-  - v11.0.1
-  - v11.1.3
-  - v11.1.4
-  - v11.2.0
-  - v11.2.1
-  - v11.3.0
-  - v11.3.1
-  - v11.3.2
-  - v11.3.3
-  - v11.4.0
+- v8.2.0
+- v8.5.0
+- v9.0.0
+- v9.0.3
+- v9.0.4
+- v9.0.5
+- v9.0.6
+- v9.2.2
+- v9.2.4
+- v9.2.5
+- v9.3.0
+- v9.3.2
+- v9.3.3
+- v10.1.0
+- v11.0.1
+- v11.1.3
+- v11.1.4
+- v11.2.0
+- v11.2.1
+- v11.3.0
+- v11.3.1
+- v11.3.2
+- v11.3.3
+- v11.4.0
+transformers:
+- releaseNotesTransformer.yaml

--- a/aws/v10.1.0/release.yaml
+++ b/aws/v10.1.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v10.1.0
 spec:
-  state: deprecated
-  date: 2019-12-18T14:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.0.2
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 2.0.0
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.5
+  date: "2019-12-18T14:00:00Z"
+  state: deprecated

--- a/aws/v11.0.1/release.yaml
+++ b/aws/v11.0.1/release.yaml
@@ -1,55 +1,56 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.0.1
 spec:
-  state: deprecated
-  date: 2020-02-05T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.5
   - name: chart-operator
     version: 0.11.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.3
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.1.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.0
+  - componentVersion: 1.9.0
+    name: kube-state-metrics
     version: 1.0.0
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.5.1
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.1.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.1
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-02-05T12:00:00Z"
+  state: deprecated

--- a/aws/v11.1.3/release.yaml
+++ b/aws/v11.1.3/release.yaml
@@ -1,55 +1,56 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.1.3
 spec:
-  state: deprecated
-  date: 2020-04-06T13:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.6
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.1
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 8.2.3
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.7
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-06T13:00:00Z"
+  state: deprecated

--- a/aws/v11.1.4/release.yaml
+++ b/aws/v11.1.4/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.1.4
 spec:
-  state: deprecated
-  date: 2020-04-19T11:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.3.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-19T11:00:00Z"
+  state: deprecated

--- a/aws/v11.2.0/release.yaml
+++ b/aws/v11.2.0/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.0
 spec:
-  state: deprecated
-  date: 2020-04-23T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.4.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.9
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-23T15:00:00Z"
+  state: deprecated

--- a/aws/v11.2.1/release.yaml
+++ b/aws/v11.2.1/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.1
 spec:
-  state: deprecated
-  date: 2020-04-28T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.4.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.10
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-28T15:00:00Z"
+  state: deprecated

--- a/aws/v11.3.0/release.yaml
+++ b/aws/v11.3.0/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.0
 spec:
-  state: deprecated
-  date: 2020-05-11T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.5.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.1.10
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-05-11T15:00:00Z"
+  state: deprecated

--- a/aws/v11.3.1/release.yaml
+++ b/aws/v11.3.1/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.1
 spec:
-  state: deprecated
-  date: 2020-05-21T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.6.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.2.0
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-05-21T15:00:00Z"
+  state: deprecated

--- a/aws/v11.3.2/release.yaml
+++ b/aws/v11.3.2/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.2
 spec:
-  state: deprecated
-  date: 2020-06-04T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.7
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.6.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.2.0
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-06-04T15:00:00Z"
+  state: deprecated

--- a/aws/v11.3.3/release.yaml
+++ b/aws/v11.3.3/release.yaml
@@ -1,40 +1,39 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.3
 spec:
-  state: active
-  date: 2020-06-05T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.8
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -43,15 +42,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.6.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.2.0
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-06-05T15:00:00Z"
+  state: active

--- a/aws/v11.4.0/release.yaml
+++ b/aws/v11.4.0/release.yaml
@@ -3,40 +3,39 @@ kind: Release
 metadata:
   annotations:
     giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  creationTimestamp: null
   name: v11.4.0
 spec:
-  state: deprecated
-  date: 2020-06-17T13:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.3
-  - name: cert-manager
-    componentVersion: 0.9.0
+  - componentVersion: 0.9.0
+    name: cert-manager
     version: 1.0.8
   - name: chart-operator
     version: 0.12.4
-  - name: cluster-autoscaler
-    componentVersion: 1.16.5
+  - componentVersion: 1.16.5
+    name: cluster-autoscaler
     version: 1.16.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kiam
-    componentVersion: 3.5.0
+  - componentVersion: 3.5.0
+    name: kiam
     version: 1.2.2
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.8.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
@@ -45,15 +44,17 @@ spec:
     version: 1.6.0
   - name: aws-operator
     version: 8.7.0
+  - name: calico
+    version: 3.10.4
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 2.3.0
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.4
   - name: etcd
     version: 3.4.9
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-06-17T13:00:00Z"
+  state: deprecated

--- a/aws/v8.2.0/release.yaml
+++ b/aws/v8.2.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.2.0
 spec:
-  state: deprecated
-  date: 2019-06-03T10:00:00Z
   apps: []
   components:
   - name: aws-operator
     version: 5.2.0
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: kubernetes
-    version: 1.14.3
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.3
+  date: "2019-06-03T10:00:00Z"
+  state: deprecated

--- a/aws/v8.5.0/release.yaml
+++ b/aws/v8.5.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.5.0
 spec:
-  state: deprecated
-  date: 2019-09-02T13:30:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.4.0
+  - name: calico
+    version: 3.8.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.20.0
-  - name: kubernetes
-    version: 1.14.6
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.6.2
-  - name: calico
-    version: 3.8.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.6
+  date: "2019-09-02T13:30:00Z"
+  state: deprecated

--- a/aws/v9.0.0/release.yaml
+++ b/aws/v9.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.0
 spec:
-  state: deprecated
-  date: 2019-10-28T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.5.0
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.21.0
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.4
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.5
+  date: "2019-10-28T12:00:00Z"
+  state: deprecated

--- a/aws/v9.0.3/release.yaml
+++ b/aws/v9.0.3/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.3
 spec:
-  state: deprecated
-  date: 2020-04-23T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.5.1
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.11
+  date: "2020-04-23T12:00:00Z"
+  state: deprecated

--- a/aws/v9.0.4/release.yaml
+++ b/aws/v9.0.4/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.4
 spec:
-  state: deprecated
-  date: 2020-05-06T13:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.5.2
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.11
+  date: "2020-05-06T13:00:00Z"
+  state: deprecated

--- a/aws/v9.0.5/release.yaml
+++ b/aws/v9.0.5/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.5
 spec:
-  state: deprecated
-  date: 2020-05-12T11:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.9.5
-      version: 1.0.5
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.9
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
+    version: 1.1.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
+    version: 1.0.5
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.9
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 5.5.2
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: kubernetes
-      version: 1.15.11
-    - name: containerlinux
-      version: 2191.5.0
-    - name: calico
-      version: 3.9.1
-    - name: etcd
-      version: 3.3.15
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.5.2
+  - name: calico
+    version: 3.9.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2191.5.0
+  - name: etcd
+    version: 3.3.15
+  - name: kubernetes
+    version: 1.15.11
+  date: "2020-05-12T11:00:00Z"
+  state: deprecated

--- a/aws/v9.0.6/release.yaml
+++ b/aws/v9.0.6/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.6
 spec:
-  state: active
-  date: 2020-06-02T11:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.9.5
-      version: 1.0.5
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.12
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
+    version: 1.1.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
+    version: 1.0.5
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.12
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 5.5.3
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: kubernetes
-      version: 1.15.12
-    - name: containerlinux
-      version: 2512.2.0
-    - name: calico
-      version: 3.9.6
-    - name: etcd
-      version: 3.3.15
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.5.3
+  - name: calico
+    version: 3.9.6
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2512.2.0
+  - name: etcd
+    version: 3.3.15
+  - name: kubernetes
+    version: 1.15.12
+  date: "2020-06-02T11:00:00Z"
+  state: active

--- a/aws/v9.2.2/release.yaml
+++ b/aws/v9.2.2/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.2
 spec:
-  state: deprecated
-  date: 2020-04-01T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.5
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-01T12:00:00Z"
+  state: deprecated

--- a/aws/v9.2.4/release.yaml
+++ b/aws/v9.2.4/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.4
 spec:
-  state: deprecated
-  date: 2020-04-22T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-22T12:00:00Z"
+  state: deprecated

--- a/aws/v9.2.5/release.yaml
+++ b/aws/v9.2.5/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.2.5
 spec:
-  state: deprecated
-  date: 2020-04-24T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.6.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-04-24T12:00:00Z"
+  state: deprecated

--- a/aws/v9.3.0/release.yaml
+++ b/aws/v9.3.0/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.3.0
 spec:
-  state: deprecated
-  date: 2020-05-07T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: cluster-autoscaler
-    componentVersion: 1.16.2
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
     version: 1.1.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: aws-operator
     version: 5.7.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-05-07T12:00:00Z"
+  state: deprecated

--- a/aws/v9.3.2/release.yaml
+++ b/aws/v9.3.2/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.3.2
 spec:
-  state: deprecated
-  date: 2020-05-26T15:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.9.5
-      version: 1.0.5
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.11
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
+    version: 1.1.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
+    version: 1.0.5
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.11
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 5.7.1
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: kubernetes
-      version: 1.16.9
-    - name: containerlinux
-      version: 2345.3.1
-    - name: calico
-      version: 3.10.1
-    - name: etcd
-      version: 3.3.17
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.7.1
+  - name: calico
+    version: 3.10.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2345.3.1
+  - name: etcd
+    version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-05-26T15:00:00Z"
+  state: deprecated

--- a/aws/v9.3.3/release.yaml
+++ b/aws/v9.3.3/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.3.3
 spec:
-  state: active
-  date: 2020-06-05T15:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: cluster-autoscaler
-      componentVersion: 1.16.2
-      version: 1.1.4
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.9.5
-      version: 1.0.5
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.12
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.16.2
+    name: cluster-autoscaler
+    version: 1.1.4
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
+    version: 1.0.5
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.12
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: aws-operator
-      version: 5.7.1
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: kubernetes
-      version: 1.16.9
-    - name: containerlinux
-      version: 2345.3.1
-    - name: calico
-      version: 3.10.1
-    - name: etcd
-      version: 3.3.17
+  - name: app-operator
+    version: 1.0.0
+  - name: aws-operator
+    version: 5.7.1
+  - name: calico
+    version: 3.10.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2345.3.1
+  - name: etcd
+    version: 3.3.17
+  - name: kubernetes
+    version: 1.16.9
+  date: "2020-06-05T15:00:00Z"
+  state: active

--- a/azure/archived/v11.0.0/release.yaml
+++ b/azure/archived/v11.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.0.0
 spec:
-  state: deprecated
-  date: 2020-01-08T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.8.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.21.4
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-01-08T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.1.0/release.yaml
+++ b/azure/archived/v11.1.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.1.0
 spec:
-  state: deprecated
-  date: 2020-02-20T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.9.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.21.4
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-02-20T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.0/release.yaml
+++ b/azure/archived/v11.2.0/release.yaml
@@ -1,49 +1,50 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.0
 spec:
-  state: deprecated
-  date: 2020-02-26T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.11.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.3
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.2
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.6.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.29.0
+  - componentVersion: 0.29.0
+    name: nginx-ingress-controller
     version: 1.5.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.9.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.1
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.3
+  date: "2020-02-26T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.1/release.yaml
+++ b/azure/archived/v11.2.1/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.1
 spec:
-  state: deprecated
-  date: 2020-03-30T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.5
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.4
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-03-30T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.2/release.yaml
+++ b/azure/archived/v11.2.2/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.2
 spec:
-  state: deprecated
-  date: 2020-04-08T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.7
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.5
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2303.4.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-04-08T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.3/release.yaml
+++ b/azure/archived/v11.2.3/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.3
 spec:
-  state: deprecated
-  date: 2020-04-09T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.5
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.6
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2303.4.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-04-09T12:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.4/release.yaml
+++ b/azure/archived/v11.2.4/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.4
 spec:
-  state: deprecated
-  date: 2020-04-14T14:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.8
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.6
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2303.4.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-04-14T14:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.5/release.yaml
+++ b/azure/archived/v11.2.5/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.5
 spec:
-  state: deprecated
-  date: 2020-04-22T17:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.6
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2303.4.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-04-22T17:00:00Z"
+  state: deprecated

--- a/azure/archived/v11.2.6/release.yaml
+++ b/azure/archived/v11.2.6/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.6
 spec:
-  state: deprecated
-  date: 2020-04-28T14:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 3.0.7
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2303.4.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-04-28T14:00:00Z"
+  state: deprecated

--- a/azure/archived/v8.0.0/release.yaml
+++ b/azure/archived/v8.0.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.0.0
 spec:
-  state: deprecated
-  date: 2019-03-21T10:00:00Z
   apps: []
   components:
   - name: azure-operator
     version: 2.3.0
+  - name: calico
+    version: 3.6.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.5.0
   - name: cluster-operator
     version: 0.15.0
-  - name: kubernetes
-    version: 1.14.1
   - name: containerlinux
     version: 2023.5.0
   - name: coredns
     version: 1.5.0
-  - name: calico
-    version: 3.6.1
   - name: etcd
     version: 3.3.12
+  - name: kubernetes
+    version: 1.14.1
+  date: "2019-03-21T10:00:00Z"
+  state: deprecated

--- a/azure/archived/v8.2.0/release.yaml
+++ b/azure/archived/v8.2.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.2.0
 spec:
-  state: deprecated
-  date: 2019-03-30T10:00:00Z
   apps: []
   components:
   - name: azure-operator
     version: 2.4.0
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: kubernetes
-    version: 1.14.3
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.3
+  date: "2019-03-30T10:00:00Z"
+  state: deprecated

--- a/azure/archived/v8.2.1/release.yaml
+++ b/azure/archived/v8.2.1/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.2.1
 spec:
-  state: deprecated
-  date: 2019-03-30T10:00:00Z
   apps: []
   components:
   - name: azure-operator
     version: 2.4.1
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: kubernetes
-    version: 1.14.5
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.5
+  date: "2019-03-30T10:00:00Z"
+  state: deprecated

--- a/azure/archived/v8.3.0/release.yaml
+++ b/azure/archived/v8.3.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.3.0
 spec:
-  state: deprecated
-  date: 2019-07-11T10:00:00Z
   apps: []
   components:
   - name: azure-operator
     version: 2.5.0
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.18.0
-  - name: kubernetes
-    version: 1.14.5
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.5
+  date: "2019-07-11T10:00:00Z"
+  state: deprecated

--- a/azure/archived/v8.4.0/release.yaml
+++ b/azure/archived/v8.4.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.4.0
 spec:
-  state: deprecated
-  date: 2019-08-14T10:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.6.0
+  - name: calico
+    version: 3.8.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.19.0
-  - name: kubernetes
-    version: 1.14.6
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.6.2
-  - name: calico
-    version: 3.8.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.6
+  date: "2019-08-14T10:00:00Z"
+  state: deprecated

--- a/azure/archived/v9.0.0/release.yaml
+++ b/azure/archived/v9.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.0
 spec:
-  state: active
-  date: 2019-10-25T10:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.7.0
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.21.0
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.4
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: kubernetes
+    version: 1.15.5
+  date: "2019-10-25T10:00:00Z"
+  state: active

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -1,13 +1,11 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-
-transformers:
-  - releaseNotesTransformer.yaml
-
 resources:
-  - v8.4.1
-  - v11.3.0
-  - v11.3.1
-  - v11.3.2
-  - v11.3.3
-  - v11.4.0
+- v8.4.1
+- v11.3.0
+- v11.3.1
+- v11.3.2
+- v11.3.3
+- v11.4.0
+transformers:
+- releaseNotesTransformer.yaml

--- a/azure/v11.3.0/release.yaml
+++ b/azure/v11.3.0/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.0
 spec:
-  state: deprecated
-  date: 2020-05-05T07:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 4.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2345.3.1
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-05-05T07:00:00Z"
+  state: deprecated

--- a/azure/v11.3.1/release.yaml
+++ b/azure/v11.3.1/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.1
 spec:
-  state: deprecated
-  date: 2020-05-21T07:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.0
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 4.0.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2345.3.1
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-05-21T07:00:00Z"
+  state: deprecated

--- a/azure/v11.3.2/release.yaml
+++ b/azure/v11.3.2/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.2
 spec:
-  state: deprecated
-  date: 2020-06-11T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.12
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 4.0.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2345.3.1
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-06-11T15:00:00Z"
+  state: deprecated

--- a/azure/v11.3.3/release.yaml
+++ b/azure/v11.3.3/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.3
 spec:
-  state: deprecated
-  date: 2020-06-18T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.1.0
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.1.0
   - name: net-exporter
     version: 1.8.1
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.12
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 4.0.1
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: kubernetes
-    version: 1.16.8
   - name: containerlinux
     version: 2345.3.1
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.8
+  date: "2020-06-18T15:00:00Z"
+  state: deprecated

--- a/azure/v11.4.0/release.yaml
+++ b/azure/v11.4.0/release.yaml
@@ -1,51 +1,52 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.4.0
 spec:
-  state: active
-  date: 2020-06-30T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.10
-  - name: external-dns
-    componentVersion: 0.5.18
+  - componentVersion: 0.5.18
+    name: external-dns
     version: 1.2.1
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.1.0
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.1.0
   - name: net-exporter
     version: 1.8.1
-  - name: nginx-ingress-controller
-    componentVersion: 0.33.0
+  - componentVersion: 0.33.0
+    name: nginx-ingress-controller
     version: 1.7.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 4.1.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.10
-  - name: kubernetes
-    version: 1.16.12
   - name: containerlinux
     version: 2512.2.1
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: kubernetes
+    version: 1.16.12
+  date: "2020-06-30T15:00:00Z"
+  state: active

--- a/azure/v8.4.1/release.yaml
+++ b/azure/v8.4.1/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.4.1
 spec:
-  state: deprecated
-  date: 2019-09-26T17:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
   - name: azure-operator
     version: 2.6.1
+  - name: calico
+    version: 3.8.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.7.0
   - name: cluster-operator
     version: 0.19.0
-  - name: kubernetes
-    version: 1.14.6
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.6.2
-  - name: calico
-    version: 3.8.2
   - name: etcd
     version: 3.3.13
+  - name: kubernetes
+    version: 1.14.6
+  date: "2019-09-26T17:00:00Z"
+  state: deprecated

--- a/kvm/archived/v11.0.0/release.yaml
+++ b/kvm/archived/v11.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.0.0
 spec:
-  state: deprecated
-  date: 2020-01-10T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.21.4
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-01-10T12:00:00Z"
+  state: deprecated

--- a/kvm/archived/v11.1.0/release.yaml
+++ b/kvm/archived/v11.1.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.1.0
 spec:
-  state: deprecated
-  date: 2020-01-29T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.22.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.5
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-01-29T12:00:00Z"
+  state: deprecated

--- a/kvm/archived/v11.2.2/release.yaml
+++ b/kvm/archived/v11.2.2/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.2
 spec:
-  state: deprecated
-  date: 2020-04-09T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.8
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-04-09T12:00:00Z"
+  state: deprecated

--- a/kvm/archived/v11.2.3/release.yaml
+++ b/kvm/archived/v11.2.3/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.3
 spec:
-  state: deprecated
-  date: 2020-04-23T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-04-23T12:00:00Z"
+  state: deprecated

--- a/kvm/archived/v8.0.0/release.yaml
+++ b/kvm/archived/v8.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.0.0
 spec:
-  state: deprecated
-  date: 2019-03-21T10:00:00Z
   apps: []
   components:
+  - name: calico
+    version: 3.6.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.5.0
   - name: cluster-operator
     version: 0.15.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.5.0
-  - name: kubernetes
-    version: 1.14.1
   - name: containerlinux
     version: 2023.5.0
   - name: coredns
     version: 1.5.0
-  - name: calico
-    version: 3.6.1
   - name: etcd
     version: 3.3.12
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.1
+  - name: kvm-operator
+    version: 3.5.0
+  date: "2019-03-21T10:00:00Z"
+  state: deprecated

--- a/kvm/archived/v8.1.0/release.yaml
+++ b/kvm/archived/v8.1.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.1.0
 spec:
-  state: deprecated
-  date: 2019-04-30T10:00:00Z
   apps: []
   components:
+  - name: calico
+    version: 3.6.1
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.6.0
-  - name: kubernetes
-    version: 1.14.1
   - name: containerlinux
     version: 2023.5.0
   - name: coredns
     version: 1.5.0
-  - name: calico
-    version: 3.6.1
   - name: etcd
     version: 3.3.12
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.1
+  - name: kvm-operator
+    version: 3.6.0
+  date: "2019-04-30T10:00:00Z"
+  state: deprecated

--- a/kvm/archived/v8.2.0/release.yaml
+++ b/kvm/archived/v8.2.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.2.0
 spec:
-  state: deprecated
-  date: 2019-06-24T10:00:00Z
   apps: []
   components:
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.7.0
-  - name: kubernetes
-    version: 1.14.3
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.3
+  - name: kvm-operator
+    version: 3.7.0
+  date: "2019-06-24T10:00:00Z"
+  state: deprecated

--- a/kvm/archived/v8.2.1/release.yaml
+++ b/kvm/archived/v8.2.1/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.2.1
 spec:
-  state: deprecated
-  date: 2019-06-24T10:00:00Z
   apps: []
   components:
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: chart-operator
     version: 0.6.0
   - name: cluster-operator
     version: 0.17.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.7.1
-  - name: kubernetes
-    version: 1.14.5
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.5
+  - name: kvm-operator
+    version: 3.7.1
+  date: "2019-06-24T10:00:00Z"
+  state: deprecated

--- a/kvm/archived/v8.3.0/release.yaml
+++ b/kvm/archived/v8.3.0/release.yaml
@@ -1,27 +1,28 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.3.0
 spec:
-  state: deprecated
-  date: 2019-08-20T16:40:00Z
   apps: []
   components:
+  - name: calico
+    version: 3.7.2
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.18.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.7.1
-  - name: kubernetes
-    version: 1.14.5
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.5.1
-  - name: calico
-    version: 3.7.2
   - name: etcd
     version: 3.3.13
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.5
+  - name: kvm-operator
+    version: 3.7.1
+  date: "2019-08-20T16:40:00Z"
+  state: deprecated

--- a/kvm/archived/v8.4.0/release.yaml
+++ b/kvm/archived/v8.4.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v8.4.0
 spec:
-  state: deprecated
-  date: 2019-08-20T17:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.8.2
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.19.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.8.0
-  - name: kubernetes
-    version: 1.14.6
   - name: containerlinux
     version: 2135.4.0
   - name: coredns
     version: 1.6.2
-  - name: calico
-    version: 3.8.2
   - name: etcd
     version: 3.3.13
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.14.6
+  - name: kvm-operator
+    version: 3.8.0
+  date: "2019-08-20T17:00:00Z"
+  state: deprecated

--- a/kvm/archived/v9.0.1/release.yaml
+++ b/kvm/archived/v9.0.1/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.1
 spec:
-  state: deprecated
-  date: 2020-04-24T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.2
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.8.0
+  - componentVersion: 1.8.0
+    name: kube-state-metrics
     version: 0.6.0
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.1
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.9.1
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.15.11
+  - name: kvm-operator
+    version: 3.9.1
+  date: "2020-04-24T12:00:00Z"
+  state: deprecated

--- a/kvm/archived/v9.0.2/release.yaml
+++ b/kvm/archived/v9.0.2/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.2
 spec:
-  state: deprecated
-  date: 2020-05-04T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.2
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.8.0
+  - componentVersion: 1.8.0
+    name: kube-state-metrics
     version: 0.6.0
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.1
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.9.2
-  - name: kubernetes
-    version: 1.15.11
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.15.11
+  - name: kvm-operator
+    version: 3.9.2
+  date: "2020-05-04T12:00:00Z"
+  state: deprecated

--- a/kvm/kustomization.yaml
+++ b/kvm/kustomization.yaml
@@ -1,14 +1,12 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
-
-transformers:
-  - releaseNotesTransformer.yaml
-
 resources:
-  - v9.0.0
-  - v9.0.3
-  - v11.2.0
-  - v11.2.1
-  - v11.3.0
-  - v11.3.1
-  - v11.3.2
+- v9.0.0
+- v9.0.3
+- v11.2.0
+- v11.2.1
+- v11.3.0
+- v11.3.1
+- v11.3.2
+transformers:
+- releaseNotesTransformer.yaml

--- a/kvm/v11.2.0/release.yaml
+++ b/kvm/v11.2.0/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.0
 spec:
-  state: deprecated
-  date: 2020-02-26T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.11.4
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.3
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.2
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.6.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.29.0
+  - componentVersion: 0.29.0
+    name: nginx-ingress-controller
     version: 1.5.0
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.1
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-02-26T12:00:00Z"
+  state: deprecated

--- a/kvm/v11.2.1/release.yaml
+++ b/kvm/v11.2.1/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.2.1
 spec:
-  state: deprecated
-  date: 2020-03-23T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.12.1
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.2
+  - componentVersion: 1.9.2
+    name: kube-state-metrics
     version: 1.0.4
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.5
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.10.0
-  - name: kubernetes
-    version: 1.16.3
   - name: containerlinux
     version: 2191.5.0
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.3
+  - name: kvm-operator
+    version: 3.10.0
+  date: "2020-03-23T12:00:00Z"
+  state: deprecated

--- a/kvm/v11.3.0/release.yaml
+++ b/kvm/v11.3.0/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.0
 spec:
-  state: deprecated
-  date: 2020-04-27T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.11.0
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.9
+  - name: kvm-operator
+    version: 3.11.0
+  date: "2020-04-27T12:00:00Z"
+  state: deprecated

--- a/kvm/v11.3.1/release.yaml
+++ b/kvm/v11.3.1/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.1
 spec:
-  state: deprecated
-  date: 2020-05-04T12:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.9
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.11.1
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.9
+  - name: kvm-operator
+    version: 3.11.1
+  date: "2020-05-04T12:00:00Z"
+  state: deprecated

--- a/kvm/v11.3.2/release.yaml
+++ b/kvm/v11.3.2/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v11.3.2
 spec:
-  state: active
-  date: 2020-06-11T15:00:00Z
   apps:
   - name: cert-exporter
     version: 1.2.1
   - name: chart-operator
     version: 0.13.0
-  - name: coredns
-    componentVersion: 1.6.5
+  - componentVersion: 1.6.5
+    name: coredns
     version: 1.1.8
-  - name: kube-state-metrics
-    componentVersion: 1.9.5
+  - componentVersion: 1.9.5
+    name: kube-state-metrics
     version: 1.0.5
-  - name: metrics-server
-    componentVersion: 0.3.3
+  - componentVersion: 0.3.3
+    name: metrics-server
     version: 1.0.0
   - name: net-exporter
     version: 1.7.0
-  - name: nginx-ingress-controller
-    componentVersion: 0.30.0
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
     version: 1.6.12
-  - name: node-exporter
-    componentVersion: 0.18.1
+  - componentVersion: 0.18.1
+    name: node-exporter
     version: 1.2.0
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.10.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.23.8
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.11.1
-  - name: kubernetes
-    version: 1.16.9
   - name: containerlinux
     version: 2345.3.1
-  - name: calico
-    version: 3.10.1
   - name: etcd
     version: 3.3.17
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.16.9
+  - name: kvm-operator
+    version: 3.11.1
+  date: "2020-06-11T15:00:00Z"
+  state: active

--- a/kvm/v9.0.0/release.yaml
+++ b/kvm/v9.0.0/release.yaml
@@ -1,29 +1,30 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.0
 spec:
-  state: deprecated
-  date: 2019-10-28T12:00:00Z
   apps: []
   components:
   - name: app-operator
     version: 1.0.0
+  - name: calico
+    version: 3.9.1
   - name: cert-operator
     version: 0.1.0
   - name: cluster-operator
     version: 0.21.0
-  - name: flannel-operator
-    version: 0.2.0
-  - name: kvm-operator
-    version: 3.9.0
-  - name: kubernetes
-    version: 1.15.5
   - name: containerlinux
     version: 2191.5.0
   - name: coredns
     version: 1.6.4
-  - name: calico
-    version: 3.9.1
   - name: etcd
     version: 3.3.15
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.15.5
+  - name: kvm-operator
+    version: 3.9.0
+  date: "2019-10-28T12:00:00Z"
+  state: deprecated

--- a/kvm/v9.0.3/release.yaml
+++ b/kvm/v9.0.3/release.yaml
@@ -1,48 +1,49 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
+  creationTimestamp: null
   name: v9.0.3
 spec:
-  state: active
-  date: 2020-05-13T19:00:00Z
   apps:
-    - name: cert-exporter
-      version: 1.2.2
-    - name: chart-operator
-      version: 0.13.0
-    - name: coredns
-      componentVersion: 1.6.5
-      version: 1.1.8
-    - name: kube-state-metrics
-      componentVersion: 1.8.0
-      version: 0.6.0
-    - name: metrics-server
-      componentVersion: 0.3.3
-      version: 1.0.0
-    - name: net-exporter
-      version: 1.7.1
-    - name: nginx-ingress-controller
-      componentVersion: 0.30.0
-      version: 1.6.9
-    - name: node-exporter
-      componentVersion: 0.18.1
-      version: 1.2.0
+  - name: cert-exporter
+    version: 1.2.2
+  - name: chart-operator
+    version: 0.13.0
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.1.8
+  - componentVersion: 1.8.0
+    name: kube-state-metrics
+    version: 0.6.0
+  - componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.0.0
+  - name: net-exporter
+    version: 1.7.1
+  - componentVersion: 0.30.0
+    name: nginx-ingress-controller
+    version: 1.6.9
+  - componentVersion: 0.18.1
+    name: node-exporter
+    version: 1.2.0
   components:
-    - name: app-operator
-      version: 1.0.0
-    - name: cert-operator
-      version: 0.1.0
-    - name: cluster-operator
-      version: 0.23.9
-    - name: flannel-operator
-      version: 0.2.0
-    - name: kvm-operator
-      version: 3.9.2
-    - name: kubernetes
-      version: 1.15.11
-    - name: containerlinux
-      version: 2345.3.1
-    - name: calico
-      version: 3.9.1
-    - name: etcd
-      version: 3.3.1
+  - name: app-operator
+    version: 1.0.0
+  - name: calico
+    version: 3.9.1
+  - name: cert-operator
+    version: 0.1.0
+  - name: cluster-operator
+    version: 0.23.9
+  - name: containerlinux
+    version: 2345.3.1
+  - name: etcd
+    version: 3.3.1
+  - name: flannel-operator
+    version: 0.2.0
+  - name: kubernetes
+    version: 1.15.11
+  - name: kvm-operator
+    version: 3.9.2
+  date: "2020-05-13T19:00:00Z"
+  state: active


### PR DESCRIPTION
To enable automated release creation, we need a consistent format for releases. I wrote a quick script which reads all releases and writes them to the same file with sorted fields and sorted components. I also sorted aws/azure/kvm kustomization.yaml for the same reason. There should be no change to the content of the releases.