### PR TITLE
Request chart-operator v2.5.1 for Azure 12.X

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -10,9 +10,6 @@ releases:
         - name: app-operator
           version: ">= 2.7.0"
           issue: https://github.com/giantswarm/roadmap/issues/191
-        - name: chart-operator
-          version: ">= 2.5.0"
-          issue: https://github.com/giantswarm/roadmap/issues/191
     - name: "> 11.4.0, < 12.0.0"
       requests:
         - name: calico
@@ -26,6 +23,9 @@ releases:
         - name: calico
           version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
+        - name: chart-operator
+          version: ">= 2.5.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14642
     - name: "> 12.1.0, < 13.0.0"
       requests:
         - name: containerlinux

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -23,7 +23,7 @@ releases:
         - name: calico
           version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
-    - name: "> 12.1.0, < 13.0.0"
+    - name: "> 12.1.2, < 13.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -23,14 +23,14 @@ releases:
         - name: calico
           version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
-        - name: chart-operator
-          version: ">= 2.5.1"
-          issue: https://github.com/giantswarm/giantswarm/issues/14642
     - name: "> 12.1.0, < 13.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
+        - name: chart-operator
+          version: ">= 2.5.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14642
           except:
             - releaseVersion: 12.1.1
               reason: only app changes are required


### PR DESCRIPTION
chart-operator v2.5.1 is already in the KVM 13.0.1 release.

Also adding to requests in case we need to do patch releases.