### PR TITLE
AWS: Request cert-manager >= 2.15.2.

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -7,6 +7,8 @@ releases:
     version: ">= 4.3.0"
   - name: chart-operator
     version: ">= 2.25.0"
+  - name: cert-manager
+    version: ">= 2.15.2"
 - name: ">= 17.4.0"
   requests:
   - name: external-dns


### PR DESCRIPTION
Fixes an issue introduced in v2.15.1 and occurring during cluster upgrades.

Fresh installs of AWS v17.4.1 work, upgrades from any version below to v17.4.1 may break. So we probably should release v17.4.2 soon so customers upgrading their workload clusters don't run into this issue.