### PR TITLE
update-capa-release

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -61,7 +61,7 @@ spec:
   - catalog: control-plane-test-catalog
     name: cluster-api-provider-aws
     releaseOperatorDeploy: true
-    version: 0.6.8-gs4
+    version: 0.6.8-gs5
   - catalog: control-plane-test-catalog
     name: policies-common
     releaseOperatorDeploy: true


### PR DESCRIPTION
include changes for labels for cluster-api-provider-aws