### PR TITLE
Update capi/capa components

### DIFF
--- a/aws/v20.0.0-alpha1/release.yaml
+++ b/aws/v20.0.0-alpha1/release.yaml
@@ -57,19 +57,19 @@ spec:
   - catalog: control-plane-catalog
     name: cluster-api-bootstrap-provider-kubeadm
     releaseOperatorDeploy: true
-    version: 0.3.22-gs6
+    version: 0.3.22-gs10
   - catalog: control-plane-catalog
     name: cluster-api-control-plane
     releaseOperatorDeploy: true
-    version: 0.3.22-gs9
+    version: 0.3.22-gs10
   - catalog: control-plane-catalog
     name: cluster-api-core
     releaseOperatorDeploy: true
-    version: 0.3.22-gs4
+    version: 0.3.22-gs5
   - catalog: control-plane-catalog
     name: cluster-api-provider-aws
     releaseOperatorDeploy: true
-    version: 0.6.8-gs8
+    version: 0.6.8-gs10
   - catalog: control-plane-test-catalog
     name: policies-common
     releaseOperatorDeploy: true


### PR DESCRIPTION
This will fix running multiple apps via argo and release. 

There was a bug which stopped helm installing the app for CRD webhook and
dynamic webhooks plus controller. It was only able to install CRD
webhook via argo but failed deploying the release apps.

We also had to rename the tags for the CRD webhook (ending *-crd)
because the management webhook doesn't allow to have the same tag for
the same app twice.

This madness will hopefully end when using v1alpha4 and above. 

Issue: https://github.com/giantswarm/giantswarm/issues/19415

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->