### PR TITLE
revert cluster-api-bootstrap-provider-kubeadm release

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -50,7 +50,7 @@ spec:
   - catalog: control-plane-catalog
     name: cluster-api-bootstrap-provider-kubeadm
     releaseOperatorDeploy: true
-    version: 0.3.22-gs4
+    version: 0.3.22-gs1
   - catalog: control-plane-test-catalog
     name: cluster-api-control-plane
     releaseOperatorDeploy: true


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

I didn't double check that cluster-api-bootstrap-provider-kubeadm doesn't have the same tag as the others 🤦🏻. My bad.