### PR TITLE
Upgrade kyverno policies

### DIFF
--- a/aws/v20.0.0-alpha1/release.yaml
+++ b/aws/v20.0.0-alpha1/release.yaml
@@ -73,11 +73,11 @@ spec:
   - catalog: control-plane-test-catalog
     name: policies-common
     releaseOperatorDeploy: true
-    version: 0.6.2
+    version: 0.10.0
   - catalog: control-plane-test-catalog
     name: policies-aws
     releaseOperatorDeploy: true
-    version: 0.6.2
+    version: 0.10.0
   - catalog: control-plane-catalog
     name: cluster-apps-operator
     releaseOperatorDeploy: true


### PR DESCRIPTION
Since we renamed the release, we need to use the upgraded policies that take the renaming into account.
