### PR TITLE
Request: update cert-manager for AWS releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-    - name: "> 12.7.0, < 13.0.0"
+    - name: "> 13.0.0, < 14.0.0"
       requests:
         - name: cert-manager
           version: ">= 2.3.3"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: "> 12.7.0, < 13.0.0"
+      requests:
+        - name: cert-manager
+          version: ">= 2.3.3"
+          issue: https://github.com/giantswarm/giantswarm/issues/14281
     - name: "> 12.6.0, < 13.0.0"
       requests:
         - name: cert-manager


### PR DESCRIPTION
towards giantswarm/giantswarm/issues/14281

This release allows cert-manager components to be scheduled on master nodes, so the deployment won't fail when a cluster is created without any nodepools.
