### PR TITLE
Set EOL date for AWS v8 releases

### DIFF
--- a/aws/v8.2.0/release.yaml
+++ b/aws/v8.2.0/release.yaml
@@ -26,4 +26,4 @@ spec:
     version: 1.14.3
   date: "2019-06-03T10:00:00Z"
   state: deprecated
-  endOfLifeDate: "2019-09-01T00:00:00Z"
+  endOfLifeDate: "2020-09-01T00:00:00Z"

--- a/aws/v8.2.0/release.yaml
+++ b/aws/v8.2.0/release.yaml
@@ -26,3 +26,4 @@ spec:
     version: 1.14.3
   date: "2019-06-03T10:00:00Z"
   state: deprecated
+  endOfLifeDate: "2019-09-01T00:00:00Z"

--- a/aws/v8.5.0/release.yaml
+++ b/aws/v8.5.0/release.yaml
@@ -28,4 +28,4 @@ spec:
     version: 1.14.6
   date: "2019-09-02T13:30:00Z"
   state: deprecated
-  endOfLifeDate: "2019-09-01T00:00:00Z"
+  endOfLifeDate: "2020-09-01T00:00:00Z"

--- a/aws/v8.5.0/release.yaml
+++ b/aws/v8.5.0/release.yaml
@@ -28,3 +28,4 @@ spec:
     version: 1.14.6
   date: "2019-09-02T13:30:00Z"
   state: deprecated
+  endOfLifeDate: "2019-09-01T00:00:00Z"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12224

This adds an EOL date to the two remaining AWS releases with version 8.x.x