### PR TITLE
Adds helm keep resource policy

### DIFF
--- a/aws/v20.0.0-v1alpha3/release.yaml
+++ b/aws/v20.0.0-v1alpha3/release.yaml
@@ -3,6 +3,8 @@ kind: Release
 metadata:
   creationTimestamp: null
   name: v20.0.0-v1alpha3
+  annotations:
+    "helm.sh/resource-policy": keep # TODO: Remove when this release is merged to master.
 spec:
   apps:
   - componentVersion: 3.18.0


### PR DESCRIPTION
Towwards https://github.com/giantswarm/giantswarm/issues/16261

See https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource.

Given that we want to keep our branch of releases (`add-aws-capi`) deployed to test MCs for longer periods, where merges to master of this repo removes the release CR (due to newer helm 3 behaviour), this annotation keeps release CRs around, even if they would be deleted.

We will need to manually clean up this release from test MCs later.

Note the non-master target branch.