### PR TITLE
Request cert-exporter 2.0.1

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: "> 16.2.0 > 16.1.0 > 16.0.1"
+      requests:
+        - name: cert-exporter
+          version: ">= 2.0.1"
     - name: "> 16.1.0"
       requests:
         - name: containerlinux

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: "> 16.1.1 > 16.0.2 > 15.1.3"
+      requests:
+        - name: cert-exporter
+          version: ">= 2.0.1"
     - name: "> 16.0.2"
       requests:
         - name: cert-operator

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -2,6 +2,6 @@ releases:
     - name: "> 16.1.0"
       requests:
         - name: cert-exporter
-          version: ">= 2.0.0"
+          version: ">= 2.0.1"
         - name: cert-operator
           version: ">= 1.1.0 < 1.2.0"


### PR DESCRIPTION
This PR requests cert-exporter 2.0.1 in upcoming releases. It should fix upgrade issues upgrading cert-exporter from 1.8.0 to 2.0.0
