### PR TITLE
deprecate v15.2.1 release

### DIFF
--- a/aws/v15.2.1/release.yaml
+++ b/aws/v15.2.1/release.yaml
@@ -65,7 +65,7 @@ spec:
   - name: kubernetes
     version: 1.20.9
   date: "2021-08-26T10:00:00Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
AWS v15.2.1 is deprecated in favor of v15.2.2.