### PR TITLE
Adding requests for cert-operator in azure and aws

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,6 +3,8 @@ releases:
       requests:
         - name: aws-ebs-csi-driver
           version: ">= 2.7.0"
+        - name: cert-operator
+          version: ">= 1.2.0"
     - name: "> 15.2.2"
       requests:
         - name: external-dns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,6 +5,8 @@ releases:
           version: ">= 2.5.0"
         - name: cert-exporter
           version: ">= 1.8.0"
+        - name: cert-operator
+          version: "< 1.2.0"
     - name: "> 15.0.1"
       requests:
         - name: external-dns


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/494

The new version of `cert-operator` ensures that secrets are in the same namespace as the cluster. We want this for AWS but sadly in azure it does not work yet.

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
