### PR TITLE
Update architect-orb version for config-management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.11.0
+  architect: giantswarm/architect@3.0.0
 
 jobs:
   build:

--- a/helm/releases-aws/Chart.yaml
+++ b/helm/releases-aws/Chart.yaml
@@ -4,3 +4,5 @@ version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for aws.
 home: https://github.com/giantswarm/releases
+annotations:
+  config.giantswarm.io/version: 1.x.x

--- a/helm/releases-azure/Chart.yaml
+++ b/helm/releases-azure/Chart.yaml
@@ -4,3 +4,5 @@ version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for azure.
 home: https://github.com/giantswarm/releases
+annotations:
+  config.giantswarm.io/version: 1.x.x

--- a/helm/releases-kvm/Chart.yaml
+++ b/helm/releases-kvm/Chart.yaml
@@ -4,3 +4,5 @@ version: [[ .Version ]]
 appVersion: master
 description: Giant Swarm releases for kvm.
 home: https://github.com/giantswarm/releases
+annotations:
+  config.giantswarm.io/version: 1.x.x


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17386

We could potentially use separate argocd app for releases to sync them directly as there is kustomize.
But then I don't know how would we roll changes