### PR TITLE
Request chart-operator 2.20.1 for AWS and Azure

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -7,6 +7,8 @@ releases:
           version: ">= 0.6.0"
         - name: aws-ebs-csi-driver
           version: ">= 2.9.0"
+        - name: chart-operator
+          version: ">= 2.20.1"
     - name: "> 17.0.0"
       requests:
         - name: coredns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,6 +3,8 @@ releases:
       requests:
       - name: azure-operator
         version: ">= 5.18.0"
+      - name: chart-operator
+        version: ">= 2.20.1"
     - name: "> 17.0.0-alpha1"
       requests:
       - name: external-dns


### PR DESCRIPTION
Latest chart-operator has a fix to improve the chart CR status when problems occur.

https://github.com/giantswarm/chart-operator/pull/860

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
