### PR TITLE
Update terminology to "tenant cluster release"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/releases.svg?style=shield)](https://circleci.com/gh/giantswarm/releases)
 
-# Giant Swarm Releases
+# Giant Swarm Tenant Cluster Releases
 
-This repository contains Giant Swarm releases and changelogs. Releases can be in
+This repository contains tenant cluster release notes and changelogs.
+
+Tenant cluster releases can be in
 different states, namely `active`, `deprecated` and `wip`. With pull requests
-merged to the `master` branch releases get automatically deployed to all Giant
-Swarm control planes.
+merged to the `master` branch, tenant cluster releases get automatically deployed
+to all Giant Swarm installations.
 
 ## AWS
 - v12

--- a/aws/archived/v10.1.0/README.md
+++ b/aws/archived/v10.1.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 10.1.0 for AWS :zap:
+# :zap: Tenant Cluster Release 10.1.0 for AWS :zap:
 
 We are pleased to announce that the new release v10.1.0 contains the much anticipated Node Pools feature.
 

--- a/aws/archived/v10.1.1/README.md
+++ b/aws/archived/v10.1.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 10.1.1 for AWS :zap:
+# :zap: Tenant Cluster Release 10.1.1 for AWS :zap:
 
 This Node Pools release fixes a problem with CoreDNS in clusters using custom
 cluster IP ranges. Additionally, CPU limits have been removed from multiple

--- a/aws/archived/v10.1.2/README.md
+++ b/aws/archived/v10.1.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 10.1.2 for AWS :zap:
+# :zap: Tenant Cluster Release 10.1.2 for AWS :zap:
 
 This release fixes a problem with the cluster role for chart-operator, which is responsible for installing and updating Managed Apps. The changes affect only Managed Apps and upgrading to this release will not cause cluster nodes to be rolled. **To prevent encountering problems when installing or updating an app, please upgrade to this release.**
 

--- a/aws/archived/v11.0.0/README.md
+++ b/aws/archived/v11.0.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 11.0.0 for AWS :zap:
+# :zap: Tenant Cluster Release 11.0.0 for AWS :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition to this update, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/aws/archived/v11.0.1/README.md
+++ b/aws/archived/v11.0.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 11.0.1 for AWS :zap:
+# :zap: Tenant Cluster Release 11.0.1 for AWS :zap:
 
 This release fixes an issue with network traffic between node pools in 10.x and
 11.x clusters reported on the 5th of February 2020. **To prevent encountering

--- a/aws/archived/v11.1.2/README.md
+++ b/aws/archived/v11.1.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.1.2 for AWS :zap:
+# :zap: Tenant Cluster Release v11.1.2 for AWS :zap:
 
 __Note:__ Upgrading to this release from any release prior 11.1.1 will cause a network downtime due to the network-related changes coming with the switch from Calico CNI to AWS CNI.
 

--- a/aws/archived/v11.1.3/README.md
+++ b/aws/archived/v11.1.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.1.3 for AWS :zap:
+# :zap: Tenant Cluster Release v11.1.3 for AWS :zap:
 
 __Note:__ Upgrading to this release from any release prior v11.1.1 will cause a network downtime due to the network-related changes coming with the switch from Calico CNI to AWS CNI.
 

--- a/aws/archived/v11.1.4/README.md
+++ b/aws/archived/v11.1.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.1.4 for AWS :zap:
+# :zap: Tenant Cluster Release v11.1.4 for AWS :zap:
 
 This release makes the pod CIDR of a tenant cluster configurable via the control plane Kubernetes API. When using this option to avoid IP address overlap, this enables VPC peering between tenant clusters of the same installation.
 

--- a/aws/archived/v11.2.0/README.md
+++ b/aws/archived/v11.2.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.2.0 for AWS :zap:
+# :zap: Tenant Cluster Release v11.2.0 for AWS :zap:
 
 This release adds support for [EC2 Spot Instances](https://aws.amazon.com/ec2/spot/) in your node pools to allow reduction of your compute resource cost. Find details on how to use spot instances [in our node pools documentation](https://docs.giantswarm.io/basics/nodepools/#instance-distribution).
 

--- a/aws/archived/v11.2.1/README.md
+++ b/aws/archived/v11.2.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.2.1 for AWS :zap:
+# :zap: Tenant Cluster Release v11.2.1 for AWS :zap:
 
 This release fixes a problem that could occur when upgrading from an older release to a v11.2.x release.
 

--- a/aws/archived/v11.3.0/README.md
+++ b/aws/archived/v11.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.3.0 for AWS :zap:
+## :zap: Tenant Cluster Release 11.3.0 for AWS :zap:
 
 This release includes Kubernetes v1.16.9 as well as reliability and user experience improvements.
 

--- a/aws/archived/v11.3.2/README.md
+++ b/aws/archived/v11.3.2/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release v11.3.2 for AWS :zap:
+## :zap: Tenant Cluster Release v11.3.2 for AWS :zap:
 
 **If you are upgrading from 11.3.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v11.4.0/README.md
+++ b/aws/archived/v11.4.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.4.0 for AWS :zap:
+# :zap: Tenant Cluster Release v11.4.0 for AWS :zap:
 
 This release introduces [high availability Kubernetes masters](https://docs.giantswarm.io/basics/ha-masters/),
 which means that clusters can have three master nodes in different availability zones

--- a/aws/archived/v11.4.1/README.md
+++ b/aws/archived/v11.4.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.4.1 for AWS :zap:
+# :zap: Tenant Cluster Release v11.4.1 for AWS :zap:
 
 This release re-activates the recent AWS [release of high-availability (HA) masters](https://github.com/giantswarm/releases/tree/master/aws/v11.4.0), fixing OIDC configurations issues.
 

--- a/aws/archived/v11.5.3/README.md
+++ b/aws/archived/v11.5.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.3 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.3 for AWS :zap:
 
 This release provides a new cluster-operator which fixes preventing release upgrade when reference id does not align with the G8sControlPlane id or MachineDeployment id and cluster status condition not being changed during cluster upgrade.
 

--- a/aws/archived/v11.6.0/README.md
+++ b/aws/archived/v11.6.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.6.0 for AWS :zap:
+# :zap: Tenant Cluster Release v11.6.0 for AWS :zap:
 
 This release updates Cert-Manager to `1.1.0` to add support for Route53 using Kiam annotation.
 

--- a/aws/archived/v12.0.0/README.md
+++ b/aws/archived/v12.0.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.0.0 for AWS :zap:
+# :zap: Tenant Cluster Release v12.0.0 for AWS :zap:
 
 This is the first release to support Kubernetes 1.17 on AWS.
 

--- a/aws/archived/v12.1.1/README.md
+++ b/aws/archived/v12.1.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.1 for AWS :zap:
+# :zap: Tenant Cluster Release v12.1.1 for AWS :zap:
 
 This release provides new aws-operator version with reliability improvements and upgrades kiam-app from v1.3.1 to v1.4.0, to align with Cert Manager v0.16.1 API changes.
 

--- a/aws/archived/v12.1.2/README.md
+++ b/aws/archived/v12.1.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.2 for AWS :zap:
+# :zap: Tenant Cluster Release v12.1.2 for AWS :zap:
 
 This release upgrades external-dns app to v1.3.0.
 

--- a/aws/archived/v12.1.3/README.md
+++ b/aws/archived/v12.1.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.3 for AWS :zap:
+# :zap: Tenant Cluster Release v12.1.3 for AWS :zap:
 
 This release provides a new cluster-operator which fixes the issue that prevented release upgrade when reference id does not align with the G8sControlPlane id or MachineDeployment id and cluster status condition not being changed during cluster upgrade. 
 

--- a/aws/archived/v12.2.0/README.md
+++ b/aws/archived/v12.2.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.2.0 for AWS :zap:
+# :zap: Tenant Cluster Release v12.2.0 for AWS :zap:
 
 This release includes a number of stability and security fixes, improvements, and picks up various component and app upgrades.
 

--- a/aws/archived/v12.4.0/README.md
+++ b/aws/archived/v12.4.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.4.0 for AWS :zap:
+## :zap:  Tenant Cluster Release 12.4.0 for AWS :zap:
 
 This release upgrades cert-manager-app to `v2.3.0` which brings new patch version `v1.0.2` of the upstream project. 
 

--- a/aws/archived/v8.2.0/README.md
+++ b/aws/archived/v8.2.0/README.md
@@ -1,1 +1,1 @@
-# :zap:  Giant Swarm Release 8.2.0 for AWS :zap:
+# :zap:  Tenant Cluster Release 8.2.0 for AWS :zap:

--- a/aws/archived/v8.5.0/README.md
+++ b/aws/archived/v8.5.0/README.md
@@ -1,4 +1,4 @@
-# :zap:  Giant Swarm Release 8.5.0 for AWS :zap:
+# :zap:  Tenant Cluster Release 8.5.0 for AWS :zap:
 
 **IMPORTANT**: Due to cgroup restructure (change can be found [here](https://github.com/giantswarm/k8scloudconfig/pull/564)) and more resource reservation for core components, we are now switching to bigger master instance types (from m4.large to m4.xlarge). This adds some room for additional workload scheduling on master.
 This release also contains multiple fixes to the private/public hosted zones which were altered in the previous release. In-Cluster communication between services and the Kubernetes API should now stay inside the VPC without issues.

--- a/aws/archived/v9.0.0/README.md
+++ b/aws/archived/v9.0.0/README.md
@@ -1,4 +1,4 @@
-# :zap:  Giant Swarm Release 9.0.0 for AWS :zap:
+# :zap:  Tenant Cluster Release 9.0.0 for AWS :zap:
 
 ### Kubernetes v1.15.5
 - Updated from v1.14.6 - [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes)

--- a/aws/archived/v9.0.1/README.md
+++ b/aws/archived/v9.0.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.0.1 for AWS :zap:
+# :zap: Tenant Cluster Release 9.0.1 for AWS :zap:
 
 This release includes Kubernetes v1.15.11 as well as some reliability and user experience improvements.
 We highly recommend you to upgrade to this release if you want to continue running on Kubernetes 1.15 for now.

--- a/aws/archived/v9.0.2/README.md
+++ b/aws/archived/v9.0.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.0.2 for AWS :zap:
+# :zap: Tenant Cluster Release 9.0.2 for AWS :zap:
 
 **If you are upgrading from 9.0.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.0.3/README.md
+++ b/aws/archived/v9.0.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.0.3 for AWS :zap:
+# :zap: Tenant Cluster Release 9.0.3 for AWS :zap:
 
 **If you are upgrading from 9.0.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.0.4/README.md
+++ b/aws/archived/v9.0.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.0.4 for AWS :zap:
+# :zap: Tenant Cluster Release 9.0.4 for AWS :zap:
 
 **Note** If you are upgrading from 8.5.0 or 9.0.0:
 

--- a/aws/archived/v9.0.5/README.md
+++ b/aws/archived/v9.0.5/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.0.5 for AWS :zap:
+# :zap: Tenant Cluster Release v9.0.5 for AWS :zap:
 
 This release fixes a rare bug that would prevent the NGINX IC from being installed on a new cluster.
 
@@ -8,7 +8,7 @@ Solution Engineers have already done the manual fix for affected customers.
 
 It also modifies release templates to support the coming upgrade to Helm 3.
 
-**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Giant Swarm Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
+**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Tenant Cluster Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
 
 **Note for future 9.0.x releases:** Please include this note and the one above in all future 9.0.x releases.
 

--- a/aws/archived/v9.0.7/README.md
+++ b/aws/archived/v9.0.7/README.md
@@ -1,8 +1,8 @@
-## :zap: Giant Swarm Release 9.0.7 for AWS :zap:
+## :zap: Tenant Cluster Release 9.0.7 for AWS :zap:
 
 This release updates managed apps to the latest releases.
 
-**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Giant Swarm Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
+**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Tenant Cluster Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
 
 **Note for future 9.0.x releases:** Please include this note and the one above in all future 9.0.x releases.
 

--- a/aws/archived/v9.1.0/README.md
+++ b/aws/archived/v9.1.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.1.0 for AWS :zap:
+# :zap: Tenant Cluster Release 9.1.0 for AWS :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition to this update, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/aws/archived/v9.2.0/README.md
+++ b/aws/archived/v9.2.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.0 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.0 for AWS :zap:
 
 **If you are upgrading from 9.1.0, upgrading to this release merely updates the app. It will *not* roll your nodes.**
 

--- a/aws/archived/v9.2.1/README.md
+++ b/aws/archived/v9.2.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.1 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.1 for AWS :zap:
 
 **With this release, horizontal pod autoscaling (HPA) is enabled by default for NGINX Ingress Controller (NGINX IC) on selected cluster profiles.**
 

--- a/aws/archived/v9.2.2/README.md
+++ b/aws/archived/v9.2.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.2 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.2 for AWS :zap:
 
 **If you are upgrading from 9.2.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.2.3/README.md
+++ b/aws/archived/v9.2.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.3 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.3 for AWS :zap:
 
 **If you are upgrading from 9.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.2.4/README.md
+++ b/aws/archived/v9.2.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.4 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.4 for AWS :zap:
 
 **If you are upgrading from 9.2.3, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.2.5/README.md
+++ b/aws/archived/v9.2.5/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 9.2.5 for AWS :zap:
+# :zap: Tenant Cluster Release 9.2.5 for AWS :zap:
 
 **If you are upgrading from 9.2.4, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.2.6/README.md
+++ b/aws/archived/v9.2.6/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.2.6 for AWS :zap:
+# :zap: Tenant Cluster Release v9.2.6 for AWS :zap:
 
 This release fixes a problem in aws-operator communicating to the Control Plane Kubernetes API.
 

--- a/aws/archived/v9.3.0/README.md
+++ b/aws/archived/v9.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.3.0 for AWS :zap:
+## :zap: Tenant Cluster Release 9.3.0 for AWS :zap:
 
 This release includes Kubernetes v1.16.9 as well as reliability and user experience improvements.
 

--- a/aws/archived/v9.3.1/README.md
+++ b/aws/archived/v9.3.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.1 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.1 for AWS :zap:
 
 This release fixes a rare bug that would prevent the NGINX IC from being installed on a new cluster.
 

--- a/aws/archived/v9.3.3/README.md
+++ b/aws/archived/v9.3.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.3 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.3 for AWS :zap:
 
 **If you are upgrading from 9.3.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/archived/v9.3.4/README.md
+++ b/aws/archived/v9.3.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.4 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.4 for AWS :zap:
 
 This release makes security fixes for 2 CVEs:
 - IPv6 rogue router advertisement vulnerability [CVE-2020-13597](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13597)

--- a/aws/archived/v9.3.5/README.md
+++ b/aws/archived/v9.3.5/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.5 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.5 for AWS :zap:
 
 This release updates NGINX Ingress Controller to the latest upstream release.
 Most importantly, it includes a fix for a regression introduced in the previous upstream release related to `use-regex` and `rewrite` annotations.

--- a/aws/archived/v9.3.6/README.md
+++ b/aws/archived/v9.3.6/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.6 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.6 for AWS :zap:
 
 This release updates managed apps to the latest releases, updates Calico to version `3.13.4`, and Flatcar Container Linux to `2512.2.1`.
 

--- a/aws/v11.3.1/README.md
+++ b/aws/v11.3.1/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release v11.3.1 for AWS :zap:
+## :zap: Tenant Cluster Release v11.3.1 for AWS :zap:
 
 This release provides fixes for a race condition seen in some upgrades to v11.2.x when allocating the IP address for the master node.
 

--- a/aws/v11.3.3/README.md
+++ b/aws/v11.3.3/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release v11.3.3 for AWS :zap:
+## :zap: Tenant Cluster Release v11.3.3 for AWS :zap:
 
 **If you are upgrading from 11.3.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/v11.5.0/README.md
+++ b/aws/v11.5.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.0 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.0 for AWS :zap:
 
 This release includes a number of fixes, improvements, and picks up various component and app upgrades.
 

--- a/aws/v11.5.1/README.md
+++ b/aws/v11.5.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.1 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.1 for AWS :zap:
 
 This patch release fixes two known issues found in our v11.5.0 release:
 

--- a/aws/v11.5.2/README.md
+++ b/aws/v11.5.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.2 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.2 for AWS :zap:
 
 This release provides a new aws-operator which is fixing an issue with NetworkPolicies and custom Pod CIDRs.
 

--- a/aws/v11.5.4/README.md
+++ b/aws/v11.5.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.4 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.4 for AWS :zap:
 
 This release upgrades external-dns app to v1.4.0 to improve observability.
 

--- a/aws/v11.5.5/README.md
+++ b/aws/v11.5.5/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.5 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.5 for AWS :zap:
 
 This release upgrades:
 * aws-cni to v1.7.3 to fix stability issues.

--- a/aws/v11.5.6/README.md
+++ b/aws/v11.5.6/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.5.6 for AWS :zap:
+# :zap: Tenant Cluster Release v11.5.6 for AWS :zap:
 
 This release updates Flatcar containerlinux images for AWS CN.
 

--- a/aws/v11.6.1/README.md
+++ b/aws/v11.6.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v11.6.1 for AWS :zap:
+# :zap: Tenant Cluster Release v11.6.1 for AWS :zap:
 
 **Nodes will be rolled during upgrade to this version.**
 

--- a/aws/v12.1.0/README.md
+++ b/aws/v12.1.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.0 for AWS :zap:
+# :zap: Tenant Cluster Release v12.1.0 for AWS :zap:
 
 **If you are upgrading from 12.0.0, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/v12.1.0/announcement.md
+++ b/aws/v12.1.0/announcement.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 12.1.0 for AWS :zap:
+# :zap: Tenant Cluster Release 12.1.0 for AWS :zap:
 
 This release upgrades Cert Manager from upstream v0.9.0 to v0.15.2.
 

--- a/aws/v12.1.4/README.md
+++ b/aws/v12.1.4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.4 for AWS :zap:
+# :zap: Tenant Cluster Release v12.1.4 for AWS :zap:
 
 This release upgrades external-dns app to v1.4.0 to improve observability.
 

--- a/aws/v12.3.0/README.md
+++ b/aws/v12.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.3.0 for AWS :zap:
+## :zap:  Tenant Cluster Release 12.3.0 for AWS :zap:
 
 **If you are upgrading from 12.2.0, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/v12.5.0/README.md
+++ b/aws/v12.5.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.5.0 for AWS :zap:
+# :zap: Tenant Cluster Release v12.5.0 for AWS :zap:
 
 This release offers the possibility to add additional Network Pools to the Control Plane and flexibly choose the IP range for new Tenant Clusters from these pools. It also upgrades Kubernetes to v1.17.13.
 

--- a/aws/v12.5.1/README.md
+++ b/aws/v12.5.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.5.1 for AWS :zap:
+# :zap: Tenant Cluster Release v12.5.1 for AWS :zap:
 
 This release fixes an issue that prevented upgrades of the Control Planes.
 

--- a/aws/v12.5.2/README.md
+++ b/aws/v12.5.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.5.2 for AWS :zap:
+# :zap: Tenant Cluster Release v12.5.2 for AWS :zap:
 
 **If you are upgrading from 12.5.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/aws/v12.6.0/README.md
+++ b/aws/v12.6.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.6.0 for AWS :zap:
+# :zap: Tenant Cluster Release v12.6.0 for AWS :zap:
 
 This patch release prevents an issue with QPS (Queries per Second) limits introduced by Docker Hub. Also, it solves a corner case scenario during ETCD mouting time.
 

--- a/aws/v9.0.10/README.md
+++ b/aws/v9.0.10/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.0.10 for AWS :zap:
+# :zap: Tenant Cluster Release v9.0.10 for AWS :zap:
 
 This release provides a new aws-operator which is fixing an issue with overlapping networks when creating legacy clusters together with node pools clusters.
 

--- a/aws/v9.0.6/README.md
+++ b/aws/v9.0.6/README.md
@@ -1,11 +1,11 @@
-## :zap: Giant Swarm Release 9.0.6 for AWS :zap:
+## :zap: Tenant Cluster Release 9.0.6 for AWS :zap:
 
 This release [replaces CoreOS with Flatcar Container Linux](https://www.giantswarm.io/blog/time-to-catch-a-new-train-flatcar-linux).
 CoreOS has gone [end-of-life](https://coreos.com/os/eol/) and is being rapidly phased out.
 Flatcar is a compatible fork of CoreOS which receives ongoing support.
 To continue receiving security updates and to minimize the effort needed to migrate in the future, we recommend upgrading to this release.
 
-**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Giant Swarm Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
+**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Tenant Cluster Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
 
 **Note for future 9.0.x releases:** Please include this note and the one above in all future 9.0.x releases.
 

--- a/aws/v9.0.8/README.md
+++ b/aws/v9.0.8/README.md
@@ -1,11 +1,11 @@
-## :zap: Giant Swarm Release 9.0.8 for AWS :zap:
+## :zap: Tenant Cluster Release 9.0.8 for AWS :zap:
 
 **If you are upgrading from 9.0.7, upgrading to this release will not roll your nodes. It will only update the apps.**
 
 This release updates NGINX Ingress Controller to the latest upstream release.
 Most importantly, it includes a fix for a regression introduced in the previous upstream release related to `use-regex` and `rewrite` annotations.
 
-**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Giant Swarm Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
+**Note to SEs when upgrading from 8.5.0 or 9.0.0:** Existing customer automation or processes that manage the configuration of coredns, nginx-ingress-controller, or cluster-autoscaler must be modified in order to work with the changed location and format of the *-user-values configmaps. Please see our docs on [Tenant Cluster Release Versions: Versions that use the App Platform](https://docs.giantswarm.io/reference/release-versions/#versions-that-use-the-app-platform) for more details.
 
 **Note for future 9.0.x releases:** Please include this note and the one above in all future 9.0.x releases.
 

--- a/aws/v9.0.9/README.md
+++ b/aws/v9.0.9/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.0.9 for AWS :zap:
+# :zap: Tenant Cluster Release v9.0.9 for AWS :zap:
 
 This release updates managed apps to the latest releases, Calico to version `3.13.4`, and Flatcar Container Linux to `2512.2.1`.
 

--- a/aws/v9.3.2/README.md
+++ b/aws/v9.3.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.2 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.2 for AWS :zap:
 
 This release fixes an issue where upgrading from an earlier platform release to platform release v9.3.0 or v9.3.1 would result in the `nginx-ingress-controller` service having no endpoints, causing the NGINX IC app to not work.
 

--- a/aws/v9.3.7/README.md
+++ b/aws/v9.3.7/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.7 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.7 for AWS :zap:
 
 This release provides a new aws-operator which is fixing an issue with overlapping networks when creating legacy clusters together with node pools clusters.
 

--- a/aws/v9.3.8/README.md
+++ b/aws/v9.3.8/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.8 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.8 for AWS :zap:
 
 This is a patch release to update core component versions and remove memory limits from calico-kube-controllers which caused some control plane instability in certain clusters.
 

--- a/aws/v9.3.9/README.md
+++ b/aws/v9.3.9/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.3.9 for AWS :zap:
+# :zap: Tenant Cluster Release v9.3.9 for AWS :zap:
 
 **If you are upgrading from 9.3.8, upgrading to this release will not roll your nodes.**
 

--- a/azure/archived/v11.0.0/README.md
+++ b/azure/archived/v11.0.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.0.0 for Azure :zap:
+## :zap: Tenant Cluster Release 11.0.0 for Azure :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/azure/archived/v11.1.0/README.md
+++ b/azure/archived/v11.1.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.1.0 for Azure :zap:
+## :zap: Tenant Cluster Release 11.1.0 for Azure :zap:
 
 This is the first Giant Swarm release which includes Multiple Availability Zones for Azure. This release also introduces faster and less disruptive upgrade procedure that respects PDBs, as well as improved worker labeling.
 

--- a/azure/archived/v11.2.0/README.md
+++ b/azure/archived/v11.2.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.0 for Azure :zap:
+## :zap: Tenant Cluster Release 11.2.0 for Azure :zap:
 
 **If you are upgrading from 11.1.0, upgrading to this release merely updates the app. It will *not* roll your nodes.**
 

--- a/azure/archived/v11.2.1/README.md
+++ b/azure/archived/v11.2.1/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.1 for Azure :zap:
+## :zap: Tenant Cluster Release 11.2.1 for Azure :zap:
 
 ### This release contains Kubernetes ```1.16.8``` and other changes that increase cluster resiliency against API Throttling (error 429). Additional improvements include:
 - **Failed provisioning of VMs does not cause 429 anymore.**  We have added an automation that will reimage the failed instance immediately, before it exhausts API rate limits.

--- a/azure/archived/v11.2.2/README.md
+++ b/azure/archived/v11.2.2/README.md
@@ -1,4 +1,4 @@
-## ⚡️ Giant Swarm Release 11.2.2 for Azure ⚡️
+## ⚡️ Tenant Cluster Release 11.2.2 for Azure ⚡️
 
 This release contains improvements in the upgrade procedure.
 We have improved new nodes discovery at the stage where the cluster size is doubled with new versions of the machines.

--- a/azure/archived/v11.2.3/README.md
+++ b/azure/archived/v11.2.3/README.md
@@ -1,4 +1,4 @@
-## ⚡️ Giant Swarm Release 11.2.3 for Azure ⚡️
+## ⚡️ Tenant Cluster Release 11.2.3 for Azure ⚡️
 
 This release improves the way upgrades handle Azure VMSS Instances to make them more reliable in the Germany West Central location. This does not affect any existing functionality.
 

--- a/azure/archived/v11.2.4/README.md
+++ b/azure/archived/v11.2.4/README.md
@@ -1,4 +1,4 @@
-## ⚡️ Giant Swarm Release 11.2.4 for Azure ⚡️
+## ⚡️ Tenant Cluster Release 11.2.4 for Azure ⚡️
 
 **If you are upgrading from 11.2.3, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/archived/v11.2.5/README.md
+++ b/azure/archived/v11.2.5/README.md
@@ -1,4 +1,4 @@
-## ⚡️ Giant Swarm Release 11.2.5 for Azure ⚡️
+## ⚡️ Tenant Cluster Release 11.2.5 for Azure ⚡️
 
 **If you are upgrading from 11.2.4, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/archived/v11.2.6/README.md
+++ b/azure/archived/v11.2.6/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.2.6 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.2.6 for Azure :zap:
 
 This release adds two instance types to the list of supported instance types and fixes an error that was interrupting cluster creation.
 

--- a/azure/archived/v11.3.1/README.md
+++ b/azure/archived/v11.3.1/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.3.1 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.3.1 for Azure :zap:
 
 This release brings improvements to the upgrade process from clusters using CoreOS image to Flatcar image.
 The temporary firewall rule for workers was changed to be more focused in blocking traffic towards the API load balancer.

--- a/azure/archived/v11.3.2/README.md
+++ b/azure/archived/v11.3.2/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.3.2 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.3.2 for Azure :zap:
 
 **If you are upgrading from 11.3.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/archived/v12.0.1/README.md
+++ b/azure/archived/v12.0.1/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.0.1 for Azure :zap:
+## :zap:  Tenant Cluster Release 12.0.1 for Azure :zap:
 
 **If you are upgrading from 12.0.0, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/archived/v8.0.0/README.md
+++ b/azure/archived/v8.0.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.0.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.0.0 for Azure :zap:

--- a/azure/archived/v8.2.0/README.md
+++ b/azure/archived/v8.2.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.2.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.2.0 for Azure :zap:

--- a/azure/archived/v8.2.1/README.md
+++ b/azure/archived/v8.2.1/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.2.1 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.2.1 for Azure :zap:

--- a/azure/archived/v8.3.0/README.md
+++ b/azure/archived/v8.3.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.3.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.3.0 for Azure :zap:

--- a/azure/archived/v8.4.0/README.md
+++ b/azure/archived/v8.4.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 8.4.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.4.0 for Azure :zap:
 
 This release contains Kubernetes 1.14.6 and therefore fixes for CVE-2019-9512 and CVE-2019-9514.
 

--- a/azure/archived/v8.4.1/README.md
+++ b/azure/archived/v8.4.1/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 8.4.1 for Azure :zap:
+## :zap:  Tenant Cluster Release 8.4.1 for Azure :zap:
 
 This release adds the following service endpoints to the worker VNET:
 Storage, Sql, AzureCosmosDB, KeyVault, ServiceBus, EventHub, AzureActiveDirectory, ContainerRegistry, Web.

--- a/azure/archived/v9.0.0/README.md
+++ b/azure/archived/v9.0.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.0 for Azure :zap:
+## :zap: Tenant Cluster Release 9.0.0 for Azure :zap:
 
 This release contains Kubernetes `1.15.5` as well as a change to the default worker size of new clusters to `Standard_D4s_v3`.
 

--- a/azure/v11.3.0/README.md
+++ b/azure/v11.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.3.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.3.0 for Azure :zap:
 
 This release replaces CoreOS Container Linux that is going [end of life](https://coreos.com/os/eol/) on the 26th of May 2020 with [Flatcar Container Linux](https://www.flatcar-linux.org/). Flatcar is a compatible fork of CoreOS which receives ongoing support, including security updates and fixes. To learn more please read our recent blog post: [Time to Catch a New Train: Flatcar Linux](https://www.giantswarm.io/blog/time-to-catch-a-new-train-flatcar-linux)
 

--- a/azure/v11.3.3/README.md
+++ b/azure/v11.3.3/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.3.3 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.3.3 for Azure :zap:
 
 **If you are upgrading from 11.3.1 or 11.3.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/v11.4.0/README.md
+++ b/azure/v11.4.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 11.4.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 11.4.0 for Azure :zap:
 
 **In this release, NGINX Ingress Controller LoadBalancer Service external traffic policy has been made configurable, and the policy default has been changed from `Cluster` to `Local`.**
 

--- a/azure/v12.0.0/README.md
+++ b/azure/v12.0.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.0.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 12.0.0 for Azure :zap:
 
 This is the first release to support **Kubernetes 1.17** on Azure.
 

--- a/azure/v12.0.0/announcement.md
+++ b/azure/v12.0.0/announcement.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 12.0.0 for Azure :zap:
+# :zap: Tenant Cluster Release 12.0.0 for Azure :zap:
 
 This is the first Giant Swarm Azure release which includes **Kubernetes v1.17** and changes **NGINX Ingress Controller App** from being **pre-installed to optional** component on Azure. This allows NGINX App installations to be managed independently from the base platform lifecycle.
 It also includes a fix for Quay being a single point of failure by using Docker mirroring feature. This ensures availability of all images needed for node bootstrap, thus the cluster creation/scaling doesn’t depend on Quay availability anymore.

--- a/azure/v12.0.2/README.md
+++ b/azure/v12.0.2/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.0.2 for Azure :zap:
+## :zap:  Tenant Cluster Release 12.0.2 for Azure :zap:
 
 **If you are upgrading from 12.0.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/v12.1.0/README.md
+++ b/azure/v12.1.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.1.0 for Azure :zap:
+## :zap:  Tenant Cluster Release 12.1.0 for Azure :zap:
 
 **If you are upgrading from 12.0.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/azure/v12.1.1/README.md
+++ b/azure/v12.1.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.1 for Azure :zap:
+# :zap: Tenant Cluster Release v12.1.1 for Azure :zap:
 
 **If you are upgrading from 12.1.0, upgrading to this release will not roll your nodes.**
 

--- a/azure/v12.1.2/README.md
+++ b/azure/v12.1.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.1.2 for Azure :zap:
+# :zap: Tenant Cluster Release v12.1.2 for Azure :zap:
 
 **Nodes will be rolled during upgrade to this version.**
 

--- a/azure/v13.0.0-alpha4/README.md
+++ b/azure/v13.0.0-alpha4/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v13.0.0-alpha4 for Azure :zap:
+# :zap: Tenant Cluster Release v13.0.0-alpha4 for Azure :zap:
 
 ## Change details
 

--- a/kvm/archived/v11.0.0/README.md
+++ b/kvm/archived/v11.0.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.0.0 for KVM :zap:
+## :zap: Tenant Cluster Release 11.0.0 for KVM :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.16. In addition, CPU limits have been removed from several supporting components and priority classes have been adjusted to ensure system reliability under heavy load. Further details about changes to individual components can be found below.
 

--- a/kvm/archived/v11.1.0/README.md
+++ b/kvm/archived/v11.1.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.1.0 for KVM :zap:
+## :zap: Tenant Cluster Release 11.1.0 for KVM :zap:
 
 This release upgrades the NGINX Ingress Controller app to upstream v0.28.0. It contains several non-breaking changes that fix a few issues. We also enabled the metrics service. This allows prometheus-operator to scrape for metrics and improves monitoring of the app.
 

--- a/kvm/archived/v11.2.2/README.md
+++ b/kvm/archived/v11.2.2/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.2 for KVM :zap:
+## :zap: Tenant Cluster Release 11.2.2 for KVM :zap:
 
 **If you are upgrading from 11.2.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/kvm/archived/v11.2.3/README.md
+++ b/kvm/archived/v11.2.3/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.3 for KVM :zap:
+## :zap: Tenant Cluster Release 11.2.3 for KVM :zap:
 
 **If you are upgrading from 11.2.2, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/kvm/archived/v8.0.0/README.md
+++ b/kvm/archived/v8.0.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.0.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.0.0 for KVM :zap:

--- a/kvm/archived/v8.1.0/README.md
+++ b/kvm/archived/v8.1.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.1.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.1.0 for KVM :zap:

--- a/kvm/archived/v8.2.0/README.md
+++ b/kvm/archived/v8.2.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.2.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.2.0 for KVM :zap:

--- a/kvm/archived/v8.2.1/README.md
+++ b/kvm/archived/v8.2.1/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.2.1 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.2.1 for KVM :zap:

--- a/kvm/archived/v8.3.0/README.md
+++ b/kvm/archived/v8.3.0/README.md
@@ -1,1 +1,1 @@
-## :zap:  Giant Swarm Release 8.3.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.3.0 for KVM :zap:

--- a/kvm/archived/v8.4.0/README.md
+++ b/kvm/archived/v8.4.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 8.4.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 8.4.0 for KVM :zap:
 
 This release contains Kubernetes 1.14.6 and therefor fixes for CVE-2019-9512 and CVE-2019-9514.
 

--- a/kvm/archived/v9.0.1/README.md
+++ b/kvm/archived/v9.0.1/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.1 for KVM :zap:
+## :zap: Tenant Cluster Release 9.0.1 for KVM :zap:
 
 **Note** If you are upgrading from 8.4.0 or 9.0.0:
 

--- a/kvm/archived/v9.0.2/README.md
+++ b/kvm/archived/v9.0.2/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.2 for KVM :zap:
+## :zap: Tenant Cluster Release 9.0.2 for KVM :zap:
 
 **Note** If you are upgrading from 8.4.0 or 9.0.0:
 

--- a/kvm/v11.2.0/README.md
+++ b/kvm/v11.2.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.0 for KVM :zap:
+## :zap: Tenant Cluster Release 11.2.0 for KVM :zap:
 
 **If you are upgrading from 11.1.0, upgrading to this release merely updates the app. It will *not* roll your nodes.**
 

--- a/kvm/v11.2.1/README.md
+++ b/kvm/v11.2.1/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.2.1 for KVM :zap:
+## :zap: Tenant Cluster Release 11.2.1 for KVM :zap:
 
 **With this release, horizontal pod autoscaling (HPA) is enabled by default for NGINX Ingress Controller (NGINX IC) on selected cluster profiles.**
 

--- a/kvm/v11.3.0/README.md
+++ b/kvm/v11.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.3.0 for KVM :zap:
+## :zap: Tenant Cluster Release 11.3.0 for KVM :zap:
 
 This release includes Kubernetes v1.16.9 as well as reliability and user experience improvements.
 

--- a/kvm/v11.3.1/README.md
+++ b/kvm/v11.3.1/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.3.1 for KVM :zap:
+## :zap: Tenant Cluster Release 11.3.1 for KVM :zap:
 
 This release fixes a problem that prevented clusters with OIDC user and group prefix settings to work as expected in `11.3.0`.
 

--- a/kvm/v11.3.2/README.md
+++ b/kvm/v11.3.2/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 11.3.2 for KVM :zap:
+## :zap: Tenant Cluster Release 11.3.2 for KVM :zap:
 
 **If you are upgrading from 11.3.1, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/kvm/v12.0.0/README.md
+++ b/kvm/v12.0.0/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 12.0.0 for KVM :zap:
+# :zap: Tenant Cluster Release 12.0.0 for KVM :zap:
 
 This is the first Giant Swarm release which includes Kubernetes v1.17. Many core components and default apps have been updated for improved reliability and observability. Further details about changes to individual components can be found below.
 

--- a/kvm/v12.0.0/announcement.md
+++ b/kvm/v12.0.0/announcement.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 12.0.0 for KVM :zap:
+# :zap: Tenant Cluster Release 12.0.0 for KVM :zap:
 
 KVM release 12.0.0 is now available. This is the first Giant Swarm release which includes **Kubernetes v1.17**. Many core components and default apps have been updated for improved reliability and observability. Further details about changes to individual components can be found in the [release notes](https://github.com/giantswarm/releases/blob/master/kvm/v12.0.0).
 

--- a/kvm/v12.0.1/README.md
+++ b/kvm/v12.0.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release 12.0.1 for KVM :zap:
+# :zap: Tenant Cluster Release 12.0.1 for KVM :zap:
 
 **If you are upgrading from 12.0.0, upgrading to this release will not roll your nodes. It will only update the apps.**
 

--- a/kvm/v12.1.0/README.md
+++ b/kvm/v12.1.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.1.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 12.1.0 for KVM :zap:
 
 This release includes two **significant improvements to NGINX Ingress Controller**. It also includes a **fix for Quay being a single point of failure** by using Docker mirroring feature. This ensures availability of all images needed for node bootstrap, thus the cluster creation/scaling doesn’t depend on Quay availability anymore.
 

--- a/kvm/v12.1.0/announcement.md
+++ b/kvm/v12.1.0/announcement.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.1.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 12.1.0 for KVM :zap:
 
 This release includes two **significant improvements to NGINX Ingress Controller**. It also includes a **fix for Quay being a single point of failure** by using Docker mirroring feature.
 

--- a/kvm/v12.2.0/README.md
+++ b/kvm/v12.2.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.2.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 12.2.0 for KVM :zap:
 
 **If you are upgrading from 12.1.0, upgrading to this release will not roll your nodes.**
 

--- a/kvm/v12.2.0/announcement.md
+++ b/kvm/v12.2.0/announcement.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release 12.2.0 for KVM :zap:
+## :zap:  Tenant Cluster Release 12.2.0 for KVM :zap:
 
 As of this release, **NGINX Ingress Controller App** is now an **optional (and not pre-installed)** component on KVM.
 

--- a/kvm/v12.3.0/README.md
+++ b/kvm/v12.3.0/README.md
@@ -1,4 +1,4 @@
-## :zap:  Giant Swarm Release v12.3.0 for KVM :zap:
+## :zap:  Tenant Cluster Release v12.3.0 for KVM :zap:
 
 This release upgrades all Helm releases managed by Giant Swarm to use [Helm v3.3.4](https://github.com/helm/helm/releases/tag/v3.3.4).
 

--- a/kvm/v12.3.1/README.md
+++ b/kvm/v12.3.1/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.3.1 for KVM :zap:
+# :zap: Tenant Cluster Release v12.3.1 for KVM :zap:
 
 **If you are upgrading from 12.3.0, upgrading to this release will not roll your nodes.**
 

--- a/kvm/v12.3.2/README.md
+++ b/kvm/v12.3.2/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v12.3.2 for KVM :zap:
+# :zap: Tenant Cluster Release v12.3.2 for KVM :zap:
 
 **Nodes will be rolled during upgrade to this version.**
 

--- a/kvm/v9.0.0/README.md
+++ b/kvm/v9.0.0/README.md
@@ -1,4 +1,4 @@
-## :zap: Giant Swarm Release 9.0.0 for KVM :zap:
+## :zap: Tenant Cluster Release 9.0.0 for KVM :zap:
 
 ### Kubernetes v1.15.5
 - Updated from v1.14.6 - [changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#kubernetes-v115-release-notes)

--- a/kvm/v9.0.3/README.md
+++ b/kvm/v9.0.3/README.md
@@ -1,4 +1,4 @@
-# :zap: Giant Swarm Release v9.0.3 for KVM :zap:
+# :zap: Tenant Cluster Release v9.0.3 for KVM :zap:
 
 This release fixes a rare bug that would prevent the NGINX IC from being installed on a new cluster.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 
 <!--
-If this is a PR with details for new release please review [Releases Board](https://github.com/orgs/giantswarm/projects/136) 
+If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
 - if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
 - otherwise create appropriate ticket for your release
 


### PR DESCRIPTION
This PR updates the main headline of all release notes.