### PR TITLE
Add required status fields to KVM release CRs

### DIFF
--- a/kvm/v11.2.0/release.yaml
+++ b/kvm/v11.2.0/release.yaml
@@ -52,3 +52,6 @@ spec:
     version: 3.10.0
   date: "2020-02-26T12:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v11.2.1/release.yaml
+++ b/kvm/v11.2.1/release.yaml
@@ -52,3 +52,6 @@ spec:
     version: 3.10.0
   date: "2020-03-23T12:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v11.3.0/release.yaml
+++ b/kvm/v11.3.0/release.yaml
@@ -53,3 +53,6 @@ spec:
     version: 3.11.0
   date: "2020-04-27T12:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v11.3.1/release.yaml
+++ b/kvm/v11.3.1/release.yaml
@@ -52,3 +52,6 @@ spec:
     version: 3.11.1
   date: "2020-05-04T12:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v11.3.2/release.yaml
+++ b/kvm/v11.3.2/release.yaml
@@ -52,3 +52,6 @@ spec:
     version: 3.11.1
   date: "2020-06-11T15:00:00Z"
   state: active
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.0.0/release.yaml
+++ b/kvm/v12.0.0/release.yaml
@@ -51,3 +51,6 @@ spec:
     version: 3.12.0
   date: "2020-07-16T12:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.0.1/release.yaml
+++ b/kvm/v12.0.1/release.yaml
@@ -51,3 +51,6 @@ spec:
     version: 3.12.0
   date: "2020-07-21T15:00:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.1.0/release.yaml
+++ b/kvm/v12.1.0/release.yaml
@@ -51,3 +51,6 @@ spec:
     version: 3.12.1
   date: "2020-07-29T15:00:00Z"
   state: active
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.2.0/release.yaml
+++ b/kvm/v12.2.0/release.yaml
@@ -48,3 +48,6 @@ spec:
     version: 3.12.1
   date: "2020-07-31T15:00:00Z"
   state: active
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.3.0/release.yaml
+++ b/kvm/v12.3.0/release.yaml
@@ -49,3 +49,6 @@ spec:
     version: 3.12.2
   date: "2020-10-15T17:30:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.3.1/release.yaml
+++ b/kvm/v12.3.1/release.yaml
@@ -49,3 +49,6 @@ spec:
     version: 3.12.2
   date: "2020-10-21T16:30:00Z"
   state: deprecated
+status:
+  inUse: false
+  ready: false

--- a/kvm/v12.3.2/release.yaml
+++ b/kvm/v12.3.2/release.yaml
@@ -49,3 +49,6 @@ spec:
     version: 3.13.0
   date: "2020-11-02T10:50:00Z"
   state: active
+status:
+  inUse: false
+  ready: false

--- a/kvm/v9.0.3/release.yaml
+++ b/kvm/v9.0.3/release.yaml
@@ -52,3 +52,6 @@ spec:
     version: 3.9.2
   date: "2020-05-13T19:00:00Z"
   state: active
+status:
+  inUse: false
+  ready: false


### PR DESCRIPTION
 releases-kvm-unique is failed on dragon due to missing required fields in the release CR.

```
kg get app releases-kvm-unique -o yaml | yq .status
{
  "appVersion": "",
  "release": {
    "lastDeployed": null,
    "reason": "Upgrade \"releases-kvm-unique\" failed: cannot patch \"v11.2.0\" with kind Release: Release.release.giantswarm.io \"v11.2.0\" is invalid: status.inUse: Required value && cannot patch \"v11.2.1\" with kind Release: Release.release.giantswarm.io 
...
```

This fixes it by adding the missing fields as suggested by @tfussell in https://gigantic.slack.com/archives/C03CPNRTS/p1605170707041300?thread_ts=1605170388.040800&cid=C03CPNRTS

