### PR TITLE
Update cluster-operator requests for new cert-operator

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,7 +5,7 @@ releases:
           version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: cluster-operator
-          version: ">= 0.24.1"
+          version: ">= 0.24.2"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -5,7 +5,7 @@ releases:
           version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: cluster-operator
-          version: ">= 0.24.1"
+          version: ">= 0.24.2"
           issue: https://github.com/giantswarm/giantswarm/issues/14205
         - name: coredns
           version: ">= 1.4.0"


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Bump request to latest cluster-operator legacy
