### PR TITLE
bump architect-orb to v4.12.0

### DIFF
--- a/.circleci/provider_config.yml
+++ b/.circleci/provider_config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.3.0
+  architect: giantswarm/architect@4.12.0
 
 parameters:
   push-aws:


### PR DESCRIPTION
Merging this PR will cause architect-orb to correctly update `flux-manifests` in provider collections.