### PR TITLE
Request chart-operator v2.5.1 for AWS 12.X

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -16,8 +16,8 @@ releases:
           version: ">= 2.7.0"
           issue: https://github.com/giantswarm/roadmap/issues/191
         - name: chart-operator
-          version: ">= 2.5.0"
-          issue: https://github.com/giantswarm/roadmap/issues/191
+          version: ">= 2.5.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14642
         - name: cluster-operator
           version: ">= 3.4.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14677


### PR DESCRIPTION
chart-operator v2.5.1 is already in the AWS 13.0.0 release. 

Also adding to requests in case we need to do patch releases.


<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
