### PR TITLE
Request newer versions of app- and chart-operator for AWS

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -7,6 +7,12 @@ releases:
         - name: external-dns
           version: ">= 1.5.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13671
+        - name: app-operator
+          version: ">= 2.3.3"
+          issue: https://github.com/giantswarm/giantswarm/issues/13648
+        - name: chart-operator
+          version: ">= 2.3.5" 
+          issue: https://github.com/giantswarm/giantswarm/issues/13677     
     - name: "> 12.0.0, < 13.0.0"
       requests:
         - name: calico

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,12 @@
 releases:
+    - name: "> 12.5.0, < 13.0.0"
+      requests:
+        - name: app-operator
+          version: ">= 2.3.3"
+          issue: https://github.com/giantswarm/giantswarm/issues/13648
+        - name: chart-operator
+          version: ">= 2.3.5"
+          issue: https://github.com/giantswarm/giantswarm/issues/13677
     - name: "> 12.3.0, < 13.0.0"
       requests:
         - name: cert-manager
@@ -7,12 +15,6 @@ releases:
         - name: external-dns
           version: ">= 1.5.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13671
-        - name: app-operator
-          version: ">= 2.3.3"
-          issue: https://github.com/giantswarm/giantswarm/issues/13648
-        - name: chart-operator
-          version: ">= 2.3.5" 
-          issue: https://github.com/giantswarm/giantswarm/issues/13677     
     - name: "> 12.0.0, < 13.0.0"
       requests:
         - name: calico


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13328

Requesting latest versions of both operators. This also upgrades Helm to its latest release (v3.3.4).

