### PR TITLE
Remove old CAPI and CAPA apps from v20.0.0-alpha1 on AWS

### DIFF
--- a/aws/v20.0.0-alpha1/release.yaml
+++ b/aws/v20.0.0-alpha1/release.yaml
@@ -54,22 +54,6 @@ spec:
     reference: 0.3.0
     releaseOperatorDeploy: true
     version: 0.3.0
-  - catalog: control-plane-catalog
-    name: cluster-api-bootstrap-provider-kubeadm
-    releaseOperatorDeploy: true
-    version: 0.3.22-gs12
-  - catalog: control-plane-catalog
-    name: cluster-api-control-plane
-    releaseOperatorDeploy: true
-    version: 0.3.22-gs12
-  - catalog: control-plane-catalog
-    name: cluster-api-core
-    releaseOperatorDeploy: true
-    version: 0.3.22-gs6
-  - catalog: control-plane-catalog
-    name: cluster-api-provider-aws
-    releaseOperatorDeploy: true
-    version: 0.6.8-gs10
   - catalog: control-plane-test-catalog
     name: policies-common
     releaseOperatorDeploy: true


### PR DESCRIPTION
We are deploying CAPI and CAPA from the app collection now.

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
