### PR TITLE
Rename flatcar to containerlinux in requests

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,16 +6,16 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/11307
     - name: "> 12.1.4, < 13.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 11.5.4, < 12.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 9.3.8, < 10.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -11,16 +11,16 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/11307
     - name: "> 12.1.0, < 13.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 12.0.2, < 12.1.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 11.4.0, < 12.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -14,26 +14,26 @@ releases:
               reason: kvm-operator work needed
     - name: "> 12.2.0, < 13.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 12.1.0, < 12.2.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 12.0.1, < 12.1.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 11.3.2, < 12.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "> 9.0.3, < 10.0.0"
       requests:
-        - name: flatcar
+        - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150


### PR DESCRIPTION
https://github.com/giantswarm/releases/pull/442 used an incorrect component name. This renames `flatcar` requests to `containerlinux`
