### PR TITLE
Bump gitleaks version

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -14,4 +14,4 @@ jobs:
       with:
         fetch-depth: '0'
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@v1.1.4
+      uses: zricethezav/gitleaks-action@v1.2.0


### PR DESCRIPTION
Manually updating the generated file to get people unblocked. It wasn't updated due to an unknown issue in the automation
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
