### PR TITLE
Request: update cert-manager in next AWS release

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: "> 12.6.0, < 13.0.0"
+      requests:
+        - name: cert-manager
+          version: ">= 2.3.2"
+          issue: https://github.com/giantswarm/giantswarm/issues/14284
     - name: "> 12.5.0, < 13.0.0"
       requests:
         - name: app-operator


### PR DESCRIPTION
Towards giantswarm/giantswarm/issues/14284

This PR includes the latest upstream release of cert-manager for AWS.
