### PR TITLE
Bump cert-operator request

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -2,7 +2,7 @@ releases:
     - name: ">= 15.0.0"
       requests:
         - name: cert-operator
-          version: ">= 1.0.0"
+          version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: cluster-operator
           version: ">= 3.6.1"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -2,10 +2,10 @@ releases:
     - name: ">= 15.0.0"
       requests:
         - name: cert-operator
-          version: ">= 1.0.0"
+          version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: cluster-operator
-          version: ">= 0.24.0"
+          version: ">= 0.24.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -2,10 +2,10 @@ releases:
     - name: ">= 14.0.0"
       requests:
         - name: cert-operator
-          version: ">= 1.0.0"
+          version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: cluster-operator
-          version: ">= 0.24.0"
+          version: ">= 0.24.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Bump requested version for `cert-operator` and associated `cluster-operator` legacy version

Pending https://github.com/giantswarm/cluster-operator/pull/1348 and https://github.com/giantswarm/cert-operator/pull/374
