### PR TITLE
Request external-dns v2.9.0 in upcoming platform releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: "> 17.0.0-alpha1"
+      requests:
+        - name: external-dns
+          version: ">= 2.9.0"
     - name: ">= 17.0.0-alpha1"
       requests:
         - name: calico
@@ -12,7 +16,7 @@ releases:
     - name: "> 16.3.1 > 16.1.0 > 16.0.1"
       requests:
         - name: external-dns
-          version: ">= 2.8.0"
+          version: ">= 2.9.0"
     - name: "> 16.2.0 > 16.1.0 > 16.0.1"
       requests:
         - name: cert-exporter

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: "> 17.0.0-alpha1"
+      requests:
+      - name: external-dns
+        version: ">= 2.9.0"
     - name: ">= 17.0.0-alpha1"
       requests:
         - name: calico
@@ -14,7 +18,7 @@ releases:
       - name: cert-operator
         version: ">= 1.3.0"
       - name: external-dns
-        version: ">= 2.8.0"
+        version: ">= 2.9.0"
     - name: "> 16.1.1 > 16.0.2 > 15.1.3"
       requests:
         - name: cert-exporter


### PR DESCRIPTION
Please include external-dns-app v2.9.0 in upcoming platform releases. It contains changes which mitigate rate limiting.