### PR TITLE
Update the request to request net-export v1.10.0+ on R14+

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,11 +1,9 @@
 releases:
-    - name: ">= 14.1.1"
+    - name: ">= 15.0.0"
       requests:
         - name: net-exporter
           version: ">= 1.10.0"
           issue: https://github.com/giantswarm/giantswarm/issues/16574
-    - name: ">= 15.0.0"
-      requests:
         - name: app-operator
           version: ">= 4.2.0"
           issue: https://github.com/giantswarm/roadmap/issues/254

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -25,6 +25,9 @@ releases:
         - name: chart-operator
           version: ">= 2.12.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15213
+        - name: net-exporter
+          version: ">= 1.10.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 13.1.0 < 14.0.0"
       requests:
         - name: cert-manager

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: ">= 14.1.1"
+      requests:
+        - name: net-exporter
+          version: ">= 1.10.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: ">= 15.0.0"
       requests:
         - name: app-operator
@@ -25,9 +30,6 @@ releases:
         - name: chart-operator
           version: ">= 2.12.0"
           issue: https://github.com/giantswarm/giantswarm/issues/15213
-        - name: net-exporter
-          version: ">= 1.10.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 13.1.0 < 14.0.0"
       requests:
         - name: cert-manager

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -90,6 +90,9 @@ releases:
         version: ">= 2605.10.0"
       - name: etcd
         version: ">= 3.4.14"
+      - name: net-exporter
+        version: ">= 1.10.0"
+        issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 14.0.2"
       requests:
       - name: containerlinux

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: ">= 14.1.4"
+      requests:
+        - name: net-exporter
+          version: ">= 1.10.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: ">= 15.0.0"
       requests:
         - name: app-operator
@@ -90,9 +95,6 @@ releases:
         version: ">= 2605.10.0"
       - name: etcd
         version: ">= 3.4.14"
-      - name: net-exporter
-        version: ">= 1.10.0"
-        issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 14.0.2"
       requests:
       - name: containerlinux

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,11 +1,9 @@
 releases:
-    - name: ">= 14.1.4"
+    - name: ">= 15.0.0"
       requests:
         - name: net-exporter
           version: ">= 1.10.0"
           issue: https://github.com/giantswarm/giantswarm/issues/16574
-    - name: ">= 15.0.0"
-      requests:
         - name: app-operator
           version: ">= 4.2.0"
           issue: https://github.com/giantswarm/roadmap/issues/254

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -10,6 +10,9 @@ releases:
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771
+        - name: net-exporter
+          version: ">= 1.10.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 13.1.0"
       requests:
         - name: app-operator

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,11 +1,9 @@
 releases:
-    - name: ">= 13.1.0"
+    - name: ">= 14.0.0"
       requests:
         - name: net-exporter
           version: ">= 1.10.0"
           issue: https://github.com/giantswarm/giantswarm/issues/16574
-    - name: ">= 14.0.0"
-      requests:
         - name: cert-operator
           version: ">= 1.0.1"
           issue: https://github.com/giantswarm/giantswarm/issues/14205

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,4 +1,9 @@
 releases:
+    - name: ">= 13.1.0"
+      requests:
+        - name: net-exporter
+          version: ">= 1.10.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: ">= 14.0.0"
       requests:
         - name: cert-operator
@@ -10,9 +15,6 @@ releases:
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771
-        - name: net-exporter
-          version: ">= 1.10.0"
-          issue: https://github.com/giantswarm/giantswarm/issues/16574
     - name: "> 13.1.0"
       requests:
         - name: app-operator


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
This PR is to change the request parameter to request the next release increase the net-exporter version.