### PR TITLE
Clear up releases list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains Giant Swarm releases and changelogs. Releases can be in
 different states, namely `active`, `deprecated` and `wip`. With pull requests
 merged to the `master` branch releases get automatically deployed to all Giant
 Swarm control planes.
+Deprecated and unused releases are removed from this list and stored in Archived folder separate for each provider.
 
 ## AWS
 - v12
@@ -19,24 +20,15 @@ Swarm control planes.
     - [v11.4.0](https://github.com/giantswarm/releases/tree/master/aws/v11.4.0)
   - v11.3
     - [v11.3.3](https://github.com/giantswarm/releases/tree/master/aws/v11.3.3)
-    - [v11.3.2](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.3.2)
     - [v11.3.1](https://github.com/giantswarm/releases/tree/master/aws/v11.3.1)
-    - [v11.3.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.3.0)
   - v11.2
     - [v11.2.1](https://github.com/giantswarm/releases/tree/master/aws/v11.2.1)
-    - [v11.2.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.2.0)
   - v11.1
     - [v11.1.4](https://github.com/giantswarm/releases/tree/master/aws/v11.1.4)
-    - [v11.1.3](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.1.3)
-    - [v11.1.2](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.1.2)
   - v11.0
     - [v11.0.1](https://github.com/giantswarm/releases/tree/master/aws/v11.0.1)
-    - [v11.0.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v11.0.0)
 - v10
   - v10.1
-    - [v10.1.2](https://github.com/giantswarm/releases/tree/master/aws/archived/v10.1.2)
-    - [v10.1.1](https://github.com/giantswarm/releases/tree/master/aws/archived/v10.1.1)
-    - [v10.1.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v10.1.0)
 - v9
   - v9.3
     - [v9.3.6](https://github.com/giantswarm/releases/tree/master/aws/v9.3.6)
@@ -44,34 +36,25 @@ Swarm control planes.
     - [v9.3.4](https://github.com/giantswarm/releases/tree/master/aws/v9.3.4)
     - [v9.3.3](https://github.com/giantswarm/releases/tree/master/aws/v9.3.3)
     - [v9.3.2](https://github.com/giantswarm/releases/tree/master/aws/v9.3.2)
-    - [v9.3.1](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.3.1)
-    - [v9.3.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.3.0)
   - v9.2
-    - [v9.2.6](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.2.6)
     - [v9.2.5](https://github.com/giantswarm/releases/tree/master/aws/v9.2.5)
     - [v9.2.4](https://github.com/giantswarm/releases/tree/master/aws/v9.2.4)
-    - [v9.2.3](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.2.3)
     - [v9.2.2](https://github.com/giantswarm/releases/tree/master/aws/v9.2.2)
-    - [v9.2.1](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.2.1)
-    - [v9.2.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.2.0)
-  - v9.1
-    - [v9.1.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.1.0)
   - v9.0
     - [v9.0.9](https://github.com/giantswarm/releases/tree/master/aws/v9.0.9)
     - [v9.0.8](https://github.com/giantswarm/releases/tree/master/aws/v9.0.8)
     - [v9.0.7](https://github.com/giantswarm/releases/tree/master/aws/v9.0.7)
     - [v9.0.6](https://github.com/giantswarm/releases/tree/master/aws/v9.0.6)
-    - [v9.0.5](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.0.5)
     - [v9.0.4](https://github.com/giantswarm/releases/tree/master/aws/v9.0.4)
     - [v9.0.3](https://github.com/giantswarm/releases/tree/master/aws/v9.0.3)
-    - [v9.0.2](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.0.2)
-    - [v9.0.1](https://github.com/giantswarm/releases/tree/master/aws/archived/v9.0.1)
     - [v9.0.0](https://github.com/giantswarm/releases/tree/master/aws/v9.0.0)
 - v8
   - v8.5
     - [v8.5.0](https://github.com/giantswarm/releases/tree/master/aws/v8.5.0)
   - v8.2
     - [v8.2.0](https://github.com/giantswarm/releases/tree/master/aws/v8.2.0)
+    
+[Archived AWS releases](https://github.com/giantswarm/releases/tree/master/aws/archived)
 
 ## Azure
 
@@ -82,35 +65,10 @@ Swarm control planes.
     - [v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0)
   - v11.3
     - [v11.3.3](https://github.com/giantswarm/releases/tree/master/azure/v11.3.3)
-    - [v11.3.2](https://github.com/giantswarm/releases/tree/master/azure/v11.3.2)
     - [v11.3.1](https://github.com/giantswarm/releases/tree/master/azure/v11.3.1)
     - [v11.3.0](https://github.com/giantswarm/releases/tree/master/azure/v11.3.0)
-  - v11.2
-    - [v11.2.6](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.6)
-    - [v11.2.5](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.5)
-    - [v11.2.4](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.4)
-    - [v11.2.3](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.3)
-    - [v11.2.2](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.2)
-    - [v11.2.1](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.1)
-    - [v11.2.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.2.0)
-  - v11.1
-    - [v11.1.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.1.0)
-  - v11.0
-    - [v11.0.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v11.0.0)
-- v9
-  - v9.0
-    - [v9.0.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v9.0.0)
-- v8
-  - v8.4
-    - [v8.4.1](https://github.com/giantswarm/releases/tree/master/azure/v8.4.1)
-    - [v8.4.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v8.4.0)
-  - v8.3
-    - [v8.3.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v8.3.0)
-  - v8.2
-    - [v8.2.1](https://github.com/giantswarm/releases/tree/master/azure/archived/v8.2.1)
-    - [v8.2.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v8.2.0)
-  - v8.0
-    - [v8.0.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v8.0.0)
+
+[Archived Azure releases](https://github.com/giantswarm/releases/tree/master/azure/archived)
 
 ## KVM
 
@@ -128,29 +86,11 @@ Swarm control planes.
     - [v11.3.1](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.1)
     - [v11.3.0](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.0)
   - v11.2
-    - [v11.2.3](https://github.com/giantswarm/releases/tree/master/kvm/archived/v11.2.3)
-    - [v11.2.2](https://github.com/giantswarm/releases/tree/master/kvm/archived/v11.2.2)
     - [v11.2.1](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.1)
     - [v11.2.0](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.0)
-  - v11.1
-    - [v11.1.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v11.1.0)
-  - v11.0
-    - [v11.0.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v11.0.0)
 - v9
   - v9.0
     - [v9.0.3](https://github.com/giantswarm/releases/tree/master/kvm/v9.0.3)
-    - [v9.0.2](https://github.com/giantswarm/releases/tree/master/kvm/archived/v9.0.2)
-    - [v9.0.1](https://github.com/giantswarm/releases/tree/master/kvm/archived/v9.0.1)
     - [v9.0.0](https://github.com/giantswarm/releases/tree/master/kvm/v9.0.0)
-- v8
-  - v8.4
-    - [v8.4.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.4.0)
-  - v8.3
-    - [v8.3.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.3.0)
-  - v8.2
-    - [v8.2.1](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.2.1)
-    - [v8.2.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.2.0)
-  - v8.1
-    - [v8.1.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.1.0)
-  - v8.0
-    - [v8.0.0](https://github.com/giantswarm/releases/tree/master/kvm/archived/v8.0.0)
+
+[Archived KVM releases](https://github.com/giantswarm/releases/tree/master/kvm/archived)

--- a/README.md
+++ b/README.md
@@ -16,43 +16,41 @@ Deprecated and unused releases are removed from this list and stored in Archived
   - v11.5
     - [v11.5.0](https://github.com/giantswarm/releases/tree/master/aws/v11.5.0)
   - v11.4
-    - [v11.4.1](https://github.com/giantswarm/releases/tree/master/aws/v11.4.1)
-    - [v11.4.0](https://github.com/giantswarm/releases/tree/master/aws/v11.4.0)
+    - [v11.4.1(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.4.1)
+    - [v11.4.0(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.4.0)
   - v11.3
-    - [v11.3.3](https://github.com/giantswarm/releases/tree/master/aws/v11.3.3)
-    - [v11.3.1](https://github.com/giantswarm/releases/tree/master/aws/v11.3.1)
+    - [v11.3.3(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.3.3)
+    - [v11.3.1(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.3.1)
   - v11.2
-    - [v11.2.1](https://github.com/giantswarm/releases/tree/master/aws/v11.2.1)
+    - [v11.2.1(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.2.1)
   - v11.1
-    - [v11.1.4](https://github.com/giantswarm/releases/tree/master/aws/v11.1.4)
+    - [v11.1.4(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.1.4)
   - v11.0
-    - [v11.0.1](https://github.com/giantswarm/releases/tree/master/aws/v11.0.1)
-- v10
-  - v10.1
+    - [v11.0.1(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v11.0.1)
 - v9
   - v9.3
     - [v9.3.6](https://github.com/giantswarm/releases/tree/master/aws/v9.3.6)
-    - [v9.3.5](https://github.com/giantswarm/releases/tree/master/aws/v9.3.5)
-    - [v9.3.4](https://github.com/giantswarm/releases/tree/master/aws/v9.3.4)
-    - [v9.3.3](https://github.com/giantswarm/releases/tree/master/aws/v9.3.3)
-    - [v9.3.2](https://github.com/giantswarm/releases/tree/master/aws/v9.3.2)
+    - [v9.3.5(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.3.5)
+    - [v9.3.4(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.3.4)
+    - [v9.3.3(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.3.3)
+    - [v9.3.2(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.3.2)
   - v9.2
-    - [v9.2.5](https://github.com/giantswarm/releases/tree/master/aws/v9.2.5)
-    - [v9.2.4](https://github.com/giantswarm/releases/tree/master/aws/v9.2.4)
-    - [v9.2.2](https://github.com/giantswarm/releases/tree/master/aws/v9.2.2)
+    - [v9.2.5(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.2.5)
+    - [v9.2.4(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.2.4)
+    - [v9.2.2(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.2.2)
   - v9.0
     - [v9.0.9](https://github.com/giantswarm/releases/tree/master/aws/v9.0.9)
-    - [v9.0.8](https://github.com/giantswarm/releases/tree/master/aws/v9.0.8)
-    - [v9.0.7](https://github.com/giantswarm/releases/tree/master/aws/v9.0.7)
-    - [v9.0.6](https://github.com/giantswarm/releases/tree/master/aws/v9.0.6)
-    - [v9.0.4](https://github.com/giantswarm/releases/tree/master/aws/v9.0.4)
-    - [v9.0.3](https://github.com/giantswarm/releases/tree/master/aws/v9.0.3)
-    - [v9.0.0](https://github.com/giantswarm/releases/tree/master/aws/v9.0.0)
+    - [v9.0.8(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.8)
+    - [v9.0.7(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.7)
+    - [v9.0.6(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.6)
+    - [v9.0.4(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.4)
+    - [v9.0.3(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.3)
+    - [v9.0.0(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v9.0.0)
 - v8
   - v8.5
-    - [v8.5.0](https://github.com/giantswarm/releases/tree/master/aws/v8.5.0)
+    - [v8.5.0(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v8.5.0)
   - v8.2
-    - [v8.2.0](https://github.com/giantswarm/releases/tree/master/aws/v8.2.0)
+    - [v8.2.0(deprecated)](https://github.com/giantswarm/releases/tree/master/aws/v8.2.0)
     
 [Archived AWS releases](https://github.com/giantswarm/releases/tree/master/aws/archived)
 
@@ -64,9 +62,9 @@ Deprecated and unused releases are removed from this list and stored in Archived
   - v11.4
     - [v11.4.0](https://github.com/giantswarm/releases/tree/master/azure/v11.4.0)
   - v11.3
-    - [v11.3.3](https://github.com/giantswarm/releases/tree/master/azure/v11.3.3)
-    - [v11.3.1](https://github.com/giantswarm/releases/tree/master/azure/v11.3.1)
-    - [v11.3.0](https://github.com/giantswarm/releases/tree/master/azure/v11.3.0)
+    - [v11.3.3(deprecated)](https://github.com/giantswarm/releases/tree/master/azure/v11.3.3)
+    - [v11.3.1(deprecated)](https://github.com/giantswarm/releases/tree/master/azure/v11.3.1)
+    - [v11.3.0(deprecated)](https://github.com/giantswarm/releases/tree/master/azure/v11.3.0)
 
 [Archived Azure releases](https://github.com/giantswarm/releases/tree/master/azure/archived)
 

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ Deprecated and unused releases are removed from this list and stored in Archived
   - v12.1
     - [v12.1.0](https://github.com/giantswarm/releases/tree/master/kvm/v12.1.0)
   - v12.0
-    - [v12.0.1](https://github.com/giantswarm/releases/tree/master/kvm/v12.0.1)
-    - [v12.0.0](https://github.com/giantswarm/releases/tree/master/kvm/v12.0.0)
+    - [v12.0.1(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v12.0.1)
+    - [v12.0.0(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v12.0.0)
 - v11
   - v11.3
     - [v11.3.2](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.2)
-    - [v11.3.1](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.1)
-    - [v11.3.0](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.0)
+    - [v11.3.1(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.1)
+    - [v11.3.0(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v11.3.0)
   - v11.2
-    - [v11.2.1](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.1)
-    - [v11.2.0](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.0)
+    - [v11.2.1(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.1)
+    - [v11.2.0(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v11.2.0)
 - v9
   - v9.0
     - [v9.0.3](https://github.com/giantswarm/releases/tree/master/kvm/v9.0.3)
-    - [v9.0.0](https://github.com/giantswarm/releases/tree/master/kvm/v9.0.0)
+    - [v9.0.0(deprecated)](https://github.com/giantswarm/releases/tree/master/kvm/v9.0.0)
 
 [Archived KVM releases](https://github.com/giantswarm/releases/tree/master/kvm/archived)


### PR DESCRIPTION
I have been using the releases list recently to find out which patch releases are needed for CVE mitigation and it was hard to get this information from here.

My suggestion is to:
- remove archived releases from the list - it's growing fast and readability decreases 
- clearly mark deprecated - to make it easier for us to know which releases are deprecated and maybe it will be an additional push for customers to move 

In future, we could also mark EoL-ed releases here.