### PR TITLE
update capa release

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -53,7 +53,7 @@ spec:
   - catalog: control-plane-test-catalog
     name: cluster-api-control-plane
     releaseOperatorDeploy: true
-    version: 0.3.22-gs2
+    version: 0.3.22-gs3
   - catalog: control-plane-catalog
     name: cluster-api-core
     releaseOperatorDeploy: true
@@ -61,7 +61,7 @@ spec:
   - catalog: control-plane-test-catalog
     name: cluster-api-provider-aws
     releaseOperatorDeploy: true
-    version: 0.6.8-gs2
+    version: 0.6.8-gs3
   - catalog: control-plane-test-catalog
     name: policies-common
     releaseOperatorDeploy: true


### PR DESCRIPTION
This just bumps the capa app for a minor bug and the capi control-plane app because the previous tag did not get released properly and could not be deployed.

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
