### PR TITLE
Request cert-manager 2.9.0 for AWS >15.2.0

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,6 +3,8 @@ releases:
       requests:
         - name: external-dns
           version: ">= 2.5.0"
+        - name: cert-manager
+          version: ">= 2.9.0"
     - name: ">= 15.0.0"
       requests:
         - name: net-exporter


### PR DESCRIPTION
Please include cert-manager-app 2.9.0 in future AWS releases. Thanks!