### PR TITLE
Hotfix; Update all cluster-operator 0.23.17 dependencies to 0.23.18

### DIFF
--- a/aws/v9.3.9/README.md
+++ b/aws/v9.3.9/README.md
@@ -8,7 +8,7 @@ Please upgrade all older clusters to this version in order to prevent possible d
 
 ## Change details
 
-### cluster-operator [0.23.17](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02317---2020-10-19)
+### cluster-operator [0.23.18](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02318---2020-10-21)
 
 ### Changed
 

--- a/aws/v9.3.9/release.yaml
+++ b/aws/v9.3.9/release.yaml
@@ -43,7 +43,7 @@ spec:
     version: 0.1.0
   - name: cluster-operator
     releaseOperatorDeploy: true
-    version: 0.23.17
+    version: 0.23.18
   - name: containerlinux
     version: 2512.3.0
   - name: etcd

--- a/azure/v12.1.1/README.md
+++ b/azure/v12.1.1/README.md
@@ -20,7 +20,7 @@ Please persist this note and the above, until all customers are on Azure v12.1.x
 
 ## Change details
 
-### cluster-operator [0.23.17](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02317---2020-10-19)
+### cluster-operator [0.23.18](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02318---2020-10-21)
 - Remove all chartconfig migration logic that caused accidental deletion and is no longer needed.
 
 ### app-operator [2.3.5](https://github.com/giantswarm/app-operator/blob/master/CHANGELOG.md#235---2020-10-20)

--- a/azure/v12.1.1/release.yaml
+++ b/azure/v12.1.1/release.yaml
@@ -39,7 +39,7 @@ spec:
     reference: 0.1.0-2
   - name: cluster-operator
     releaseOperatorDeploy: true
-    version: 0.23.17
+    version: 0.23.18
   - name: kubernetes
     version: 1.17.9
   - name: containerlinux

--- a/kvm/v12.3.1/README.md
+++ b/kvm/v12.3.1/README.md
@@ -22,7 +22,7 @@ Please ensure cluster is on [KVM 12.1.x](https://github.com/giantswarm/releases/
 
 ## Change details
 
-### cluster-operator [0.23.17](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02317---2020-10-19)
+### cluster-operator [0.23.18](https://github.com/giantswarm/cluster-operator/blob/legacy/CHANGELOG.md#02318---2020-10-21)
 - Remove all chartconfig migration logic that caused accidental deletion and is no longer needed.
 
 ### app-operator [2.3.5](https://github.com/giantswarm/app-operator/blob/master/CHANGELOG.md#235---2020-10-20)

--- a/kvm/v12.3.1/release.yaml
+++ b/kvm/v12.3.1/release.yaml
@@ -35,7 +35,7 @@ spec:
     reference: 0.1.0-2
   - name: cluster-operator
     releaseOperatorDeploy: true
-    version: 0.23.17
+    version: 0.23.18
   - name: containerlinux
     version: 2512.5.0
   - name: etcd


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

There are `MultipleOperatorsRunningSameBundleVersion` alerts from azure, this is because I didn't update project.go in cluster-operator. Going to replace it with 0.23.18.
