### PR TITLE
require new external-dns

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -13,6 +13,10 @@ releases:
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771
+    - name: "> 13.1.0 > 14.0.0 > 14.1.0"
+      requests:
+        - name: external-dns
+          version: ">= 2.3.0"
     - name: "> 14.0.0"
       requests:
         - name: app-operator

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -18,6 +18,8 @@ releases:
         - name: chart-operator
           version: ">= 2.12.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15920
+        - name: external-dns
+          version: ">= 2.3.0"
     - name: "> 14.1.2"
       requests:
         - name: app-operator
@@ -61,23 +63,6 @@ releases:
         - name: cluster-operator
           version: ">= 0.23.20"
           issue: https://github.com/giantswarm/roadmap/issues/187
-
-    - name: ">= 12.0.0 < 13.0.0"
-      requests:
-        - name: calico
-          version: ">= 3.15.1"
-          issue: https://github.com/giantswarm/giantswarm/issues/11307
-    - name: "> 12.1.2 < 13.0.0"
-      requests:
-        - name: containerlinux
-          version: ">= 2512.4.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/13150
-        - name: chart-operator
-          version: ">= 2.5.1"
-          issue: https://github.com/giantswarm/giantswarm/issues/14642
-          except:
-            - releaseVersion: 12.1.1
-              reason: only app changes are required
     - name: ">= 13.0.0"
       requests:
         - name: containerlinux


### PR DESCRIPTION
require externaldns 2.3.0 for all new azure and AWS releases