### PR TITLE
Deprecate AWS v16.2.0 and Azure v16.1.1

### DIFF
--- a/aws/v16.2.0/release.yaml
+++ b/aws/v16.2.0/release.yaml
@@ -67,7 +67,7 @@ spec:
   - name: kubernetes
     version: 1.21.7
   date: "2021-12-09T10:14:45Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false

--- a/azure/v16.1.1/release.yaml
+++ b/azure/v16.1.1/release.yaml
@@ -53,7 +53,7 @@ spec:
   - name: etcd
     version: 3.4.18
   date: "2021-12-14T08:14:17Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
Deprecate AWS v16.2.0 and Azure v16.1.1 because of Java applications using old JDKs are crashing when using cgroups v2.

More details:
- https://bugs.openjdk.java.net/browse/JDK-8230305
- https://gigantic.slack.com/archives/C02HLSDH3DZ/p1639997225244900