### PR TITLE
AWS & Azure: Request `external-dns` v2.14.0 in upcoming minor releases.

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,8 +1,8 @@
 releases:
-- name: "> 17.3.9"
+- name: ">= 17.4.0"
   requests:
   - name: external-dns
-    version: ">= 2.10.0"
+    version: ">= 2.14.0"
 - name: "> 17.3.2"
   requests:
   - name: metrics-server-app

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 17.1.0"
+  requests:
+  - name: external-dns
+    version: ">= 2.14.0"
 - name: "> 17.0.0"
   requests:
   - name: azure-operator
@@ -7,8 +11,6 @@ releases:
     version: ">= 2.20.1"
   - name: kube-state-metrics
     version: ">= 1.10.0"
-  - name: external-dns
-    version: ">= 2.10.0"
   - name: vertical-pod-autoscaler
     version: ">= 2.4.0"
   - name: node-exporter


### PR DESCRIPTION
Also postponed updating `external-dns` to v2.10.0 on Azure since there are no relevant changes and there shouldn't be a minor app bump in a patch release without relevant changes.


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
