### PR TITLE
Add PR warning

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,4 +9,4 @@ Ping @sig-product for review of release notes.
 
 # Prechecks
 
-- [ ] Verify there is no `Reference:` tags for components. If there is, it will override other components with the same version in other releases.
+- [ ] Verify there is no `Reference:` tags for components. References should only be used during testing.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,3 +6,7 @@ If this is a PR with details for new release please review [Workload Cluster Rel
 
 Ping @sig-product for review of release notes.
 --->
+
+# Prechecks
+
+- [ ] Verify there is no `Reference:` tags for components. If there is, it will override other components with the same version in other releases.


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
We had a case where accidental `Reference` tag in aws 14.2.0 caused cert-operator-1.0.1 to not be deployed . Release operator failed to deploy cert-operator in other release due to this accidental tag.   