### PR TITLE
Use cert-manager 2.10.0 in upcoming AWS releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -4,7 +4,7 @@ releases:
         - name: external-dns
           version: ">= 2.5.0"
         - name: cert-manager
-          version: ">= 2.9.0"
+          version: ">= 2.10.0"
         - name: cert-exporter
           version: ">= 1.8.0"
     - name: ">= 15.0.0"


### PR DESCRIPTION
Please include https://github.com/giantswarm/cert-manager-app/releases/tag/v2.10.0 in upcoming AWS releases


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
