### PR TITLE
Add cert-manager 2.15.0

### DIFF
--- a/aws/v17.4.0/README.md
+++ b/aws/v17.4.0/README.md
@@ -88,7 +88,11 @@ _Nothing has changed._
 #### Removed
 _Nothing has changed._
 
+### cert-manager [2.15.0](https://github.com/giantswarm/cert-manager-app/releases/tag/v2.15.0)
 
+#### Changed
+- Upgrade to upstream image [`v1.7.3`](https://github.com/jetstack/cert-manager/releases/tag/v1.7.3) which increases some hard-coded timeouts for certain ACME issuers (ZeroSSL and Sectigo) ([#243](https://github.com/giantswarm/cert-manager-app/pull/243))
+- Update kubectl container version to `1.24.2` ([#243](https://github.com/giantswarm/cert-manager-app/pull/243))
 
 ### external-dns [2.14.0](https://github.com/giantswarm/external-dns-app/releases/tag/v2.14.0)
 

--- a/aws/v17.4.0/release.diff
+++ b/aws/v17.4.0/release.diff
@@ -14,9 +14,9 @@ spec:                                                              spec:
     version: 2.12.0                                             |      version: 2.14.0
   - name: cert-exporter                                              - name: cert-exporter
     version: 2.2.0                                                     version: 2.2.0
-  - componentVersion: 1.6.1                                          - componentVersion: 1.6.1
+  - componentVersion: 1.6.1                                     |    - componentVersion: 1.7.3
     name: cert-manager                                                 name: cert-manager
-    version: 2.13.0                                                    version: 2.13.0
+    version: 2.13.0                                             |      version: 2.15.0
   - name: chart-operator                                             - name: chart-operator
     version: 2.21.0                                             |      version: 2.24.0
   - name: cluster-autoscaler                                         - name: cluster-autoscaler
@@ -71,7 +71,7 @@ spec:                                                              spec:
     version: 3.4.18                                                    version: 3.4.18
   - name: kubernetes                                                 - name: kubernetes
     version: 1.22.9                                             |      version: 1.22.11
-  date: "2022-06-02T10:00:00Z"                                  |    date: "2022-06-14T12:56:45Z"
+  date: "2022-06-02T10:00:00Z"                                  |    date: "2022-06-28T14:12:34Z"
   state: active                                                      state: active
 status:                                                            status:
   inUse: false                                                       inUse: false

--- a/aws/v17.4.0/release.yaml
+++ b/aws/v17.4.0/release.yaml
@@ -1,5 +1,5 @@
 # Generated with:
-# devctl release create --name v17.4.0 --provider aws --base v17.3.3 --component aws-operator@11.14.1 --component cluster-operator@4.3.0 --component app-operator@5.12.0 --component aws-cni@1.11.2 --component containerlinux@3139.2.2 --component kubernetes@1.22.10 --app external-dns@2.14.0 --app chart-operator@2.24.0 --app node-exporter@1.12.0 --app vertical-pod-autoscaler@2.4.0 --app metrics-server@1.7.0 --overwrite
+# devctl release create --name v17.4.0 --provider aws --base v17.3.3 --component aws-operator@11.15.0 --component cluster-operator@4.3.0 --component app-operator@5.12.0 --component aws-cni@1.11.2-nftables --component containerlinux@3139.2.2 --component kubernetes@1.22.11 --app external-dns@2.14.0@0.11.0 --app chart-operator@2.24.0 --app node-exporter@1.12.0@1.3.1 --app vertical-pod-autoscaler@2.4.0 --app metrics-server@1.7.0@0.5.2 --app cert-manager@2.15.0@1.7.3 --app aws-ebs-csi-driver@2.14.0@1.6.2 --app cluster-autoscaler@1.22.2-gs7 --overwrite
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -14,9 +14,9 @@ spec:
     version: 2.14.0
   - name: cert-exporter
     version: 2.2.0
-  - componentVersion: 1.6.1
+  - componentVersion: 1.7.3
     name: cert-manager
-    version: 2.13.0
+    version: 2.15.0
   - name: chart-operator
     version: 2.24.0
   - name: cluster-autoscaler
@@ -71,7 +71,7 @@ spec:
     version: 3.4.18
   - name: kubernetes
     version: 1.22.11
-  date: "2022-06-14T12:56:45Z"
+  date: "2022-06-28T14:12:34Z"
   state: active
 status:
   inUse: false


### PR DESCRIPTION
After running 

```
devctl release create --name v17.4.0 --provider aws --base v17.3.3 --component aws-operator@11.15.0 --component cluster-operator@4.3.0 --component app-operator@5.12.0 --component aws-cni@1.11.2-nftables --component containerlinux@3139.2.2 --component kubernetes@1.22.11 --app external-dns@2.14.0@0.11.0 --app chart-operator@2.24.0 --app node-exporter@1.12.0@1.3.1 --app vertical-pod-autoscaler@2.4.0 --app metrics-server@1.7.0@0.5.2 --app cert-manager@2.15.0@1.7.3 --app aws-ebs-csi-driver@2.14.0@1.6.2 --app cluster-autoscaler@1.22.2-gs7 --overwrite
```

I reverted removal of webhook-exporter and changes to the Readme where I then added cert-manager manually.