### PR TITLE
Request app-operator 5.4.1 for AWS and Azure

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -9,8 +9,6 @@ releases:
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
-        - name: app-operator
-          version: ">= 5.4.1"
     - name: "> 16.2.0 > 16.1.0 > 16.0.1"
       requests:
         - name: cert-exporter

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,10 +3,14 @@ releases:
       requests:
         - name: calico
           version: ">= 3.21.3"
+        - name: app-operator
+          version: ">= 5.4.1"
     - name: "< 17.0.0"
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
+        - name: app-operator
+          version: ">= 5.4.1"
     - name: "> 16.2.0 > 16.1.0 > 16.0.1"
       requests:
         - name: cert-exporter

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -9,8 +9,6 @@ releases:
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
-        - name: app-operator
-          version: ">= 5.4.1"
     - name: "> 16.1.2"
       requests:
       - name: cert-operator

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,10 +3,14 @@ releases:
       requests:
         - name: calico
           version: ">= 3.21.3"
+        - name: app-operator
+          version: ">= 5.4.1"
     - name: "< 17.0.0"
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
+        - name: app-operator
+          version: ">= 5.4.1"
     - name: "> 16.1.2"
       requests:
       - name: cert-operator


### PR DESCRIPTION
Fix for PM giantswarm/giantswarm#20379

Chart CRD is now embedded rather than fetched from GitHub to avoid hitting API rate limits.