### PR TITLE
Use cluster-apps-operator v0.6.1

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -80,7 +80,7 @@ spec:
   - catalog: control-plane-catalog
     name: cluster-apps-operator
     releaseOperatorDeploy: true
-    version: 0.6.0
+    version: 0.6.1
   - catalog: control-plane-catalog
     name: kubernetes
     version: 1.19.9


### PR DESCRIPTION
Contains a fix for ensuring the workload cluster namespace is deleted correctly.

See https://github.com/giantswarm/cluster-apps-operator/pull/103

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
