### PR TITLE
Deprecate AWS v14.2.1 release

### DIFF
--- a/aws/v14.2.1/release.yaml
+++ b/aws/v14.2.1/release.yaml
@@ -61,7 +61,7 @@ spec:
   - name: kubernetes
     version: 1.19.9
   date: "2021-06-07T07:00:00Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
Deprecate AWS v14.2.1 release. See: https://app.incident.io/incidents/47 .