### PR TITLE
Request Calico 3.13.4 for next 11.x release on all providers

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,6 +1,6 @@
 releases:
-    - name: "> 11.5.0, < 12.0.0"
+    - name: "> 12.0.0, < 13.0.0"
       requests:
         - name: calico
-          version: ">= 3.13.4"
+          version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,0 +1,6 @@
+releases:
+    - name: "> 11.5.0, < 12.0.0"
+      requests:
+        - name: calico
+          version: ">= 3.13.4"
+          issue: https://github.com/giantswarm/giantswarm/issues/11307

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,0 +1,6 @@
+releases:
+    - name: "> 11.4.0, < 12.0.0"
+      requests:
+        - name: calico
+          version: ">= 3.13.4"
+          issue: https://github.com/giantswarm/giantswarm/issues/11307

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -2,5 +2,10 @@ releases:
     - name: "> 11.4.0, < 12.0.0"
       requests:
         - name: calico
-          version: ">= 3.13.4"
+          version: ">= 3.10.4"
+          issue: https://github.com/giantswarm/giantswarm/issues/11307
+    - name: "12.*"
+      requests:
+        - name: calico
+          version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -2,5 +2,10 @@ releases:
     - name: "> 11.3.2, < 12.0.0"
       requests:
         - name: calico
-          version: ">= 3.13.4"
+          version: ">= 3.10.4"
+          issue: https://github.com/giantswarm/giantswarm/issues/11307
+    - name: "> 12.1.0, < 13.0.0"
+      requests:
+        - name: calico
+          version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,0 +1,6 @@
+releases:
+    - name: "> 11.3.2, < 12.0.0"
+      requests:
+        - name: calico
+          version: ">= 3.13.4"
+          issue: https://github.com/giantswarm/giantswarm/issues/11307


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/11307 and https://github.com/giantswarm/giantswarm/issues/12334

Next 11.x releases should include Calico 3.13.4.

Should any other platform versions be bumped as well?