### PR TITLE
update architect-orb to 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:allow-chart-name-mismatch
+  architect: giantswarm/architect@dev:update-app-build-suite-executor
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@dev:allow-chart-name-mismatch
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ workflows:
           app_catalog_test: releases-test-catalog
           attach_workspace: true
           chart: releases-kvm
+          explicit_allow_chart_name_mismatch: true
           on_tag: false
           requires:
             - build
@@ -74,6 +75,7 @@ workflows:
           app_catalog_test: releases-test-catalog
           attach_workspace: true
           chart: releases-aws
+          explicit_allow_chart_name_mismatch: true
           on_tag: false
           requires:
             - build
@@ -98,6 +100,7 @@ workflows:
           app_catalog_test: releases-test-catalog
           attach_workspace: true
           chart: releases-azure
+          explicit_allow_chart_name_mismatch: true
           on_tag: false
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.10.0
+  architect: giantswarm/architect@2.1.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:update-app-build-suite-executor
+  architect: giantswarm/architect@2.2.0
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ workflows:
           app_catalog: releases
           app_name: releases-kvm
           app_collection_repo: kvm-app-collection
-          unique: "true"
           requires:
             - push-releases-kvm-to-releases-catalog
           filters:
@@ -85,7 +84,6 @@ workflows:
           app_catalog: releases
           app_name: releases-aws
           app_collection_repo: aws-app-collection
-          unique: "true"
           requires:
             - push-releases-aws-to-releases-catalog
             - push-releases-to-kvm-app-collection
@@ -110,7 +108,6 @@ workflows:
           app_catalog: releases
           app_name: releases-azure
           app_collection_repo: azure-app-collection
-          unique: "true"
           requires:
             - push-releases-azure-to-releases-catalog
             - push-releases-to-aws-app-collection


### PR DESCRIPTION
This PR updates the used architect-orb version to 2.1.0 which contains an important change regarding github pages deprecating redirects from giantswarm.github.com to giantswarm.github.io

https://github.com/giantswarm/giantswarm/issues/15898