### PR TITLE
AWS; add cluster-operator 3.4.1 as new constraint

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -18,6 +18,9 @@ releases:
         - name: chart-operator
           version: ">= 2.5.0"
           issue: https://github.com/giantswarm/roadmap/issues/191
+        - name: cluster-operator
+          version: ">= 3.4.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14677
     - name: "> 12.6.0, < 13.0.0"
       requests:
         - name: cert-manager


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Toward https://github.com/giantswarm/giantswarm/issues/14677

cluster-operator 3.4.1 is needed to avoid app CRs update loop in the cluster namespace.