### PR TITLE
deprecate 14.1.1

### DIFF
--- a/azure/v14.1.1/release.yaml
+++ b/azure/v14.1.1/release.yaml
@@ -54,7 +54,7 @@ spec:
   - name: etcd
     version: 3.4.14
   date: "2021-02-22T07:35:53Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
Disable broken release 14.1.1 to avoid customers from using it.
Can't delete it because it's running on gollum