### PR TITLE
Request cert-manager 2.12.0 in upcoming AWS releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,6 +3,8 @@ releases:
       requests:
         - name: cert-exporter
           version: ">= 2.0.1"
+        - name: cert-manager
+          version: ">= 2.12.0"
     - name: "> 16.1.0"
       requests:
         - name: containerlinux


### PR DESCRIPTION
This PR requests cert-manager 2.12.0 in upcoming AWS releases