### PR TITLE
Add VPA removal note to AWS v17 releases

### DIFF
--- a/aws/v17.0.0/README.md
+++ b/aws/v17.0.0/README.md
@@ -40,6 +40,8 @@ This release provides support for Kubernetes 1.22, has Control Groups v2 enabled
 **Control Groups v1**
 To ensure a smooth transition, in case you need time to modify applications to make them compatible with Control Groups v2, we provide a mechanism that will allow using Control Groups v1 on specific node pools. More details are available in our [documentation](https://docs.giantswarm.io/advanced/forcing-cgroupsv1/).
 
+**Note when upgrading from v16 to v17:** Existing `Vertical Pod Autoscaler` app installations need to be removed from the workload cluster prior to upgrading to v17 because the `Vertical Pod Autscaler` is provided as a default application. The two applications have different names which leads to them fighting each other.
+
 
 ## Change details
 

--- a/aws/v17.0.1/README.md
+++ b/aws/v17.0.1/README.md
@@ -10,6 +10,8 @@ This release allows one replica of `coredns` to run on the control plane nodes f
 **Control Groups v1**
 To ensure a smooth transition, in case you need time to modify applications to make them compatible with Control Groups v2, we provide a mechanism that will allow using Control Groups v1 on specific node pools. More details are available in our [documentation](https://docs.giantswarm.io/advanced/forcing-cgroupsv1/).
 
+**Note when upgrading from v16 to v17:** Existing `Vertical Pod Autoscaler` app installations need to be removed from the workload cluster prior to upgrading to v17 because the `Vertical Pod Autscaler` is provided as a default application. The two applications have different names which leads to them fighting each other.
+
 ## Change details
 
 

--- a/aws/v17.0.2/README.md
+++ b/aws/v17.0.2/README.md
@@ -5,6 +5,8 @@ This release downgrades the version of the Flatcar AMI from `3033.2.2` to `3033.
 * [Giant Swarm roadmap issue](https://github.com/giantswarm/roadmap/issues/891)
 * [Upstream bug issue](https://github.com/flatcar-linux/Flatcar/issues/665)
 
+**Note when upgrading from v16 to v17:** Existing `Vertical Pod Autoscaler` app installations need to be removed from the workload cluster prior to upgrading to v17 because the `Vertical Pod Autscaler` is provided as a default application. The two applications have different names which leads to them fighting each other.
+
 ## Change details
 
 ### containerlinux [3033.2.0](https://www.flatcar-linux.org/releases/#release-3033.2.0)

--- a/aws/v17.1.0/README.md
+++ b/aws/v17.1.0/README.md
@@ -11,6 +11,9 @@ This release introduces IAM roles for service accounts (IRSA) as an alternative 
 
 All the AWS prerequisites are available in the [giantswarm-aws-account-prerequisites repository](https://github.com/giantswarm/giantswarm-aws-account-prerequisites).
 
+**Note when upgrading from v16 to v17:** Existing `Vertical Pod Autoscaler` app installations need to be removed from the workload cluster prior to upgrading to v17 because the `Vertical Pod Autscaler` is provided as a default application. The two applications have different names which leads to them fighting each other.
+
+
 ## Change details
 
 

--- a/aws/v17.2.0/README.md
+++ b/aws/v17.2.0/README.md
@@ -15,6 +15,8 @@ This release improves the performance of `etcd` by using `gp3` volumes with prov
   * 1 openssl CVE;
   * 1 ignition
 
+**Note when upgrading from v16 to v17:** Existing `Vertical Pod Autoscaler` app installations need to be removed from the workload cluster prior to upgrading to v17 because the `Vertical Pod Autscaler` is provided as a default application. The two applications have different names which leads to them fighting each other.
+
 ## Change details
 
 


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
Add VPA removal note to AWS v17 releases. This is required because on workload clusters which already have the `Vertical Pod Autoscaler` an alert is being triggered: https://github.com/giantswarm/giantswarm/issues/21424 .