### PR TITLE
Request a new cluster-operator release

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -2,7 +2,7 @@ releases:
     - name: "> 13.0.3 > 13.1.2"
       requests:
         - name: cluster-operator
-          version: ">= 0.23.21"
+          version: ">= 0.23.22"
           issue: https://github.com/giantswarm/giantswarm/issues/15434
     - name: "> 13.0.2"
       requests:


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

The release `0.23.21` had a bug that was fixed in `0.23.22`, hence this change.