### PR TITLE
Add reference 0.1.0-2 to cert-operator for AWS v11.5.2

### DIFF
--- a/aws/v11.5.2/release.diff
+++ b/aws/v11.5.2/release.diff
@@ -50,6 +50,7 @@ spec:                                                              spec:
   - name: cert-operator                                              - name: cert-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 0.1.0                                                     version: 0.1.0
+    reference: 0.1.0-2                                                 reference: 0.1.0-2
   - name: cluster-operator                                           - name: cluster-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 2.3.2                                                     version: 2.3.2

--- a/aws/v11.5.2/release.yaml
+++ b/aws/v11.5.2/release.yaml
@@ -50,6 +50,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 0.1.0
+    reference: 0.1.0-2
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 2.3.2


### PR DESCRIPTION
To fix the problem that cert-operator 0.1.0 does not exist.