### PR TITLE
Request new batman components for Azure

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-    - name: "> 13.0.0-beta2"
+    - name: "> 13.0.2"
       requests:
         - name: node-exporter
           version: ">= 1.7.0"
@@ -8,8 +8,14 @@ releases:
           version: ">= 1.3.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14579
         - name: app-operator
-          version: ">= 2.7.0"
-          issue: https://github.com/giantswarm/roadmap/issues/191
+          version: ">= 3.0.0"
+          issue: https://github.com/giantswarm/roadmap/issues/187
+        - name: chart-operator
+          version: ">= 2.6.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14599
+        - name: cluster-operator
+          version: ">= 0.23.20"
+          issue: https://github.com/giantswarm/roadmap/issues/187
     - name: "> 11.4.0, < 12.0.0"
       requests:
         - name: calico


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/187  https://github.com/giantswarm/giantswarm/issues/14599

We're now ready to start using the defaulting and validation logic for tenant app CRs. See https://github.com/giantswarm/docs/pull/731 for more details.

- app-operator v3.0.0
- cluster-operator v0.23.20

Also requests the latest chart-operator v2.6.0 that upgrades Helm to the latest release v3.4.2.
