### PR TITLE
Prepare azure release

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ to all Giant Swarm installations.
 
 - v17
   - v17.0
+    - [v17.0.2](https://github.com/giantswarm/releases/tree/master/azure/v17.0.2)
     - [v17.0.1](https://github.com/giantswarm/releases/tree/master/azure/v17.0.1)
     - [v17.0.0](https://github.com/giantswarm/releases/tree/master/azure/v17.0.0)
     - [v17.0.0-alpha1](https://github.com/giantswarm/releases/tree/master/azure/archived/v17.0.0-alpha1)

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - v16.1.3
 - v17.0.0
 - v17.0.1
+- v17.0.2
 - v20.0.0-alpha1
 transformers:
 - releaseNotesTransformer.yaml

--- a/azure/v17.0.2/README.md
+++ b/azure/v17.0.2/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v17.0.2 for Azure :zap:
 
-<< Add description here >>
+This release provides quality of life improvements and bug fixes to operators and apps.
 
 ## Change details
 

--- a/azure/v17.0.2/README.md
+++ b/azure/v17.0.2/README.md
@@ -1,0 +1,47 @@
+# :zap: Giant Swarm Release v17.0.2 for Azure :zap:
+
+<< Add description here >>
+
+## Change details
+
+
+### app-operator [5.12.0](https://github.com/giantswarm/app-operator/releases/tag/v5.12.0)
+
+#### Added
+- Add `initialBootstrapMode` flag to allow deploying CNI as managed apps.
+
+
+
+### chart-operator [2.24.0--component](https://github.com/giantswarm/chart-operator/releases/tag/v2.24.0--component)
+
+Not found
+
+
+### azure-operator [5.20.0](https://github.com/giantswarm/azure-operator/releases/tag/v5.20.0)
+
+#### Changed
+- Bumped k8scc to latest version to fix `localhost` node name problem.
+
+
+
+### kube-state-metrics [1.10.0](https://github.com/giantswarm/kube-state-metrics-app/releases/tag/v1.10.0)
+
+#### Changed
+- Add `Node Pool` labels to the default allowed labels in `--metric-labels-allowlist`.
+
+
+
+### vertical-pod-autoscaler [2.4.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/releases/tag/v2.4.0)
+
+#### Changed
+- Use patched docker image tagged `0.10.0-oomfix` for `recommender` and updater (see https://github.com/giantswarm/roadmap/issues/923).
+
+
+
+### node-exporter [1.12.0](https://github.com/giantswarm/node-exporter-app/releases/tag/v1.12.0)
+
+#### Changed
+- Enabled `diskstats` collector.
+
+
+

--- a/azure/v17.0.2/announcement.md
+++ b/azure/v17.0.2/announcement.md
@@ -1,0 +1,1 @@
+**Workload cluster release v17.0.2 for Azure is available**. This release provides quality of life improvements and bug fixes to operators and apps. Major version was bumped because cluster-operator was upgraded from v3 to v4 (4.3.0).

--- a/azure/v17.0.2/kustomization.yaml
+++ b/azure/v17.0.2/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/azure/v17.0.2/release.diff
+++ b/azure/v17.0.2/release.diff
@@ -10,7 +10,7 @@ spec:                                                              spec:
   - name: cert-exporter                                              - name: cert-exporter
     version: 2.0.1                                                     version: 2.0.1
   - name: chart-operator                                             - name: chart-operator
-    version: 2.20.1                                                    version: 2.20.1
+    version: 2.20.1                                             |      version: 2.24.0
   - componentVersion: 1.8.6                                          - componentVersion: 1.8.6
     name: coredns                                                      name: coredns
     version: 1.8.0                                                     version: 1.8.0
@@ -19,21 +19,21 @@ spec:                                                              spec:
     version: 2.9.0                                                     version: 2.9.0
   - componentVersion: 2.2.4                                          - componentVersion: 2.2.4
     name: kube-state-metrics                                           name: kube-state-metrics
-    version: 1.7.0                                                     version: 1.7.0
+    version: 1.7.0                                              |      version: 1.10.0
   - name: metrics-server                                             - name: metrics-server
     version: 1.5.0                                                     version: 1.5.0
   - name: net-exporter                                               - name: net-exporter
     version: 1.11.0                                                    version: 1.11.0
   - componentVersion: 1.0.1                                          - componentVersion: 1.0.1
     name: node-exporter                                                name: node-exporter
-    version: 1.8.0                                                     version: 1.8.0
+    version: 1.8.0                                              |      version: 1.12.0
   - name: cluster-autoscaler                                         - name: cluster-autoscaler
     version: 1.22.2-gs4                                                version: 1.22.2-gs4
   - name: azure-scheduled-events                                     - name: azure-scheduled-events
     version: 0.6.1                                                     version: 0.6.1
   - componentVersion: 0.9.2                                          - componentVersion: 0.9.2
     name: vertical-pod-autoscaler                                      name: vertical-pod-autoscaler
-    version: 2.1.1                                                     version: 2.1.1
+    version: 2.1.1                                              |      version: 2.4.0
   - componentVersion: 0.9.2                                          - componentVersion: 0.9.2
     name: vertical-pod-autoscaler-crd                                  name: vertical-pod-autoscaler-crd
     version: 1.0.0                                                     version: 1.0.0
@@ -58,15 +58,7 @@ spec:                                                              spec:
     version: 3.21.3                                                    version: 3.21.3
   - name: etcd                                                       - name: etcd
     version: 3.4.18                                                    version: 3.4.18
-  date: "2022-05-19T11:39:38Z"                                  |    - name: chart-operator
-                                                                >      version: 2.24.0--component
-                                                                >    - name: kube-state-metrics
-                                                                >      version: 1.10.0
-                                                                >    - name: vertical-pod-autoscaler
-                                                                >      version: 2.4.0
-                                                                >    - name: node-exporter
-                                                                >      version: 1.12.0
-                                                                >    date: "2022-06-13T09:39:04Z"
+  date: "2022-05-19T11:39:38Z"                                  |    date: "2022-06-13T09:39:04Z"
   state: active                                                      state: active
 status:                                                            status:
   inUse: false                                                       inUse: false

--- a/azure/v17.0.2/release.diff
+++ b/azure/v17.0.2/release.diff
@@ -1,0 +1,73 @@
+# Generated with:                                                  # Generated with:
+# devctl release create --provider azure --name v17.0.1 --base  |  # devctl release create --provider azure --name v17.0.2 --base 
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v17.0.1                                                 |    name: v17.0.2
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.0.1                                                     version: 2.0.1
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.20.1                                                    version: 2.20.1
+  - componentVersion: 1.8.6                                          - componentVersion: 1.8.6
+    name: coredns                                                      name: coredns
+    version: 1.8.0                                                     version: 1.8.0
+  - componentVersion: 0.10.2                                         - componentVersion: 0.10.2
+    name: external-dns                                                 name: external-dns
+    version: 2.9.0                                                     version: 2.9.0
+  - componentVersion: 2.2.4                                          - componentVersion: 2.2.4
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.7.0                                                     version: 1.7.0
+  - name: metrics-server                                             - name: metrics-server
+    version: 1.5.0                                                     version: 1.5.0
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.11.0                                                    version: 1.11.0
+  - componentVersion: 1.0.1                                          - componentVersion: 1.0.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.8.0                                                     version: 1.8.0
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.22.2-gs4                                                version: 1.22.2-gs4
+  - name: azure-scheduled-events                                     - name: azure-scheduled-events
+    version: 0.6.1                                                     version: 0.6.1
+  - componentVersion: 0.9.2                                          - componentVersion: 0.9.2
+    name: vertical-pod-autoscaler                                      name: vertical-pod-autoscaler
+    version: 2.1.1                                                     version: 2.1.1
+  - componentVersion: 0.9.2                                          - componentVersion: 0.9.2
+    name: vertical-pod-autoscaler-crd                                  name: vertical-pod-autoscaler-crd
+    version: 1.0.0                                                     version: 1.0.0
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    version: 5.10.2                                             |      version: 5.12.0
+  - catalog: control-plane-catalog                                   - catalog: control-plane-catalog
+    name: azure-operator                                               name: azure-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 5.17.0                                             |      version: 5.20.0
+  - name: cert-operator                                              - name: cert-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 1.3.0                                                     version: 1.3.0
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 3.12.0                                                    version: 3.12.0
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.22.6                                                    version: 1.22.6
+  - name: containerlinux                                             - name: containerlinux
+    version: 3033.2.2                                                  version: 3033.2.2
+  - name: calico                                                     - name: calico
+    version: 3.21.3                                                    version: 3.21.3
+  - name: etcd                                                       - name: etcd
+    version: 3.4.18                                                    version: 3.4.18
+  date: "2022-05-19T11:39:38Z"                                  |    - name: chart-operator
+                                                                >      version: 2.24.0--component
+                                                                >    - name: kube-state-metrics
+                                                                >      version: 1.10.0
+                                                                >    - name: vertical-pod-autoscaler
+                                                                >      version: 2.4.0
+                                                                >    - name: node-exporter
+                                                                >      version: 1.12.0
+                                                                >    date: "2022-06-13T09:39:04Z"
+  state: active                                                      state: active
+status:                                                            status:
+  inUse: false                                                       inUse: false
+  ready: false                                                       ready: false

--- a/azure/v17.0.2/release.yaml
+++ b/azure/v17.0.2/release.yaml
@@ -1,0 +1,73 @@
+# Generated with:
+# devctl release create --provider azure --name v17.0.2 --base v17.0.1 --component app-operator@5.12.0 --component chart-operator@2.24.0--component cluster-operator@4.3.0 --component azure-operator@5.20.0 --component kube-state-metrics@1.10.0 --component vertical-pod-autoscaler@2.4.0 --component node-exporter@1.12.0
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  creationTimestamp: null
+  name: v17.0.2
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.0.1
+  - name: chart-operator
+    version: 2.20.1
+  - componentVersion: 1.8.6
+    name: coredns
+    version: 1.8.0
+  - componentVersion: 0.10.2
+    name: external-dns
+    version: 2.9.0
+  - componentVersion: 2.2.4
+    name: kube-state-metrics
+    version: 1.7.0
+  - name: metrics-server
+    version: 1.5.0
+  - name: net-exporter
+    version: 1.11.0
+  - componentVersion: 1.0.1
+    name: node-exporter
+    version: 1.8.0
+  - name: cluster-autoscaler
+    version: 1.22.2-gs4
+  - name: azure-scheduled-events
+    version: 0.6.1
+  - componentVersion: 0.9.2
+    name: vertical-pod-autoscaler
+    version: 2.1.1
+  - componentVersion: 0.9.2
+    name: vertical-pod-autoscaler-crd
+    version: 1.0.0
+  components:
+  - name: app-operator
+    version: 5.12.0
+  - catalog: control-plane-catalog
+    name: azure-operator
+    releaseOperatorDeploy: true
+    version: 5.20.0
+  - name: cert-operator
+    releaseOperatorDeploy: true
+    version: 1.3.0
+  - name: cluster-operator
+    releaseOperatorDeploy: true
+    version: 3.12.0
+  - name: kubernetes
+    version: 1.22.6
+  - name: containerlinux
+    version: 3033.2.2
+  - name: calico
+    version: 3.21.3
+  - name: etcd
+    version: 3.4.18
+  - name: chart-operator
+    version: 2.24.0--component
+  - name: kube-state-metrics
+    version: 1.10.0
+  - name: vertical-pod-autoscaler
+    version: 2.4.0
+  - name: node-exporter
+    version: 1.12.0
+  date: "2022-06-13T09:39:04Z"
+  state: active
+status:
+  inUse: false
+  ready: false

--- a/azure/v17.0.2/release.yaml
+++ b/azure/v17.0.2/release.yaml
@@ -1,5 +1,3 @@
-# Generated with:
-# devctl release create --provider azure --name v17.0.2 --base v17.0.1 --component app-operator@5.12.0 --component chart-operator@2.24.0--component cluster-operator@4.3.0 --component azure-operator@5.20.0 --component kube-state-metrics@1.10.0 --component vertical-pod-autoscaler@2.4.0 --component node-exporter@1.12.0
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -10,7 +8,7 @@ spec:
   - name: cert-exporter
     version: 2.0.1
   - name: chart-operator
-    version: 2.20.1
+    version: 2.24.0
   - componentVersion: 1.8.6
     name: coredns
     version: 1.8.0
@@ -19,21 +17,21 @@ spec:
     version: 2.9.0
   - componentVersion: 2.2.4
     name: kube-state-metrics
-    version: 1.7.0
+    version: 1.10.0
   - name: metrics-server
     version: 1.5.0
   - name: net-exporter
     version: 1.11.0
   - componentVersion: 1.0.1
     name: node-exporter
-    version: 1.8.0
+    version: 1.12.0
   - name: cluster-autoscaler
     version: 1.22.2-gs4
   - name: azure-scheduled-events
     version: 0.6.1
   - componentVersion: 0.9.2
     name: vertical-pod-autoscaler
-    version: 2.1.1
+    version: 2.4.0
   - componentVersion: 0.9.2
     name: vertical-pod-autoscaler-crd
     version: 1.0.0
@@ -58,14 +56,6 @@ spec:
     version: 3.21.3
   - name: etcd
     version: 3.4.18
-  - name: chart-operator
-    version: 2.24.0--component
-  - name: kube-state-metrics
-    version: 1.10.0
-  - name: vertical-pod-autoscaler
-    version: 2.4.0
-  - name: node-exporter
-    version: 1.12.0
   date: "2022-06-13T09:39:04Z"
   state: active
 status:


### PR DESCRIPTION
The `chart-operator` version of at least [v2.21.1](https://github.com/giantswarm/chart-operator/releases/tag/v2.21.1) is needed for the `NOTES` column feature of `kubectl gs` to dispaly meaningful informationt.

There are related changes in `app-operator` as well and some nice fixes like the `VPA` update or the Split Helm Client for security purposes.

Bumped `cluster-operator` as well to release fix for handling App Bundles correctly in `v4.3.0`.

Extra: Requested bumps of other apps and operators.