### PR TITLE
Bumped request for k8s 1.17 on azure 13+

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -33,4 +33,4 @@ releases:
           version: ">= 1.5.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13671
         - name: kubernetes
-          version: ">= 1.17.12"
+          version: ">= 1.17.13"


### PR DESCRIPTION
k8s 1.17.13 is out with improvements for azure disk attachment.