### PR TITLE
Added cluster-autoscaler version bump to v17 requests

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -5,6 +5,8 @@ releases:
           version: ">= 2.9.0"
         - name: app-operator
           version: ">= 5.6.0"
+        - name: cluster-autoscaler
+          version: ">= 1.22.2-gs3"
     - name: ">= 17.0.0-alpha1"
       requests:
         - name: calico

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,6 +5,8 @@ releases:
         version: ">= 2.9.0"
       - name: app-operator
         version: ">= 5.6.0"
+      - name: cluster-autoscaler
+        version: ">= 1.22.2-gs3"
     - name: ">= 17.0.0-alpha1"
       requests:
         - name: calico


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
