### PR TITLE
Update capi APP to 1.0.2

### DIFF
--- a/azure/v20.0.0-alpha1/release.yaml
+++ b/azure/v20.0.0-alpha1/release.yaml
@@ -45,7 +45,7 @@ spec:
   - name: cluster-api
     catalog: control-plane-catalog
     releaseOperatorDeploy: true
-    version: 1.0.1
+    version: 1.0.2
   - name: cluster-api-provider-azure
     catalog: control-plane-catalog
     releaseOperatorDeploy: true


### PR DESCRIPTION
The cluster-api-app `v1.0.2` doesn't use the `config` repo. We also did some improvements on kustomize generation.