### PR TITLE
deprecate v16.0.0 release

### DIFF
--- a/aws/v16.0.0/release.yaml
+++ b/aws/v16.0.0/release.yaml
@@ -65,7 +65,7 @@ spec:
   - name: kubernetes
     version: 1.21.5
   date: "2021-10-04T10:00:00Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
AWS v16.0.0 is deprecated in favor of v16.0.1.

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->