### PR TITLE
Use workload cluster naming not tenant in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/releases.svg?style=shield)](https://circleci.com/gh/giantswarm/releases)
 
-# Giant Swarm Tenant Cluster Releases
+# Giant Swarm Workload Cluster Releases
 
 This repository contains tenant cluster release notes and changelogs.
 
-Tenant cluster releases can be in
+Workload cluster releases can be in
 different states, namely `active`, `deprecated` and `wip`. With pull requests
-merged to the `master` branch, tenant cluster releases get automatically deployed
+merged to the `master` branch, workload cluster releases get automatically deployed
 to all Giant Swarm installations.
 
 ## AWS

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 
 <!--
-If this is a PR with details for new release please review [Tenant Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
+If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
 - if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
 - otherwise create appropriate ticket for your release
 


### PR DESCRIPTION
Noticed we're still using tenant cluster in a couple of places in the README and PR template.