### PR TITLE
Request cluster-operator 3.5.1 in future releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -4,6 +4,9 @@ releases:
         - name: cert-manager
           version: ">= 2.4.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14706
+        - name: cluster-operator
+          version: ">= 3.5.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15434
     - name: "> 13.0.0 < 14.0.0"
       requests:
         - name: app-operator


### PR DESCRIPTION
this PR adds the latest cluster-operator to AWS which allows developers to omit `-app` suffixes in the creation of default apps

https://github.com/giantswarm/giantswarm/issues/15434