### PR TITLE
Request cert-operator 1.0.0 and required cluster-operator versions

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,6 +1,12 @@
 releases:
     - name: ">= 15.0.0"
       requests:
+        - name: cert-operator
+          version: ">= 1.0.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
+        - name: cluster-operator
+          version: ">= 3.6.1"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,6 +1,12 @@
 releases:
     - name: ">= 15.0.0"
       requests:
+        - name: cert-operator
+          version: ">= 1.0.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
+        - name: cluster-operator
+          version: ">= 0.24.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,6 +1,12 @@
 releases:
     - name: ">= 14.0.0"
       requests:
+        - name: cert-operator
+          version: ">= 1.0.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
+        - name: cluster-operator
+          version: ">= 0.24.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14205

Request `cert-operator` 1.0.0 or above in next provider major versions. This version of `cert-operator` requires changes in `cluster-operator`, so matching versions of `cluster-operator` are also included in this request.

<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
