### PR TITLE
aws-v20-update-capa-iam-controller

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -44,9 +44,9 @@ spec:
     version: 4.1.0
   - catalog: control-plane-catalog
     name: capa-iam-controller
-    reference: 0.1.1
+    reference: 0.2.0
     releaseOperatorDeploy: true
-    version: 0.1.1
+    version: 0.2.0
   - catalog: control-plane-catalog
     name: cluster-api-bootstrap-provider-kubeadm
     releaseOperatorDeploy: true


### PR DESCRIPTION
the new version of `capa-iam-controller` will ignore  CRs without watch filter label and without control plane role label