### PR TITLE
Add releaseOperatorDeploy to operators in v12.1.0

### DIFF
--- a/aws/v12.1.0/release.yaml
+++ b/aws/v12.1.0/release.yaml
@@ -43,12 +43,15 @@ spec:
   - name: aws-cni
     version: 1.6.3
   - name: aws-operator
+    releaseOperatorDeploy: true
     version: 8.7.5
   - name: calico
     version: 3.15.1
   - name: cert-operator
+    releaseOperatorDeploy: true
     version: 0.1.0
   - name: cluster-operator
+    releaseOperatorDeploy: true
     version: 2.3.2
   - name: containerlinux
     version: 2512.2.1


### PR DESCRIPTION
Add `releaseOperatorDeploy` so that `release-operator` deploys the operators automatically.