### PR TITLE
Replace tenant with workload cluster in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Giant Swarm Workload Cluster Releases
 
-This repository contains tenant cluster release notes and changelogs.
+This repository contains workload cluster release notes and changelogs.
 
 Workload cluster releases can be in
 different states, namely `active`, `deprecated` and `wip`. With pull requests


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/releases/pull/645.

Missed one. Will go with a ping.


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
