### PR TITLE
lower containerlinux request for aws

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -2,7 +2,7 @@ releases:
     - name: "> 16.1.0"
       requests:
         - name: containerlinux
-          version: ">= 2983.2.1"
+          version: ">= 2983.2.0"
     - name: "> 15.2.2 > 16.0.2"
       requests:
         - name: cluster-operator


### PR DESCRIPTION
Lowering next aws release's containerlinux request as that version is not yet available