### PR TITLE
request latest azure scheduled events app for next azure release

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -94,3 +94,8 @@ releases:
       requests:
       - name: containerlinux
         version: ">= 2605.12.0"
+    - name: "> 14.1.4"
+      requests:
+        - name: azure-scheduled-events
+          version: ">= 0.4.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16642


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16642

require the latest azure scheduled events app for next azure release
