### PR TITLE
Request app-operator 3.2.0 for Azure > 14.1.0

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,9 +6,6 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/13771
     - name: "> 14.1.0"
       requests:
-        - name: app-operator
-          version: ">= 3.2.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: external-dns
           version: ">= 2.1.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15573
@@ -26,8 +23,8 @@ releases:
           version: ">= 1.3.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14579
         - name: app-operator
-          version: ">= 3.0.0"
-          issue: https://github.com/giantswarm/roadmap/issues/187
+          version: ">= 3.2.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: chart-operator
           version: ">= 2.6.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14599

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,6 +6,9 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/13771
     - name: "> 14.1.0"
       requests:
+        - name: app-operator
+          version: ">= 3.2.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: external-dns
           version: ">= 2.1.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15573

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,6 +6,9 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/13771
     - name: "> 14.1.0"
       requests:
+        - name: app-operator
+          version: ">= 3.2.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: external-dns
           version: ">= 2.1.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15573
@@ -23,8 +26,8 @@ releases:
           version: ">= 1.3.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14579
         - name: app-operator
-          version: ">= 3.2.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/15392
+          version: ">= 3.0.0"
+          issue: https://github.com/giantswarm/roadmap/issues/187
         - name: chart-operator
           version: ">= 2.6.0"
           issue: https://github.com/giantswarm/giantswarm/issues/14599

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -12,11 +12,13 @@ releases:
         - name: external-dns
           version: ">= 2.1.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15573
-    - name: "> 13.0.3 > 13.1.2"
+    - name: "> 13.0.2 < 13.1.1"
       requests:
         - name: app-operator
           version: ">= 3.2.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15392
+    - name: "> 13.0.3 > 13.1.2"
+      requests:
         - name: cluster-operator
           version: ">= 0.23.22"
           issue: https://github.com/giantswarm/giantswarm/issues/15434

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -14,6 +14,9 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/15573
     - name: "> 13.0.3 > 13.1.2"
       requests:
+        - name: app-operator
+          version: ">= 3.2.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/15392
         - name: cluster-operator
           version: ">= 0.23.22"
           issue: https://github.com/giantswarm/giantswarm/issues/15434


### PR DESCRIPTION
See giantswarm/giantswarm#15392

There is a problem with finalizers in the app-operator 3.1.0 release which means the cluster namespace in the MC is not deleted correctly.

This is fixed in app-operator 3.2.0 and includes migration logic to ensure the correct finalizer is used.
