### PR TITLE
Request cert-manager 2.14.0 for aws >= 17.4.0

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: external-dns
     version: ">= 2.14.0"
+  - name: cert-manager
+    version: ">= 2.14.0"
 - name: "> 17.3.3"
   requests:
   - name: metrics-server-app


### PR DESCRIPTION
Please include cert-manager-app 2.14.0 in AWS releases >=17.4.0