### PR TITLE
Request calico 3.21 for 17.x releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: ">= 17.0.0-alpha1"
+      requests:
+        - name: calico
+          version: ">= 3.21.3"
     - name: "< 17.0.0"
       requests:
         - name: containerlinux

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: ">= 17.0.0-alpha1"
+      requests:
+        - name: calico
+          version: ">= 3.21.3"
     - name: "< 17.0.0"
       requests:
         - name: containerlinux


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/695

request newer calico for 17.x releases