### PR TITLE
Request newer batman components for AWS

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-    - name: ">= 13.0.0, < 14.0.0"
+    - name: "> 13.0.0, < 14.0.0"
       requests:
         - name: app-operator
           version: ">= 3.0.0"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,6 +1,15 @@
 releases:
     - name: ">= 13.0.0, < 14.0.0"
       requests:
+        - name: app-operator
+          version: ">= 3.0.0"
+          issue: https://github.com/giantswarm/roadmap/issues/187
+        - name: chart-operator
+          version: ">= 2.6.0"
+          isssue: https://github.com/giantswarm/giantswarm/issues/14599
+        - name: cluster-operator
+          version: ">= 3.5.0"
+          issue: https://github.com/giantswarm/roadmap/issues/187
         - name: node-exporter
           version: ">= 1.7.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14579

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,7 +6,7 @@ releases:
           issue: https://github.com/giantswarm/roadmap/issues/187
         - name: chart-operator
           version: ">= 2.6.0"
-          isssue: https://github.com/giantswarm/giantswarm/issues/14599
+          issue: https://github.com/giantswarm/giantswarm/issues/14599
         - name: cluster-operator
           version: ">= 3.5.0"
           issue: https://github.com/giantswarm/roadmap/issues/187


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/187  https://github.com/giantswarm/giantswarm/issues/14599

We're now ready to start using the defaulting and validation logic for tenant app CRs. See https://github.com/giantswarm/docs/pull/731 for more details.

- app-operator v3.0.0
- cluster-operator v3.5.0

Also requests the latest chart-operator v2.6.0 that upgrades Helm to the latest release v2.4.1.