### PR TITLE
Make AWS v15.2.0 release active

### DIFF
--- a/aws/v15.2.0/release.yaml
+++ b/aws/v15.2.0/release.yaml
@@ -65,7 +65,7 @@ spec:
   - name: kubernetes
     version: 1.20.9
   date: "2021-08-23T10:00:00Z"
-  state: deprecated
+  state: active
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Make AWS v15.2.0 release active in order to enable upgrades via Happa.