### PR TITLE
capa-bump-cluster-apps-operator

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -73,7 +73,7 @@ spec:
   - catalog: control-plane-catalog
     name: cluster-apps-operator
     releaseOperatorDeploy: true
-    version: 0.4.0
+    version: 0.6.0
   - catalog: control-plane-catalog
     name: kubernetes
     version: 1.19.9


### PR DESCRIPTION
the new version is necessary for the AWS cni and calico-policy-only