### PR TITLE
Fix cluster-autoscaler component version metdata in aws 9.3.4

### DIFF
--- a/aws/v9.3.4/release.yaml
+++ b/aws/v9.3.4/release.yaml
@@ -9,7 +9,7 @@ spec:
     version: 1.2.3
   - name: chart-operator
     version: 0.13.0
-  - componentVersion: 1.16.2
+  - componentVersion: 1.16.5
     name: cluster-autoscaler
     version: 1.16.0
   - componentVersion: 1.6.5


### PR DESCRIPTION
Missed to update this in https://github.com/giantswarm/releases/pull/337