### PR TITLE
bump autoscaler for azure 17.0.0

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,7 +6,7 @@ releases:
       - name: app-operator
         version: ">= 5.6.0"
       - name: cluster-autoscaler
-        version: ">= 1.22.2-gs3"
+        version: ">= 1.22.2-gs4"
       - name: azure-operator
         version: ">= 5.15.0"
       - name: kube-state-metrics


### PR DESCRIPTION
towards: https://github.com/giantswarm/roadmap/issues/784

request fixed cluster autoscaler 1.22 version for azure 17.0.0