### PR TITLE
Deprecate AWS v12.1.0

### DIFF
--- a/aws/v12.1.0/release.yaml
+++ b/aws/v12.1.0/release.yaml
@@ -60,4 +60,4 @@ spec:
   - name: kubernetes
     version: 1.17.9
   date: "2020-08-05T12:00:00Z"
-  state: active
+  state: deprecated


### PR DESCRIPTION
Team 🧨  Firecracker is deprecating AWS release v12.1.0.

### Reason

We found that there will be issues upgrading from releases in the 11.5.1 minor version to 12.1.0. CloudFormation stacks will not be upgraded due to a problem in aws-operator's change detection and due to the fact that there is the same aws-operator version in both 11.5.1 and 12.1.0.

Release v12.1.1 will come out soon, including a fix for the change detection, with a new aws-operator version.