### PR TITLE
Fix some links in AWS releases

### DIFF
--- a/aws/archived/v11.2.0/README.md
+++ b/aws/archived/v11.2.0/README.md
@@ -12,7 +12,7 @@ If you intend to use spot instances, be aware that an AWS service limit called `
 - Add mixed instance support for worker node Auto Scaling Groups (ASG).
 - Place master node in Auto Scaling Group (ASG) as preparation to run multiple master nodes in the future.
 
-## cluster-operator [v2.9.1](https://github.com/giantswarm/cluster-operator/releases/tag/v2.9.1)
+## cluster-operator [v2.1.9](https://github.com/giantswarm/cluster-operator/blob/master/CHANGELOG.md#219-2020-04-23)
 
 - Once a cluster creation has been completed, we set `.status.infrastructureReady` in the `Cluster` resource to `true`.
 - Fixed RBAC rules for the reconciliation of the Control Plane resources.

--- a/aws/archived/v11.4.0/README.md
+++ b/aws/archived/v11.4.0/README.md
@@ -26,7 +26,7 @@ Read our [dedicated documentation article](https://docs.giantswarm.io/basics/ha-
 for more details and instructions.
 
 **Note for Solution Engineers:** This release contains an external-dns fix introduced in
-[11.3.2](https://github.com/giantswarm/releases/blob/master/aws/v11.3.2/release-notes.md).
+[11.3.2](https://docs.giantswarm.io/changes/tenant-cluster-releases-aws/releases/aws-v11.3.2/).
 It requires manual intervention for cluster upgrades in China to work. When upgrading a
 cluster, existing ingress `A+TXT` record sets do not get replaced with `CNAME+TXT` record sets
 even when external-dns is configured with CNAMEs as preferred. After upgrading, delete the

--- a/aws/archived/v11.4.1/README.md
+++ b/aws/archived/v11.4.1/README.md
@@ -1,6 +1,6 @@
 # :zap: Tenant Cluster Release v11.4.1 for AWS :zap:
 
-This release re-activates the recent AWS [release of high-availability (HA) masters](https://github.com/giantswarm/releases/tree/master/aws/v11.4.0), fixing OIDC configurations issues.
+This release re-activates the recent AWS [release of high-availability (HA) masters](https://docs.giantswarm.io/changes/tenant-cluster-releases-aws/releases/aws-v11.4.0/), fixing OIDC configurations issues.
 
 
 **Note for Solution Engineers:** This release contains an external-dns fix introduced in


### PR DESCRIPTION
Changing to use docs URLs instead of Github, as the latter change when archiving and moving the release folder in the repo.