### PR TITLE
bump cert operator to 0.1.0-3 for ancient aws releases

### DIFF
--- a/aws/v13.1.0/release.yaml
+++ b/aws/v13.1.0/release.yaml
@@ -52,7 +52,7 @@ spec:
   - name: calico
     version: 3.15.3
   - name: cert-operator
-    reference: 0.1.0-2
+    reference: 0.1.0-3
     releaseOperatorDeploy: true
     version: 0.1.0
   - name: cluster-operator

--- a/aws/v13.2.0/release.yaml
+++ b/aws/v13.2.0/release.yaml
@@ -51,7 +51,7 @@ spec:
   - name: calico
     version: 3.15.3
   - name: cert-operator
-    reference: 0.1.0-2
+    reference: 0.1.0-3
     releaseOperatorDeploy: true
     version: 0.1.0
   - name: cluster-operator

--- a/aws/v14.1.1/release.yaml
+++ b/aws/v14.1.1/release.yaml
@@ -50,7 +50,7 @@ spec:
   - name: calico
     version: 3.15.3
   - name: cert-operator
-    reference: 0.1.0-2
+    reference: 0.1.0-3
     releaseOperatorDeploy: true
     version: 0.1.0
   - name: cluster-operator


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20196

We needed to make an emergency patch release for the ancient 0.1.0 version of cert operator.
This PR bumps the AWS platform releases using it to this patched version.