### PR TITLE
Request cluster-operator 4.0.2 for AWS > 17.2.0

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -5,6 +5,8 @@ releases:
     version: ">= 1.9.0"
   - name: cert-manager
     version: ">= 2.13.0"
+  - name: cluster-operator
+    version: ">= 4.0.2"
 - name: "> 17.1.0"
   requests:
   - name: kiam

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -5,6 +5,8 @@ releases:
     version: ">= 1.9.0"
   - name: cert-manager
     version: ">= 2.13.0"
+- name: "> 17.2.0"
+  requests:
   - name: cluster-operator
     version: ">= 4.0.2"
 - name: "> 17.1.0"


### PR DESCRIPTION
cluster-operator 4.0.2 has a fix from Nick for selecting app CRs in 4.0.1.

This can cause alerts after cluster upgrades or deletions. As optional apps are not updated by cluster-operator.

