### PR TITLE
Request cluster-operator 3.11.0 for AWS

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,6 +3,8 @@ releases:
       requests:
         - name: cert-exporter
           version: ">= 2.0.0"
+        - name: cluster-operator
+          version: ">= 3.11.0"
     - name: "> 16.0.1"
       requests:
         - name: aws-ebs-csi-driver


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->

Towards https://github.com/giantswarm/roadmap/issues/545

Latest cluster-operator now includes the WC cluster CA. This is for apps like dex that need to verify it.
