### PR TITLE
Request app-operator >= 6.3.0 and cluster-operator >= 4.3.0 for aws and azure

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,6 +1,10 @@
 releases:
 - name: "> 17.4.0"
   requests:
+  - name: app-operator
+    version: ">= 6.3.0"
+  - name: cluster-operator
+    version: ">= 4.3.0"
   - name: chart-operator
     version: ">= 2.25.0"
 - name: ">= 17.4.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,6 +1,10 @@
 releases:
 - name: "> 17.2.0"
   requests:
+  - name: app-operator
+    version: ">= 6.3.0"
+  - name: cluster-operator
+    version: ">= 4.3.0"
   - name: chart-operator
     version: ">= 2.25.0"
 - name: "> 17.1.0"


### PR DESCRIPTION
## Reason for requessts
- app-operator support multi layer configs and fix for CAPI config updates
- cluster-opartor has a fix for testing app-operators
