### PR TITLE
Switched to a different semver library

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,10 +1,10 @@
 releases:
-    - name: "> 13.1.0, < 14.0.0"
+    - name: "> 13.1.0 < 14.0.0"
       requests:
         - name: cert-manager
           version: ">= 2.4.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14706
-    - name: "> 13.0.0, < 14.0.0"
+    - name: "> 13.0.0 < 14.0.0"
       requests:
         - name: app-operator
           version: ">= 3.0.0"
@@ -35,12 +35,12 @@ releases:
         - name: cluster-operator
           version: ">= 3.4.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14677
-    - name: "> 12.6.0, < 13.0.0"
+    - name: "> 12.6.0 < 13.0.0"
       requests:
         - name: cert-manager
           version: ">= 2.3.2"
           issue: https://github.com/giantswarm/giantswarm/issues/14284
-    - name: "> 12.5.0, < 13.0.0"
+    - name: "> 12.5.0 < 13.0.0"
       requests:
         - name: app-operator
           version: ">= 2.3.3"
@@ -48,7 +48,7 @@ releases:
         - name: chart-operator
           version: ">= 2.3.5"
           issue: https://github.com/giantswarm/giantswarm/issues/13677
-    - name: "> 12.3.0, < 13.0.0"
+    - name: "> 12.3.0 < 13.0.0"
       requests:
         - name: cert-manager
           version: ">= 2.3.0"
@@ -56,22 +56,22 @@ releases:
         - name: external-dns
           version: ">= 1.5.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13671
-    - name: "> 12.0.0, < 13.0.0"
+    - name: "> 12.0.0 < 13.0.0"
       requests:
         - name: calico
           version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
-    - name: "> 12.1.4, < 13.0.0"
+    - name: "> 12.1.4 < 13.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 11.5.4, < 12.0.0"
+    - name: "> 11.5.4 < 12.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 9.3.8, < 10.0.0"
+    - name: "> 9.3.8 < 10.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -16,7 +16,7 @@ releases:
         - name: cluster-operator
           version: ">= 0.23.20"
           issue: https://github.com/giantswarm/roadmap/issues/187
-    - name: "> 11.4.0, < 12.0.0"
+    - name: "> 11.4.0 < 12.0.0"
       requests:
         - name: calico
           version: ">= 3.10.4"
@@ -24,12 +24,12 @@ releases:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "12.*"
+    - name: ">= 12.0.0 < 13.0.0"
       requests:
         - name: calico
           version: ">= 3.15.1"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
-    - name: "> 12.1.2, < 13.0.0"
+    - name: "> 12.1.2 < 13.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
@@ -40,7 +40,7 @@ releases:
           except:
             - releaseVersion: 12.1.1
               reason: only app changes are required
-    - name: "> 12.0.2, < 12.1.0"
+    - name: "> 12.0.2 < 12.1.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/releases
 go 1.13
 
 require (
-	github.com/blang/semver v3.5.0+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/giantswarm/apiextensions v0.4.14
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/versionbundle v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/releases
 go 1.13
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.0
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/giantswarm/apiextensions v0.4.14
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/versionbundle v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
-github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
-github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
@@ -62,6 +60,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -27,12 +27,12 @@ releases:
         - name: cluster-operator
           version: ">= 0.23.19"
           issue: https://github.com/giantswarm/giantswarm/issues/14677
-    - name: "> 11.3.2, < 12.0.0"
+    - name: "> 11.3.2 < 12.0.0"
       requests:
         - name: calico
           version: ">= 3.10.4"
           issue: https://github.com/giantswarm/giantswarm/issues/11307
-    - name: "> 12.1.0, < 13.0.0"
+    - name: "> 12.1.0 < 13.0.0"
       requests:
         - name: calico
           version: ">= 3.15.1"
@@ -40,27 +40,27 @@ releases:
           except:
             - releaseVersion: 12.2.0
               reason: kvm-operator work needed
-    - name: "> 12.2.0, < 13.0.0"
+    - name: "> 12.2.0 < 13.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 12.1.0, < 12.2.0"
+    - name: "> 12.1.0 < 12.2.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 12.0.1, < 12.1.0"
+    - name: "> 12.0.1 < 12.1.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 11.3.2, < 12.0.0"
+    - name: "> 11.3.2 < 12.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13150
-    - name: "> 9.0.3, < 10.0.0"
+    - name: "> 9.0.3 < 10.0.0"
       requests:
         - name: containerlinux
           version: ">= 2512.4.0"

--- a/releases_test.go
+++ b/releases_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
+	"github.com/blang/semver"
 	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/versionbundle"
@@ -196,17 +196,19 @@ func releasesToIndex(releases []v1alpha1.Release) []versionbundle.IndexRelease {
 // versionMatches compares the given version with the given semver
 // constraint pattern and returns whether it matches.
 func versionMatches(version string, pattern string) (bool, error) {
-	c, err := semver.NewConstraint(pattern)
+	validator, err := semver.ParseRange(pattern)
 	if err != nil {
 		return false, fmt.Errorf("release names for requests must be valid semver constraints: %s", err)
 	}
 
-	v, err := semver.NewVersion(version)
+	version = strings.TrimPrefix(version, "v")
+
+	v, err := semver.Parse(version)
 	if err != nil {
 		return false, fmt.Errorf("release names must be valid semver: %s: %s", err, version)
 	}
 
-	return c.Check(v), nil
+	return validator(v), nil
 }
 
 func Test_Releases(t *testing.T) {

--- a/releases_test.go
+++ b/releases_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blang/semver"
+	"github.com/blang/semver/v4"
 	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/versionbundle"


### PR DESCRIPTION
We currently use the `github.com/Masterminds/semver/v3` to ensure requests are met for all providers.

That library has a problem with `-dev` releases though:

```
5.2.2-dev >= 5.2.0 ? false
5.2.0-dev >= 5.2.0 ? false
5.3.0-dev >= 5.2.0 ? false
```

This PR switches to the `github.com/blang/semver/v4` library that behaves correctly:

```
5.2.2-dev >= 5.2.0 ? true
5.2.0-dev >= 5.2.0 ? false
5.3.0-dev >= 5.2.0 ? true
```

Unluckily this requires a slightly different syntax in the range specification.

WDYT?