### PR TITLE
Fix external-dns component version in aws 11.4.1

### DIFF
--- a/aws/v11.4.1/release.yaml
+++ b/aws/v11.4.1/release.yaml
@@ -20,7 +20,7 @@ spec:
   - componentVersion: 1.6.5
     name: coredns
     version: 1.1.10
-  - componentVersion: 0.5.18
+  - componentVersion: 0.7.2
     name: external-dns
     version: 1.2.2
   - componentVersion: 3.5.0


### PR DESCRIPTION
AWS 11.4.1 includes external-dns App v1.2.2 which has upgrade to upstream external-dns 0.7.2 see https://github.com/giantswarm/releases/pull/325

Metadata about external-dns component version in the platform release has not been updated. This PR fixes the issue.