### PR TITLE
hotfix; KVM 12.3.0 upgarding app-operator into 2.3.4

### DIFF
--- a/kvm/v12.3.0/README.md
+++ b/kvm/v12.3.0/README.md
@@ -26,7 +26,7 @@ Please ensure cluster is on [KVM 12.1.x](https://github.com/giantswarm/releases/
 
 ## Change details
 
-### app-operator [v2.3.3](https://github.com/giantswarm/app-operator/blob/master/CHANGELOG.md#233---2020-10-15)
+### app-operator [v2.3.4](https://github.com/giantswarm/app-operator/blob/master/CHANGELOG.md#234---2020-10-16)
 ### chart-operator [v2.3.5](https://github.com/giantswarm/chart-operator/blob/master/CHANGELOG.md#233---2020-09-29)
 - Updated Helm to [v3.3.4](https://github.com/helm/helm/releases/tag/v3.3.4).
 

--- a/kvm/v12.3.0/release.diff
+++ b/kvm/v12.3.0/release.diff
@@ -25,7 +25,7 @@ spec:                                                              spec:
     version: 1.3.0                                                     version: 1.3.0
   components:                                                        components:
   - name: app-operator                                               - name: app-operator
-    version: 1.0.0                                              |      version: 2.3.3
+    version: 1.0.0                                              |      version: 2.3.4
                                                                 >      releaseOperatorDeploy: true
   - name: calico                                                     - name: calico
     version: 3.14.1                                                    version: 3.14.1

--- a/kvm/v12.3.0/release.yaml
+++ b/kvm/v12.3.0/release.yaml
@@ -25,7 +25,7 @@ spec:
     version: 1.3.0
   components:
   - name: app-operator
-    version: 2.3.3
+    version: 2.3.4
     releaseOperatorDeploy: true
   - name: calico
     version: 3.14.1


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

We just release a new app-operator with hotfix 2.3.4, and we don't introduce 12.3.0 to any customers yet.

So I think this is safe to merge. 