### PR TITLE
KVM; Add cluster-operator 0.23.19 as new constraint

### DIFF
--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -15,6 +15,9 @@ releases:
         - name: chart-operator
           version: ">= 2.5.0"
           issue: https://github.com/giantswarm/roadmap/issues/191
+        - name: cluster-operator
+          version: ">= 0.23.19"
+          issue: https://github.com/giantswarm/giantswarm/issues/14677
     - name: "> 11.3.2, < 12.0.0"
       requests:
         - name: calico


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Toward https://github.com/giantswarm/giantswarm/issues/14677

cluster-operator 0.23.19 is needed to avoid app CRs update loop in the cluster namespace.