### PR TITLE
Override cluster operator for old azure releases

### DIFF
--- a/azure/v15.1.2/release.yaml
+++ b/azure/v15.1.2/release.yaml
@@ -43,6 +43,7 @@ spec:
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 0.27.1
+    reference: 0.27.1-1
   - name: kubernetes
     version: 1.20.11
   - name: containerlinux

--- a/azure/v15.1.3/release.yaml
+++ b/azure/v15.1.3/release.yaml
@@ -42,6 +42,7 @@ spec:
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 0.27.1
+    reference: 0.27.1-1
   - name: kubernetes
     version: 1.20.12
   - name: containerlinux

--- a/azure/v16.0.1/release.yaml
+++ b/azure/v16.0.1/release.yaml
@@ -44,6 +44,7 @@ spec:
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 0.27.2
+    reference: 0.27.2-1
   - name: kubernetes
     version: 1.21.5
   - name: containerlinux

--- a/azure/v16.0.2/release.yaml
+++ b/azure/v16.0.2/release.yaml
@@ -44,6 +44,7 @@ spec:
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 0.27.2
+    reference: 0.27.2-1
   - name: kubernetes
     version: 1.21.6
   - name: containerlinux


### PR DESCRIPTION
See:
- https://gigantic.slack.com/archives/C02HLSDH3DZ/p1639395810009100
- https://gigantic.slack.com/archives/C02HLSDH3DZ/p1639405908028500
- https://gigantic.slack.com/archives/C02HLSDH3DZ/p1639402845023800

There was a long standing bug in cluster operator legacy, that made the operator reconcile all AzureClusterConfig CRs, even those without a matching "cluster-operator version" label matching.
This bug went silent for many azure releases, but bubbled up with release 16.1.0 when we switched to non-legacy cluster operator.
In azure clusters upgraded to this release from a previous one, the old cluster operator instances (the bugged legacy ones) and the new one fought each other for controlling default apps in the workload cluster.

We released 2 hotfix versions of legacy cluster operator to fix the 2 versions currently in use (0.27.1 and 0.27.2).

This PR does something that can't be said: it bumps cluster operator in the old releases to use the fixed version of cluster operator legacy.