### PR TITLE
Requests: Fix patterns.

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -15,6 +15,12 @@ releases:
     version: ">= 2.9.0"
   - name: chart-operator
     version: ">= 2.20.1"
+- name: "> 17.1.0 < 17.2.0"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.9.0"
+  - name: cert-manager
+    version: ">= 2.13.0"
 - name: "> 17.0.0"
   requests:
   - name: coredns
@@ -43,6 +49,12 @@ releases:
   requests:
   - name: containerlinux
     version: "<= 2905.2.6"
+- name: "> 16.4.1 < 17.0.0-alpha1"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.9.0"
+  - name: cert-manager
+    version: ">= 2.13.0"
 - name: "> 16.4.0 < 17.0.0-alpha1"
   requests:
   - name: coredns
@@ -51,6 +63,12 @@ releases:
   requests:
   - name: external-dns
     version: ">= 2.9.0"
+- name: "> 16.3.1 < 16.4.0"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.9.0"
+  - name: cert-manager
+    version: ">= 2.13.0"
 - name: "> 16.2.0 < 17.0.0-alpha1"
   requests:
   - name: cert-exporter
@@ -65,7 +83,13 @@ releases:
     version: ">= 2.1.0"
   - name: cert-operator
     version: ">= 1.3.0"
-- name: "> 15.2.2 > 16.0.2"
+- name: "> 16.1.1 < 16.2.0"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.9.0"
+  - name: cert-manager
+    version: ">= 2.13.0"
+- name: "> 16.0.2"
   requests:
   - name: cluster-operator
     version: ">= 3.11.0"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -51,7 +51,7 @@ releases:
   requests:
   - name: external-dns
     version: ">= 2.9.0"
-- name: "> 16.2.0 > 16.1.0 > 16.0.1 < 17.0.0-alpha1"
+- name: "> 16.2.0 < 17.0.0-alpha1"
   requests:
   - name: cert-exporter
     version: ">= 2.0.1"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "> 16.1.1 > 16.3.1 > 16.4.1 > 17.1.0 > 17.2.0"
+- name: "> 17.2.0"
   requests:
   - name: kube-state-metrics
     version: ">= 1.9.0"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -47,7 +47,7 @@ releases:
   requests:
   - name: coredns
     version: ">= 1.8.0"
-- name: "> 16.3.1 > 16.1.0 > 16.0.1 < 17.0.0-alpha1"
+- name: "> 16.3.1 < 17.0.0-alpha1"
   requests:
   - name: external-dns
     version: ">= 2.9.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,8 +1,4 @@
 releases:
-- name: "> 16.0.2 > 16.1.2 > 17.0.1 > 17.1.0"
-  requests:
-  - name: kube-state-metrics
-    version: ">= 1.10.0"
 - name: "> 17.0.0"
   requests:
   - name: azure-operator
@@ -10,7 +6,7 @@ releases:
   - name: chart-operator
     version: ">= 2.20.1"
   - name: kube-state-metrics
-    version: ">= 1.9.0"
+    version: ">= 1.10.0"
 - name: "> 17.0.0-alpha1"
   requests:
   - name: external-dns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -41,6 +41,8 @@ releases:
   requests:
   - name: coredns
     version: ">= 1.8.0"
+  - name: kube-state-metrics
+    version: ">= 1.10.0"
 - name: "> 16.1.2"
   requests:
   - name: cert-operator
@@ -60,7 +62,7 @@ releases:
   - name: cert-operator
     version: ">= 1.1.0 < 1.2.0"
   - name: kube-state-metrics
-    version: ">= 1.5.0"
+    version: ">= 1.10.0"
   - name: cluster-operator
     version: ">= 3.12.0"
   - name: azure-operator

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -1,9 +1,11 @@
 releases:
-- name: "> 16.1.2 > 16.2.1"
-  requests:
-  - name: kube-state-metrics
-    version: ">= 1.9.0"
 - name: "> 16.2.0"
   requests:
   - name: chart-operator
     version: ">= 2.20.1"
+  - name: kube-state-metrics
+    version: ">= 1.9.0"
+- name: "> 16.1.1 < 16.2.0"
+  requests:
+  - name: kube-state-metrics
+    version: ">= 1.9.0"


### PR DESCRIPTION
It seems those release patterns got a bit misunderstood in the past. I fixed them and attached more details and code snippets in the corresponding commit messages.

~~To make sure we're not breaking tests for already released versions, I fixed the pattern to what they are actually doing instead of what they were intended to do.~~

I ported back `kube-state-metrics` and `cert-manager` as requested by @ubergesundheit.