### PR TITLE
Revert flatcar requirement

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -28,7 +28,7 @@ releases:
     - name: ">= 13.0.0"
       requests:
         - name: containerlinux
-          version: ">= 2605.6.0"
+          version: ">= 2512.5.0"
           issue: https://github.com/giantswarm/giantswarm/issues/9313
         - name: external-dns
           version: ">= 1.5.0"


### PR DESCRIPTION
During testing we realized that `2605` causes issues on several levels. 