### PR TITLE
Request kube-state-metrics v1.9.0 in upcoming platform releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -2,7 +2,7 @@ releases:
     - name: "> 16.1.1 > 16.3.1 > 16.4.1 > 17.1.0 > 17.2.0"
       requests:
         - name: kube-state-metrics
-          version: ">= 1.8.0"
+          version: ">= 1.9.0"
     - name: "> 17.1.0"
       requests:
         - name: kiam
@@ -72,7 +72,7 @@ releases:
         - name: aws-ebs-csi-driver
           version: ">= 2.7.1"
         - name: kube-state-metrics
-          version: ">= 1.5.0"
+          version: ">= 1.9.0"
     - name: "> 16.0.0"
       requests:
         - name: cert-operator

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+    - name: "> 16.1.1 > 16.3.1 > 16.4.1 > 17.1.0 > 17.2.0"
+      requests:
+        - name: kube-state-metrics
+          version: ">= 1.8.0"
     - name: "> 17.1.0"
       requests:
         - name: kiam

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -72,7 +72,7 @@ releases:
         - name: aws-ebs-csi-driver
           version: ">= 2.7.1"
         - name: kube-state-metrics
-          version: ">= 1.9.0"
+          version: ">= 1.5.0"
     - name: "> 16.0.0"
       requests:
         - name: cert-operator

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-    - name: "> 16.0.2 > 16.1.2"
+    - name: "> 16.0.2 > 16.1.2 > 17.0.1 > 17.1.0"
       requests:
       - name: kube-state-metrics
         version: ">= 1.9.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -2,7 +2,7 @@ releases:
     - name: "> 16.0.2 > 16.1.2"
       requests:
       - name: kube-state-metrics
-        version: ">= 1.8.0"
+        version: ">= 1.9.0"
     - name: "> 17.0.0"
       requests:
       - name: azure-operator
@@ -10,7 +10,7 @@ releases:
       - name: chart-operator
         version: ">= 2.20.1"
       - name: kube-state-metrics
-        version: ">= 1.8.0"
+        version: ">= 1.9.0"
     - name: "> 17.0.0-alpha1"
       requests:
       - name: external-dns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,10 +1,16 @@
 releases:
+    - name: "> 16.0.2 > 16.1.2"
+      requests:
+      - name: kube-state-metrics
+        version: ">= 1.8.0"
     - name: "> 17.0.0"
       requests:
       - name: azure-operator
         version: ">= 5.18.0"
       - name: chart-operator
         version: ">= 2.20.1"
+      - name: kube-state-metrics
+        version: ">= 1.8.0"
     - name: "> 17.0.0-alpha1"
       requests:
       - name: external-dns

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,5 +1,11 @@
 releases:
+- name: "> 16.1.2"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.8.0"
 - name: "> 16.2.0"
   requests:
   - name: chart-operator
     version: ">= 2.20.1"
+  - name: kube-state-metrics
+    version: ">= 1.8.0"

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -2,7 +2,7 @@ releases:
 - name: "> 16.1.2"
   requests:
   - name: kube-state-metrics
-    version: ">= 1.8.0"
+    version: ">= 1.9.0"
 - name: "> 16.2.0"
   requests:
   - name: chart-operator

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "> 16.1.2"
+- name: "> 16.1.2 > 16.2.1"
   requests:
   - name: kube-state-metrics
     version: ">= 1.9.0"
@@ -7,5 +7,3 @@ releases:
   requests:
   - name: chart-operator
     version: ">= 2.20.1"
-  - name: kube-state-metrics
-    version: ">= 1.8.0"


### PR DESCRIPTION
This PR requests  kube-state-metrics v1.9.0 in upcoming platform releases

It contains a fix to include `giantswarm.io/service-type` in `kube_..._labels` metrics 
Towards https://github.com/giantswarm/giantswarm/issues/21615