### PR TITLE
KVM workload cluster release v14.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ to all Giant Swarm installations.
 
 - v14
   - v14.1
+    - [v14.1.2](https://github.com/giantswarm/releases/tree/master/kvm/v14.1.2)
     - [v14.1.1](https://github.com/giantswarm/releases/tree/master/kvm/v14.1.1)
     - [v14.1.0](https://github.com/giantswarm/releases/tree/master/kvm/v14.1.0)
   - v14.0

--- a/kvm/kustomization.yaml
+++ b/kvm/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - v14.0.0
 - v14.1.0
 - v14.1.1
+- v14.1.2
 transformers:
 - releaseNotesTransformer.yaml

--- a/kvm/v14.1.0/release.yaml
+++ b/kvm/v14.1.0/release.yaml
@@ -49,7 +49,7 @@ spec:
     releaseOperatorDeploy: true
     version: 3.17.2
   date: "2021-06-08T17:54:06Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false

--- a/kvm/v14.1.2/README.md
+++ b/kvm/v14.1.2/README.md
@@ -1,0 +1,3 @@
+# :zap: Giant Swarm Release v14.1.2 for KVM :zap:
+
+This release reverts to Linux kernel 5.4 to mitigate issues with node deadlocks on large clusters with many pods.

--- a/kvm/v14.1.2/announcement.md
+++ b/kvm/v14.1.2/announcement.md
@@ -1,0 +1,1 @@
+**Workload cluster release v14.1.2 for KVM** is now available. This release reverts to Linux kernel 5.4 to mitigate issues with node deadlocks on large clusters with many pods. See [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-kvm/releases/kvm-v14.1.2/) for more details.

--- a/kvm/v14.1.2/kustomization.yaml
+++ b/kvm/v14.1.2/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/kvm/v14.1.2/release.diff
+++ b/kvm/v14.1.2/release.diff
@@ -1,0 +1,55 @@
+# Generated with:                                                  # Generated with:
+# devctl release create --name v14.1.1 --provider kvm --base 14    # devctl release create --name v14.1.2 --provider kvm --base 14
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v14.1.1                                                 |    name: v14.1.2
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 1.6.1                                                     version: 1.6.1
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.15.0                                                    version: 2.15.0
+  - componentVersion: 1.8.0                                          - componentVersion: 1.8.0
+    name: coredns                                                      name: coredns
+    version: 1.4.1                                                     version: 1.4.1
+  - componentVersion: 1.9.7                                          - componentVersion: 1.9.7
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.3.1                                                     version: 1.3.1
+  - componentVersion: 0.4.1                                          - componentVersion: 0.4.1
+    name: metrics-server                                               name: metrics-server
+    version: 1.3.0                                                     version: 1.3.0
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.10.1                                                    version: 1.10.1
+  - componentVersion: 1.0.1                                          - componentVersion: 1.0.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.7.2                                                     version: 1.7.2
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    releaseOperatorDeploy: false                                       releaseOperatorDeploy: false
+    version: 4.4.0                                                     version: 4.4.0
+  - name: calico                                                     - name: calico
+    version: 3.15.3                                                    version: 3.15.3
+  - name: cert-operator                                              - name: cert-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 1.0.1                                                     version: 1.0.1
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 0.27.1                                                    version: 0.27.1
+  - name: containerlinux                                             - name: containerlinux
+    version: 2765.2.4                                           |      version: 2605.12.0
+  - name: etcd                                                       - name: etcd
+    version: 3.4.16                                                    version: 3.4.16
+  - name: flannel-operator                                           - name: flannel-operator
+    version: 0.2.0                                                     version: 0.2.0
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.19.11                                                   version: 1.19.11
+  - name: kvm-operator                                               - name: kvm-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 3.17.3                                                    version: 3.17.3
+  date: "2021-06-23T05:24:59Z"                                  |    date: "2021-07-16T12:13:26Z"
+  state: deprecated                                             |    state: active
+status:                                                            status:
+  inUse: false                                                       inUse: false
+  ready: false                                                       ready: false

--- a/kvm/v14.1.2/release.yaml
+++ b/kvm/v14.1.2/release.yaml
@@ -1,10 +1,10 @@
 # Generated with:
-# devctl release create --name v14.1.1 --provider kvm --base 14.1.0 --component cluster-operator@0.27.1 --component app-operator@4.4.0 --component kvm-operator@3.17.3 --app cert-exporter@1.6.1 --app chart-operator@2.15.0 --app kube-state-metrics@1.3.1@1.9.7 --app metrics-server@1.3.0@0.4.1 --app node-exporter@1.7.2@1.0.1 --component containerlinux@2765.2.4 --component etcd@3.4.16 --component kubernetes@1.19.11
+# devctl release create --name v14.1.2 --provider kvm --base 14.1.1 --component containerlinux@2605.12.0
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
   creationTimestamp: null
-  name: v14.1.1
+  name: v14.1.2
 spec:
   apps:
   - name: cert-exporter
@@ -38,7 +38,7 @@ spec:
     releaseOperatorDeploy: true
     version: 0.27.1
   - name: containerlinux
-    version: 2765.2.4
+    version: 2605.12.0
   - name: etcd
     version: 3.4.16
   - name: flannel-operator
@@ -48,8 +48,8 @@ spec:
   - name: kvm-operator
     releaseOperatorDeploy: true
     version: 3.17.3
-  date: "2021-06-23T05:24:59Z"
-  state: deprecated
+  date: "2021-07-16T12:13:26Z"
+  state: active
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18099

We are only changing the OS version to mitigate a kernel issue.