### PR TITLE
Request chart-operator v2.5.1 for KVM 12.X

### DIFF
--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -13,8 +13,8 @@ releases:
           version: ">= 2.7.0"
           issue: https://github.com/giantswarm/roadmap/issues/191
         - name: chart-operator
-          version: ">= 2.5.0"
-          issue: https://github.com/giantswarm/roadmap/issues/191
+          version: ">= 2.5.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14642
         - name: cluster-operator
           version: ">= 0.23.19"
           issue: https://github.com/giantswarm/giantswarm/issues/14677


### PR DESCRIPTION
chart-operator v2.5.1 is already in the KVM 13.0.0 release. 

Also adding to requests in case we need to do patch releases.
