### PR TITLE
Release AWS 12.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Swarm control planes.
   - v12.5
     - [v12.5.0](https://github.com/giantswarm/releases/tree/master/aws/v12.5.0)
     - [v12.5.1](https://github.com/giantswarm/releases/tree/master/aws/v12.5.1)
+    - [v12.5.2](https://github.com/giantswarm/releases/tree/master/aws/v12.5.2)
   - v12.4
     - [v12.4.0](https://github.com/giantswarm/releases/tree/master/aws/v12.4.0)
   - v12.3

--- a/aws/kustomization.yaml
+++ b/aws/kustomization.yaml
@@ -24,5 +24,6 @@ resources:
 - v12.4.0
 - v12.5.0
 - v12.5.1
+- v12.5.2
 transformers:
 - releaseNotesTransformer.yaml

--- a/aws/v12.5.1/release.yaml
+++ b/aws/v12.5.1/release.yaml
@@ -64,6 +64,6 @@ spec:
   - name: kubernetes
     version: 1.17.13
   date: "2020-10-22T06:40:57Z"
-  state: active
+  state: deprecated
 status:
   ready: false

--- a/aws/v12.5.2/README.md
+++ b/aws/v12.5.2/README.md
@@ -1,0 +1,13 @@
+# :zap: Giant Swarm Release v12.5.2 for AWS :zap:
+
+This release fixes an issue that crashing app-operator when handling cluster deletion.
+
+## Change details
+
+
+
+### app-operator [2.3.5](https://github.com/giantswarm/app-operator/releases/tag/v2.3.5)
+
+#### Fixed
+- Skip removing finalizer for chart-operator chart CR if its not present.
+- Skip deleting chart-operator in case of cluster deletion.

--- a/aws/v12.5.2/README.md
+++ b/aws/v12.5.2/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v12.5.2 for AWS :zap:
 
-This release fixes an issue that crashing app-operator when handling cluster deletion.
+This release fixes an issue that causes app-operator to crash when handling cluster deletion.
 
 ## Change details
 

--- a/aws/v12.5.2/kustomization.yaml
+++ b/aws/v12.5.2/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/aws/v12.5.2/release.diff
+++ b/aws/v12.5.2/release.diff
@@ -1,0 +1,69 @@
+# Generated with:                                                  # Generated with:
+# devctl release create --name 12.5.1 --provider aws --base 12.    # devctl release create --name 12.5.1 --provider aws --base 12.
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  annotations:                                                       annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp        giantswarm.io/docs: https://docs.giantswarm.io/reference/cp
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v12.5.1                                                 |    name: v12.5.2
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 1.2.3                                                     version: 1.2.3
+  - componentVersion: 1.0.2                                          - componentVersion: 1.0.2
+    name: cert-manager                                                 name: cert-manager
+    version: 2.3.0                                                     version: 2.3.0
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.3.5                                                     version: 2.3.5
+  - componentVersion: 1.17.3                                         - componentVersion: 1.17.3
+    name: cluster-autoscaler                                           name: cluster-autoscaler
+    version: 1.17.3                                                    version: 1.17.3
+  - componentVersion: 1.6.5                                          - componentVersion: 1.6.5
+    name: coredns                                                      name: coredns
+    version: 1.2.0                                                     version: 1.2.0
+  - componentVersion: 0.7.4                                          - componentVersion: 0.7.4
+    name: external-dns                                                 name: external-dns
+    version: 1.5.0                                                     version: 1.5.0
+  - componentVersion: 3.6.0                                          - componentVersion: 3.6.0
+    name: kiam                                                         name: kiam
+    version: 1.5.0                                                     version: 1.5.0
+  - componentVersion: 1.9.7                                          - componentVersion: 1.9.7
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.1.1                                                     version: 1.1.1
+  - componentVersion: 0.3.6                                          - componentVersion: 0.3.6
+    name: metrics-server                                               name: metrics-server
+    version: 1.1.1                                                     version: 1.1.1
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.9.0                                                     version: 1.9.0
+  - componentVersion: 1.0.1                                          - componentVersion: 1.0.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.3.0                                                     version: 1.3.0
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 2.3.3                                              |      version: 2.3.5
+  - name: aws-cni                                                    - name: aws-cni
+    version: 1.7.3                                                     version: 1.7.3
+  - name: aws-operator                                               - name: aws-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 9.1.3                                                     version: 9.1.3
+  - name: calico                                                     - name: calico
+    version: 3.15.3                                                    version: 3.15.3
+  - name: cert-operator                                              - name: cert-operator
+    reference: 0.1.0-2                                                 reference: 0.1.0-2
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 0.1.0                                                     version: 0.1.0
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 3.3.1                                                     version: 3.3.1
+  - name: containerlinux                                             - name: containerlinux
+    version: 2512.5.0                                                  version: 2512.5.0
+  - name: etcd                                                       - name: etcd
+    version: 3.4.13                                                    version: 3.4.13
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.17.13                                                   version: 1.17.13
+  date: "2020-10-22T06:40:57Z"                                  |    date: "2020-10-27T16:40:57Z"
+  state: active                                                      state: active
+status:                                                            status:
+  ready: false                                                       ready: false

--- a/aws/v12.5.2/release.yaml
+++ b/aws/v12.5.2/release.yaml
@@ -1,0 +1,69 @@
+# Generated with:
+# devctl release create --name 12.5.1 --provider aws --base 12.5.0 --component aws-operator@9.1.3 --app app-operator@2.3.3 --app chart-operator@2.3.5 --overwrite
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  creationTimestamp: null
+  name: v12.5.2
+spec:
+  apps:
+  - name: cert-exporter
+    version: 1.2.3
+  - componentVersion: 1.0.2
+    name: cert-manager
+    version: 2.3.0
+  - name: chart-operator
+    version: 2.3.5
+  - componentVersion: 1.17.3
+    name: cluster-autoscaler
+    version: 1.17.3
+  - componentVersion: 1.6.5
+    name: coredns
+    version: 1.2.0
+  - componentVersion: 0.7.4
+    name: external-dns
+    version: 1.5.0
+  - componentVersion: 3.6.0
+    name: kiam
+    version: 1.5.0
+  - componentVersion: 1.9.7
+    name: kube-state-metrics
+    version: 1.1.1
+  - componentVersion: 0.3.6
+    name: metrics-server
+    version: 1.1.1
+  - name: net-exporter
+    version: 1.9.0
+  - componentVersion: 1.0.1
+    name: node-exporter
+    version: 1.3.0
+  components:
+  - name: app-operator
+    releaseOperatorDeploy: true
+    version: 2.3.5
+  - name: aws-cni
+    version: 1.7.3
+  - name: aws-operator
+    releaseOperatorDeploy: true
+    version: 9.1.3
+  - name: calico
+    version: 3.15.3
+  - name: cert-operator
+    reference: 0.1.0-2
+    releaseOperatorDeploy: true
+    version: 0.1.0
+  - name: cluster-operator
+    releaseOperatorDeploy: true
+    version: 3.3.1
+  - name: containerlinux
+    version: 2512.5.0
+  - name: etcd
+    version: 3.4.13
+  - name: kubernetes
+    version: 1.17.13
+  date: "2020-10-27T16:40:57Z"
+  state: active
+status:
+  ready: false


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
Toward https://github.com/giantswarm/giantswarm/issues/13992

When app-operator 2.3.3+ handling tenant cluster deletion in aws platform release, `app` controller has crashed due to an error. 

This is a patch release to fix that issue. 
