### PR TITLE
Added requests for next azure release

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -14,9 +14,6 @@ releases:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-        - name: external-dns
-          version: ">= 1.5.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/13671
     - name: "> 12.0.2, < 12.1.0"
       requests:
         - name: containerlinux
@@ -27,3 +24,13 @@ releases:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
+    - name: ">= 13.0.0"
+      requests:
+        - name: containerlinux
+          version: ">= 2605.6.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/9313
+        - name: external-dns
+          version: ">= 1.5.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/13671
+        - name: kubernetes
+          version: ">= 1.17.12"


### PR DESCRIPTION
Enforce kubernetes 1.17.12, external-dns 1.5.0 and newest flatcar for next azure release