### PR TITLE
Request cluster-operator 0.23.21 in future releases

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-    - name: "> 13.0.3"
+    - name: "> 13.0.3 > 13.1.2"
       requests:
         - name: cluster-operator
           version: ">= 0.23.21"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: "> 13.0.3"
+      requests:
+        - name: cluster-operator
+          version: ">= 0.23.21"
+          issue: https://github.com/giantswarm/giantswarm/issues/15434
     - name: "> 13.0.2"
       requests:
         - name: node-exporter


### PR DESCRIPTION
this PR adds the latest cluster-operator to Azure which allows developers to omit `-app` suffixes in the creation of default apps

https://github.com/giantswarm/giantswarm/issues/15434