### PR TITLE
Request aws-cni 1.10.1 for next aws release

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -7,6 +7,8 @@ releases:
           version: ">= 2.7.0"
         - name: cert-manager
           version: ">= 2.12.0"
+        - name: aws-cni
+          version: ">= 1.10.1"
     - name: "> 15.2.2 > 16.0.2"
       requests:
         - name: cluster-operator


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/655

We are getting paged by AWS-CNI a lot, so let's do what we can and make it as updated as possible in next releases
