### PR TITLE
Update requests.yaml

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -33,6 +33,7 @@ releases:
         - name: kubernetes
           version: ">= 1.17.13"
         - name: app-operator
-          version: ">= 2.3.2"
+          version: ">= 2.3.3"
+          issue: https://github.com/giantswarm/giantswarm/issues/13648
         - name: chart-operator
           version: ">= 2.3.5"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -33,6 +33,6 @@ releases:
         - name: kubernetes
           version: ">= 1.17.13"
         - name: app-operator
-          version: ">=2.3.2"
+          version: ">= 2.3.2"
         - name: chart-operator
-          version: ">=2.3.5"
+          version: ">= 2.3.5"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -4,6 +4,9 @@ releases:
         - name: calico
           version: ">= 3.10.4"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
+        - name: containerlinux
+          version: ">= 2512.4.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: "12.*"
       requests:
         - name: calico
@@ -19,11 +22,6 @@ releases:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 11.4.0, < 12.0.0"
-      requests:
-        - name: containerlinux
-          version: ">= 2512.4.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/13150
     - name: ">= 13.0.0"
       requests:
         - name: containerlinux
@@ -34,3 +32,7 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/13671
         - name: kubernetes
           version: ">= 1.17.13"
+        - name: app-operator
+          version: ">=2.3.2"
+        - name: chart-operator
+          version: ">=2.3.5"


### PR DESCRIPTION
Again - adding chart-operator and app-operator requests to Azure v13.0.0

My previous PR was open for too long and it's easier to recreate it. Ross please review again, sorry for inconvenience.

Chiara I saw you have a PR for this open, but you're adding it to version <13.0.0 and we don't plan any releases for that version. Please check if this is the right one, those apps will be updated in Azure v13.0.0.

<!--
If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
