### PR TITLE
Deprecate AWS v12.1.4 release

### DIFF
--- a/aws/v12.1.4/release.yaml
+++ b/aws/v12.1.4/release.yaml
@@ -61,4 +61,4 @@ spec:
   - name: kubernetes
     version: 1.17.9
   date: "2020-08-28T15:00:00Z"
-  state: active
+  state: deprecated


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://github.com/giantswarm/giantswarm/blob/master/content/docs/product/requesting-changes-in-next-platform-release.md))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
AWS v12.1.4 release is now deprecated because we have AWS v12.2.0 release out. 