### PR TITLE
Only limit app-operator for 14.X releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -30,7 +30,7 @@ releases:
       requests:
         - name: external-dns
           version: ">= 2.3.0"
-    - name: "> 14.0.0"
+    - name: "> 14.0.0 < 15.0.0"
       requests:
         - name: app-operator
           version: ">= 3.2.1 < 4.0.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -28,7 +28,7 @@ releases:
           issue: https://github.com/giantswarm/giantswarm/issues/15920
         - name: external-dns
           version: ">= 2.3.0"
-    - name: "> 14.1.2"
+    - name: "> 14.1.2 < 15.0.0"
       requests:
         - name: app-operator
           version: ">= 3.2.1 < 4.0.0"


### PR DESCRIPTION
Currently we limit `app-operator` to be `< 4.0.0` - I believe in the `15.0.0` releases we should include the newest app-operator.

@giantswarm/team-batman should know best