### PR TITLE
Request external-dns 2.8.0 in upcoming aws and azure platform releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -9,6 +9,10 @@ releases:
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
+    - name: "> 16.3.0 > 16.1.0 > 16.0.1"
+      requests:
+        - name: external-dns
+          version: ">= 2.8.0"
     - name: "> 16.2.0 > 16.1.0 > 16.0.1"
       requests:
         - name: cert-exporter

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -9,7 +9,7 @@ releases:
       requests:
         - name: containerlinux
           version: "<= 2905.2.6"
-    - name: "> 16.3.0 > 16.1.0 > 16.0.1"
+    - name: "> 16.3.1 > 16.1.0 > 16.0.1"
       requests:
         - name: external-dns
           version: ">= 2.8.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -13,6 +13,8 @@ releases:
       requests:
       - name: cert-operator
         version: ">= 1.3.0"
+      - name: external-dns
+        version: ">= 2.8.0"
     - name: "> 16.1.1 > 16.0.2 > 15.1.3"
       requests:
         - name: cert-exporter


### PR DESCRIPTION
Please include external-dns 2.8.0 in upcoming AWS and Azure platform releases.