### PR TITLE
KVM release 13.0.1 with k8s-kvm GPG URL hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ to all Giant Swarm installations.
 
 - v13
   - v13.0
+    - [v13.0.1](https://github.com/giantswarm/releases/tree/master/kvm/v13.0.1)
     - [v13.0.0](https://github.com/giantswarm/releases/tree/master/kvm/v13.0.0)
 
 - v12

--- a/kvm/kustomization.yaml
+++ b/kvm/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 - v12.3.1
 - v12.3.2
 - v13.0.0
+- v13.0.1
 transformers:
 - releaseNotesTransformer.yaml

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -9,7 +9,7 @@ releases:
         - name: cluster-operator
           version: ">= 0.23.22"
           issue: https://github.com/giantswarm/giantswarm/issues/15434
-    - name: "> 13.0.0"
+    - name: "> 13.0.1"
       requests:
         - name: node-exporter
           version: ">= 1.7.0"

--- a/kvm/v13.0.1/README.md
+++ b/kvm/v13.0.1/README.md
@@ -1,0 +1,5 @@
+# :zap: Workload Cluster Release v13.0.1 for KVM :zap:
+
+**Nodes will be rolled when upgrading to this version.**
+
+This patch release mitigates a DNS issue affecting cluster creation and scaling.

--- a/kvm/v13.0.1/announcement.md
+++ b/kvm/v13.0.1/announcement.md
@@ -1,0 +1,1 @@
+**Workload cluster release v13.0.1 for KVM** is now available. This patch release mitigates a DNS issue affecting cluster creation and scaling. Nodes will be rolled when upgrading to this version. Further details can be found in the [release notes](https://github.com/giantswarm/releases/tree/master/kvm/v13.0.1).

--- a/kvm/v13.0.1/kustomization.yaml
+++ b/kvm/v13.0.1/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/kvm/v13.0.1/release.diff
+++ b/kvm/v13.0.1/release.diff
@@ -1,0 +1,56 @@
+# Generated with:                                               <
+# devctl release create --name 13.0.0 --base v12.3.2 --releases <
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v13.0.0                                                 |    name: v13.0.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 1.3.0                                                     version: 1.3.0
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.5.1                                                     version: 2.5.1
+  - componentVersion: 1.6.5                                          - componentVersion: 1.6.5
+    name: coredns                                                      name: coredns
+    version: 1.2.0                                                     version: 1.2.0
+  - componentVersion: 1.9.7                                          - componentVersion: 1.9.7
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.3.0                                                     version: 1.3.0
+  - componentVersion: 0.3.6                                          - componentVersion: 0.3.6
+    name: metrics-server                                               name: metrics-server
+    version: 1.1.1                                                     version: 1.1.1
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.9.2                                                     version: 1.9.2
+  - componentVersion: 1.0.1                                          - componentVersion: 1.0.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.7.0                                                     version: 1.7.0
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    version: 2.7.0                                                     version: 2.7.0
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+  - name: calico                                                     - name: calico
+    version: 3.15.3                                                    version: 3.15.3
+  - name: cert-operator                                              - name: cert-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 0.1.0                                                     version: 0.1.0
+    reference: 0.1.0-2                                                 reference: 0.1.0-2
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 0.23.19                                                   version: 0.23.19
+  - name: containerlinux                                             - name: containerlinux
+    version: 2512.5.0                                                  version: 2512.5.0
+  - name: etcd                                                       - name: etcd
+    version: 3.4.13                                                    version: 3.4.13
+  - name: flannel-operator                                           - name: flannel-operator
+    version: 0.2.0                                                     version: 0.2.0
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.18.12                                                   version: 1.18.12
+  - name: kvm-operator                                               - name: kvm-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 3.14.0                                             |      version: 3.14.1
+  date: "2020-12-09T00:00:00Z"                                  |    date: "2020-23T12:00:00Z"
+  state: deprecated                                             |    state: active
+status:                                                            status:
+  inUse: false                                                       inUse: false
+  ready: false                                                       ready: false

--- a/kvm/v13.0.1/release.yaml
+++ b/kvm/v13.0.1/release.yaml
@@ -1,10 +1,8 @@
-# Generated with:
-# devctl release create --name 13.0.0 --base v12.3.2 --releases . --provider kvm --component cluster-operator@0.23.19 --component etcd@3.4.13 --component kvm-operator@3.14.0 --component containerlinux@2512.5.0 --component kubernetes@1.18.12 --component calico@3.15.3 --app kube-state-metrics@1.2.0@1.9.7 --app cert-exporter@1.3.0 --app net-exporter@1.9.2 --app node-exporter@1.7.0@1.0.1 --overwrite true
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
   creationTimestamp: null
-  name: v13.0.0
+  name: v13.0.1
 spec:
   apps:
   - name: cert-exporter
@@ -48,9 +46,9 @@ spec:
     version: 1.18.12
   - name: kvm-operator
     releaseOperatorDeploy: true
-    version: 3.14.0
-  date: "2020-12-09T00:00:00Z"
-  state: deprecated
+    version: 3.14.1
+  date: "2020-23T12:00:00Z"
+  state: active
 status:
   inUse: false
   ready: false

--- a/kvm/v13.0.1/release.yaml
+++ b/kvm/v13.0.1/release.yaml
@@ -47,7 +47,7 @@ spec:
   - name: kvm-operator
     releaseOperatorDeploy: true
     version: 3.14.1
-  date: "2020-02-23T12:00:00Z"
+  date: "2021-02-23T12:00:00Z"
   state: active
 status:
   inUse: false

--- a/kvm/v13.0.1/release.yaml
+++ b/kvm/v13.0.1/release.yaml
@@ -47,7 +47,7 @@ spec:
   - name: kvm-operator
     releaseOperatorDeploy: true
     version: 3.14.1
-  date: "2020-23T12:00:00Z"
+  date: "2020-02-23T12:00:00Z"
   state: active
 status:
   inUse: false


### PR DESCRIPTION
Releasing https://github.com/giantswarm/k8s-kvm/releases/tag/v0.2.1 and https://github.com/giantswarm/kvm-operator/releases/tag/v3.14.1