### PR TITLE
Request app-operator v3.2.0 for AWS

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -13,8 +13,8 @@ releases:
     - name: "> 13.0.0 < 14.0.0"
       requests:
         - name: app-operator
-          version: ">= 3.0.0"
-          issue: https://github.com/giantswarm/roadmap/issues/187
+          version: ">= 3.2.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: chart-operator
           version: ">= 2.6.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14599


### PR DESCRIPTION
There is a problem with finalizers in app-operator 3.1.0. See https://github.com/giantswarm/releases/pull/599/files#r573779150 for more details.

This causes problems deleting the cluster namespace and was fixed by @tomahawk28 for https://github.com/giantswarm/giantswarm/issues/15392 in app-operator 3.2.0.

