### PR TITLE
Cover public/internal LB support in Azure 11.4.0 release notes

### DIFF
--- a/azure/v11.4.0/README.md
+++ b/azure/v11.4.0/README.md
@@ -69,4 +69,5 @@ since [v1.16.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/C
 - Changed NGINX Service type from NodePort to LoadBalancer for Azure.
 - Made NGINX LoadBalancer Service external traffic policy configurable.
 - Use Local as NGINX LoadBalancer Service default external traffic policy.
+- Supported configuring (via `controller.service.public` configuration property) whether NGINX LoadBalancer Service should be public (default) or internal.
 - Upgraded to ingress-nginx [0.33.0](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0330).


### PR DESCRIPTION
Missed to cover this initially. It partially address https://github.com/giantswarm/giantswarm/issues/9332 - now single NGINX LB Service can be made public (default) or internal. Both at the same time is not supported yet.

Additional support:
- for configuring separate public and internal LB Service in single NGINX IC App installation
  - will be shipped as part of Azure 12.0.0 platform release with NGINX IC App v1.7.1
- for installing multiple separate public/internal NGINX Apps in single TC
  - will be done via https://github.com/giantswarm/giantswarm/issues/9060