### PR TITLE
request cert-manager 2.7.0 for next aws releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -16,6 +16,11 @@ releases:
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771
+    - name: "> 14.1.1 > 13.1.1"
+      requests:
+        - name: cert-manager
+          version: ">= 2.7.0"
+          issue: https://github.com/giantswarm/giantswarm/issues/17029
     - name: "> 14.1.1"
       requests:
         - name: containerlinux

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -16,7 +16,7 @@ releases:
         - name: coredns
           version: ">= 1.4.0"
           issue: https://github.com/giantswarm/giantswarm/issues/13771
-    - name: "> 14.1.1 > 13.1.1"
+    - name: "> 13.1.1 > 14.1.1"
       requests:
         - name: cert-manager
           version: ">= 2.7.0"


### PR DESCRIPTION
Next releases AWS releases should include cert-manager 2.7.0
