### PR TITLE
Prepare release for aws v17.3.4 - Bump operators and apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to all Giant Swarm installations.
     - [v20.0.0-alpha1](https://github.com/giantswarm/releases/tree/master/aws/v20.0.0-alpha1)
 - v17
   - v17.3
+    - [v17.3.4](https://github.com/giantswarm/releases/tree/master/aws/v17.3.4)
     - [v17.3.3](https://github.com/giantswarm/releases/tree/master/aws/v17.3.3)
     - [v17.3.2](https://github.com/giantswarm/releases/tree/master/aws/v17.3.2)
     - [v17.3.1](https://github.com/giantswarm/releases/tree/master/aws/v17.3.1)

--- a/aws/kustomization.yaml
+++ b/aws/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - v17.3.1
 - v17.3.2
 - v17.3.3
+- v17.3.4
 - v20.0.0-alpha1
 transformers:
 - releaseNotesTransformer.yaml

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -5,7 +5,7 @@ releases:
     version: ">= 2.14.0"
 - name: "> 17.3.3"
   requests:
-  - name: metrics-server-app
+  - name: metrics-server
     version: ">= 1.7.0"
   - name: vertical-pod-autoscaler
     version: ">= 2.4.0"

--- a/aws/v17.3.4/README.md
+++ b/aws/v17.3.4/README.md
@@ -5,6 +5,16 @@ This release provides quality of life improvements and bug fixes to operators an
 ## Change details
 
 
+### cluster-operator [4.3.0](https://github.com/giantswarm/cluster-operator/releases/tag/v4.3.0)
+
+#### Added
+- Add cluster values for IRSA.
+
+#### Changed
+- Do not update "app-operator.giantswarm.io/version" label on app-operators when their value is 0.0.0 (aka they are reconciled by the management cluster app-operator). This is a use-case for App Bundles for example, because the App CRs they contain should be created in the MC so should be reconciled by the MC app-operator.
+- Store kubeconfig copy in .data.value field of the Secret.
+
+
 ### app-operator [5.12.0](https://github.com/giantswarm/app-operator/releases/tag/v5.12.0)
 
 #### Added
@@ -28,13 +38,13 @@ This release provides quality of life improvements and bug fixes to operators an
 - Fix missing PriorityClass issue.
 
 
-### metrics-server [v1.7.0](https://github.com/giantswarm/metrics-server-app/releases/tag/v1.7.0)
+### metrics-server [1.7.0](https://github.com/giantswarm/metrics-server-app/releases/tag/v1.7.0)
 
 #### Changed
 - Set kubelet-preferred-address-types to Hostname on AWS.
 
 
-### vertical-pod-autoscaler [v2.4.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v2.4.0)
+### vertical-pod-autoscaler [2.4.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v2.4.0)
 
 #### Changed
 - Change log-level from default=4 to 3.
@@ -65,7 +75,7 @@ This release provides quality of life improvements and bug fixes to operators an
 - Prefix generated secret certificate with release-name.
 
 
-### node-exporter [v1.12.0](https://github.com/giantswarm/node-exporter-app/releases/tag/v1.12.0)
+### node-exporter [1.12.0](https://github.com/giantswarm/node-exporter-app/releases/tag/v1.12.0)
 
 #### Added
 - Add options to be able to disable nvme and conntrack collectors.

--- a/aws/v17.3.4/README.md
+++ b/aws/v17.3.4/README.md
@@ -1,0 +1,29 @@
+# :zap: Giant Swarm Release v17.3.4 for AWS :zap:
+
+This release provides quality of life improvements and bug fixes to app-operator and chart-operator.
+
+## Change details
+
+
+### app-operator [5.12.0](https://github.com/giantswarm/app-operator/releases/tag/v5.12.0)
+
+#### Added
+- Add initialBootstrapMode flag to allow deploying CNI as managed apps.
+
+#### Changed
+- Only set resource limits on the deployment when the VPA is not available or disabled
+- Increase min / max resource limits on VPA
+
+
+### chart-operator [5.24.0](https://github.com/giantswarm/chart-operator/releases/tag/v2.24.0)
+
+#### Added
+- Split Helm client into private Helm client for giantswarm-namespaced apps and public Helm client for rest of the apps.
+
+#### Changed
+- Always create giantswarm-critical priority class if it does not exist.
+- Add chart-pull-failed error to differentiate between issues when pulling chart tarball and other problems.
+
+#### Fixed
+- Fix missing PriorityClass issue.
+

--- a/aws/v17.3.4/README.md
+++ b/aws/v17.3.4/README.md
@@ -63,3 +63,14 @@ This release provides quality of life improvements and bug fixes to operators an
 - Fix admission-controller webhook-service name.
 - Fix webhook name in generated secret certificate.
 - Prefix generated secret certificate with release-name.
+
+
+### node-exporter [v1.12.0](https://github.com/giantswarm/node-exporter-app/releases/tag/v1.12.0)
+
+#### Added
+- Add options to be able to disable nvme and conntrack collectors.
+
+#### Changed
+- Enabled diskstats collector.
+- Disable the fibrechannel collector.
+- Disable the tapestats collector.

--- a/aws/v17.3.4/README.md
+++ b/aws/v17.3.4/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v17.3.4 for AWS :zap:
 
-This release provides quality of life improvements and bug fixes to operators.
+This release provides quality of life improvements and bug fixes to operators and apps.
 
 ## Change details
 
@@ -28,7 +28,38 @@ This release provides quality of life improvements and bug fixes to operators.
 - Fix missing PriorityClass issue.
 
 
-### metrics-server-app [v1.7.0](https://github.com/giantswarm/metrics-server-app/releases/tag/v1.7.0)
+### metrics-server [v1.7.0](https://github.com/giantswarm/metrics-server-app/releases/tag/v1.7.0)
 
 #### Changed
 - Set kubelet-preferred-address-types to Hostname on AWS.
+
+
+### vertical-pod-autoscaler [v2.4.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v2.4.0)
+
+#### Changed
+- Change log-level from default=4 to 3.
+- Rename resources to include release name as prefix and avoid name collision.
+- Upgrade vertical-pod-autoscaler to 0.10.0
+
+    API changes:
+    Added support for alternative recommenders.
+    Added support for per-VPA Object MinReplicas.
+    
+    Other notable changes:
+    Added support for running VPA out of cluster.
+    Use v1 API for storage instead of v1beta2.
+    Allow configuring default update threshold.
+    Use v1 API to register admission webhook.
+    
+    Bug fixes:
+    Use correct timestamp for checkpoints.
+    Issues with setting limits.
+    Deploying VPA in different namespaces.
+    Loading history.
+
+- Use patched docker image tagged 0.10.0-oomfix for recommender and updater (see giantswarm/roadmap#923).
+
+#### Fixed
+- Fix admission-controller webhook-service name.
+- Fix webhook name in generated secret certificate.
+- Prefix generated secret certificate with release-name.

--- a/aws/v17.3.4/README.md
+++ b/aws/v17.3.4/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v17.3.4 for AWS :zap:
 
-This release provides quality of life improvements and bug fixes to app-operator and chart-operator.
+This release provides quality of life improvements and bug fixes to operators.
 
 ## Change details
 
@@ -27,3 +27,8 @@ This release provides quality of life improvements and bug fixes to app-operator
 #### Fixed
 - Fix missing PriorityClass issue.
 
+
+### metrics-server-app [v1.7.0](https://github.com/giantswarm/metrics-server-app/releases/tag/v1.7.0)
+
+#### Changed
+- Set kubelet-preferred-address-types to Hostname on AWS.

--- a/aws/v17.3.4/announcement.md
+++ b/aws/v17.3.4/announcement.md
@@ -1,0 +1,1 @@
+**Workload cluster release v17.3.3 for AWS is available**. This release provides quality of life improvements and bug fixes to app-operator and chart-operator.

--- a/aws/v17.3.4/announcement.md
+++ b/aws/v17.3.4/announcement.md
@@ -1,1 +1,1 @@
-**Workload cluster release v17.3.3 for AWS is available**. This release provides quality of life improvements and bug fixes to app-operator and chart-operator.
+**Workload cluster release v17.3.3 for AWS is available**. This release provides quality of life improvements and bug fixes to operators.

--- a/aws/v17.3.4/announcement.md
+++ b/aws/v17.3.4/announcement.md
@@ -1,1 +1,1 @@
-**Workload cluster release v17.3.3 for AWS is available**. This release provides quality of life improvements and bug fixes to operators.
+**Workload cluster release v17.3.3 for AWS is available**. This release provides quality of life improvements and bug fixes to operators and apps.

--- a/aws/v17.3.4/kustomization.yaml
+++ b/aws/v17.3.4/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -62,7 +62,7 @@ spec:                                                              spec:
     version: 2.0.1                                                     version: 2.0.1
   - name: cluster-operator                                           - name: cluster-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
-    version: 4.0.2                                                     version: 4.0.2
+    version: 4.0.2                                              |      version: 4.3.0
   - name: containerlinux                                             - name: containerlinux
     version: 3139.2.0                                                  version: 3139.2.0
   - name: etcd                                                       - name: etcd

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -37,7 +37,7 @@ spec:                                                              spec:
     version: 1.10.0                                                    version: 1.10.0
   - componentVersion: 0.5.2                                          - componentVersion: 0.5.2
     name: metrics-server                                               name: metrics-server
-    version: 1.6.0                                                     version: 1.6.0
+    version: 1.6.0                                              |      version: 1.7.0
   - name: net-exporter                                               - name: net-exporter
     version: 1.12.0                                                    version: 1.12.0
   - componentVersion: 1.3.1                                          - componentVersion: 1.3.1

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -44,7 +44,7 @@ spec:                                                              spec:
     name: node-exporter                                                name: node-exporter
     version: 1.9.0                                                     version: 1.9.0
   - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
-    version: 2.1.2                                                     version: 2.1.2
+    version: 2.1.2                                              |      version: 2.4.0
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 1.0.1                                                     version: 1.0.1
   components:                                                        components:

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -42,7 +42,7 @@ spec:                                                              spec:
     version: 1.12.0                                                    version: 1.12.0
   - componentVersion: 1.3.1                                          - componentVersion: 1.3.1
     name: node-exporter                                                name: node-exporter
-    version: 1.9.0                                                     version: 1.9.0
+    version: 1.9.0                                              |      version: 1.12.0
   - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
     version: 2.1.2                                              |      version: 2.4.0
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -18,7 +18,7 @@ spec:                                                              spec:
     name: cert-manager                                                 name: cert-manager
     version: 2.13.0                                                    version: 2.13.0
   - name: chart-operator                                             - name: chart-operator
-    version: 2.21.0                                                    version: 2.21.0
+    version: 2.21.0                                             |      version: 2.24.0
   - name: cluster-autoscaler                                         - name: cluster-autoscaler
     version: 1.22.2-gs6                                                version: 1.22.2-gs6
   - componentVersion: 1.8.7                                          - componentVersion: 1.8.7
@@ -69,9 +69,7 @@ spec:                                                              spec:
     version: 3.4.18                                                    version: 3.4.18
   - name: kubernetes                                                 - name: kubernetes
     version: 1.22.9                                                    version: 1.22.9
-  date: "2022-06-02T10:00:00Z"                                  |    - name: chart-operator
-                                                                >      version: 2.24.0
-                                                                >    date: "2022-06-13T07:57:11Z"
+  date: "2022-06-02T10:00:00Z"                                  |    date: "2022-06-13T07:57:11Z"
   state: active                                                      state: active
 status:                                                            status:
   inUse: false                                                       inUse: false

--- a/aws/v17.3.4/release.diff
+++ b/aws/v17.3.4/release.diff
@@ -1,0 +1,78 @@
+# Generated with:                                                  # Generated with:
+# devctl release create --provider aws --name v17.3.3 --base v1 |  # devctl release create --provider aws --name v17.3.4 --base v1
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  annotations:                                                       annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp        giantswarm.io/docs: https://docs.giantswarm.io/reference/cp
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v17.3.3                                                 |    name: v17.3.4
+spec:                                                              spec:
+  apps:                                                              apps:
+  - componentVersion: 1.5.1                                          - componentVersion: 1.5.1
+    name: aws-ebs-csi-driver                                           name: aws-ebs-csi-driver
+    version: 2.12.0                                                    version: 2.12.0
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.2.0                                                     version: 2.2.0
+  - componentVersion: 1.6.1                                          - componentVersion: 1.6.1
+    name: cert-manager                                                 name: cert-manager
+    version: 2.13.0                                                    version: 2.13.0
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.21.0                                                    version: 2.21.0
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.22.2-gs6                                                version: 1.22.2-gs6
+  - componentVersion: 1.8.7                                          - componentVersion: 1.8.7
+    name: coredns                                                      name: coredns
+    version: 1.9.0                                                     version: 1.9.0
+  - componentVersion: 0.10.2                                         - componentVersion: 0.10.2
+    name: external-dns                                                 name: external-dns
+    version: 2.9.1                                                     version: 2.9.1
+  - componentVersion: 4.2.0                                          - componentVersion: 4.2.0
+    name: kiam                                                         name: kiam
+    version: 2.3.0                                                     version: 2.3.0
+  - name: kiam-watchdog                                              - name: kiam-watchdog
+    version: 0.7.0                                                     version: 0.7.0
+  - componentVersion: 2.3.0                                          - componentVersion: 2.3.0
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.10.0                                                    version: 1.10.0
+  - componentVersion: 0.5.2                                          - componentVersion: 0.5.2
+    name: metrics-server                                               name: metrics-server
+    version: 1.6.0                                                     version: 1.6.0
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.12.0                                                    version: 1.12.0
+  - componentVersion: 1.3.1                                          - componentVersion: 1.3.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.9.0                                                     version: 1.9.0
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 2.1.2                                                     version: 2.1.2
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 1.0.1                                                     version: 1.0.1
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    version: 5.10.2                                             |      version: 5.12.0
+  - name: aws-cni                                                    - name: aws-cni
+    version: 1.11.0-nftables                                           version: 1.11.0-nftables
+  - name: aws-operator                                               - name: aws-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 11.10.0                                                   version: 11.10.0
+  - name: calico                                                     - name: calico
+    version: 3.21.3                                                    version: 3.21.3
+  - name: cert-operator                                              - name: cert-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 2.0.1                                                     version: 2.0.1
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 4.0.2                                                     version: 4.0.2
+  - name: containerlinux                                             - name: containerlinux
+    version: 3139.2.0                                                  version: 3139.2.0
+  - name: etcd                                                       - name: etcd
+    version: 3.4.18                                                    version: 3.4.18
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.22.9                                                    version: 1.22.9
+  date: "2022-06-02T10:00:00Z"                                  |    - name: chart-operator
+                                                                >      version: 2.24.0
+                                                                >    date: "2022-06-13T07:57:11Z"
+  state: active                                                      state: active
+status:                                                            status:
+  inUse: false                                                       inUse: false
+  ready: false                                                       ready: false

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -18,7 +18,7 @@ spec:
     name: cert-manager
     version: 2.13.0
   - name: chart-operator
-    version: 2.21.0
+    version: 2.24.0
   - name: cluster-autoscaler
     version: 1.22.2-gs6
   - componentVersion: 1.8.7
@@ -69,8 +69,6 @@ spec:
     version: 3.4.18
   - name: kubernetes
     version: 1.22.9
-  - name: chart-operator
-    version: 2.24.0
   date: "2022-06-13T07:57:11Z"
   state: active
 status:

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -37,7 +37,7 @@ spec:
     version: 1.10.0
   - componentVersion: 0.5.2
     name: metrics-server
-    version: 1.6.0
+    version: 1.7.0
   - name: net-exporter
     version: 1.12.0
   - componentVersion: 1.3.1

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -62,7 +62,7 @@ spec:
     version: 2.0.1
   - name: cluster-operator
     releaseOperatorDeploy: true
-    version: 4.0.2
+    version: 4.3.0
   - name: containerlinux
     version: 3139.2.0
   - name: etcd

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -1,0 +1,78 @@
+# Generated with:
+# devctl release create --provider aws --name v17.3.4 --base v17.3.3 --component app-operator@5.12.0 --component chart-operator@2.24.0
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  creationTimestamp: null
+  name: v17.3.4
+spec:
+  apps:
+  - componentVersion: 1.5.1
+    name: aws-ebs-csi-driver
+    version: 2.12.0
+  - name: cert-exporter
+    version: 2.2.0
+  - componentVersion: 1.6.1
+    name: cert-manager
+    version: 2.13.0
+  - name: chart-operator
+    version: 2.21.0
+  - name: cluster-autoscaler
+    version: 1.22.2-gs6
+  - componentVersion: 1.8.7
+    name: coredns
+    version: 1.9.0
+  - componentVersion: 0.10.2
+    name: external-dns
+    version: 2.9.1
+  - componentVersion: 4.2.0
+    name: kiam
+    version: 2.3.0
+  - name: kiam-watchdog
+    version: 0.7.0
+  - componentVersion: 2.3.0
+    name: kube-state-metrics
+    version: 1.10.0
+  - componentVersion: 0.5.2
+    name: metrics-server
+    version: 1.6.0
+  - name: net-exporter
+    version: 1.12.0
+  - componentVersion: 1.3.1
+    name: node-exporter
+    version: 1.9.0
+  - name: vertical-pod-autoscaler
+    version: 2.1.2
+  - name: vertical-pod-autoscaler-crd
+    version: 1.0.1
+  components:
+  - name: app-operator
+    version: 5.12.0
+  - name: aws-cni
+    version: 1.11.0-nftables
+  - name: aws-operator
+    releaseOperatorDeploy: true
+    version: 11.10.0
+  - name: calico
+    version: 3.21.3
+  - name: cert-operator
+    releaseOperatorDeploy: true
+    version: 2.0.1
+  - name: cluster-operator
+    releaseOperatorDeploy: true
+    version: 4.0.2
+  - name: containerlinux
+    version: 3139.2.0
+  - name: etcd
+    version: 3.4.18
+  - name: kubernetes
+    version: 1.22.9
+  - name: chart-operator
+    version: 2.24.0
+  date: "2022-06-13T07:57:11Z"
+  state: active
+status:
+  inUse: false
+  ready: false

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -1,5 +1,3 @@
-# Generated with:
-# devctl release create --provider aws --name v17.3.4 --base v17.3.3 --component app-operator@5.12.0 --component chart-operator@2.24.0
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -44,7 +44,7 @@ spec:
     name: node-exporter
     version: 1.9.0
   - name: vertical-pod-autoscaler
-    version: 2.1.2
+    version: 2.4.0
   - name: vertical-pod-autoscaler-crd
     version: 1.0.1
   components:

--- a/aws/v17.3.4/release.yaml
+++ b/aws/v17.3.4/release.yaml
@@ -42,7 +42,7 @@ spec:
     version: 1.12.0
   - componentVersion: 1.3.1
     name: node-exporter
-    version: 1.9.0
+    version: 1.12.0
   - name: vertical-pod-autoscaler
     version: 2.4.0
   - name: vertical-pod-autoscaler-crd


### PR DESCRIPTION
The `chart-operator` version of at least [v2.21.1](https://github.com/giantswarm/chart-operator/releases/tag/v2.21.1) is needed for the `NOTES` column feature of `kubectl gs` to dispaly meaningful informationt.

There are related changes in `app-operator` as well and some nice fixes like the `VPA` update or the Split Helm Client for security purposes.

Bumped `cluster-operator` as well to release fix for handling App Bundles correctly in `v4.3.0`.

Extra: Requested bumps of other apps and operators.