### PR TITLE
Use kustomize plugin v0.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install releaseNotesURLTransformer kustomize plugin
           command: |
-            CGO_ENABLED=0 go get github.com/giantswarm/kustomize-plugin-releasenotesurlannotationtransformer@v0.0.0-20200721145043-a9798549bfe0
+            CGO_ENABLED=0 go get github.com/giantswarm/kustomize-plugin-releasenotesurlannotationtransformer@v0.1.1-0.20200721171906-53730691281c
             mkdir -p "$PLUGIN_PATH"
             cp /go/bin/kustomize-plugin-releasenotesurlannotationtransformer "$PLUGIN_PATH/releaseNotesURLAnnotationTransformer"
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: Install releaseNotesURLTransformer kustomize plugin
           command: |
-            CGO_ENABLED=0 go get github.com/giantswarm/kustomize-plugin-releasenotesurlannotationtransformer@v0.1.1-0.20200721171906-53730691281c
+            CGO_ENABLED=0 go get github.com/giantswarm/kustomize-plugin-releasenotesurlannotationtransformer@v0.2.0
             mkdir -p "$PLUGIN_PATH"
             cp /go/bin/kustomize-plugin-releasenotesurlannotationtransformer "$PLUGIN_PATH/releaseNotesURLAnnotationTransformer"
           environment:


### PR DESCRIPTION
This PR changes the used kustomize plugin version to v0.2.0 which removes the dependency on apiextensions 