### PR TITLE
Request chart-operator v2.20.1 for KVM

### DIFF
--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,1 +1,5 @@
 releases:
+- name: "> 16.2.0"
+  requests:
+  - name: chart-operator
+    version: ">= 2.20.1"


### PR DESCRIPTION
Latest chart-operator has a fix to improve the chart CR status when problems occur.

https://github.com/giantswarm/chart-operator/pull/860


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
