### PR TITLE
bump azure-ad-pod-identity in 20.0.0-alpha1 while we wait to move it to the app collection

### DIFF
--- a/azure/v20.0.0-alpha1/release.yaml
+++ b/azure/v20.0.0-alpha1/release.yaml
@@ -41,7 +41,7 @@ spec:
   - catalog: control-plane-catalog
     name: azure-ad-pod-identity-app
     releaseOperatorDeploy: true
-    version: 0.7.0
+    version: 0.8.0
   - name: cluster-api
     catalog: control-plane-catalog
     releaseOperatorDeploy: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/812

