### PR TITLE
Fix AWS v14.2.0 link title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to all Giant Swarm installations.
 ## AWS
 - v14
   - v14.2
-    - [v14.1.1](https://github.com/giantswarm/releases/tree/master/aws/v14.2.0)
+    - [v14.2.0](https://github.com/giantswarm/releases/tree/master/aws/v14.2.0)
   - v14.1
     - [v14.1.1](https://github.com/giantswarm/releases/tree/master/aws/v14.1.1)
     - [v14.1.0](https://github.com/giantswarm/releases/tree/master/aws/archived/v14.1.0)


### PR DESCRIPTION
Fix AWS v14.2.0 link title in README.md