### PR TITLE
AWS/Requests: Postpone `app-operator` v6.3.0.

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,8 +1,10 @@
 releases:
-- name: "> 17.4.1"
+- name: ">= 17.5.0"
   requests:
   - name: app-operator
     version: ">= 6.3.0"
+- name: "> 17.4.1"
+  requests:
   - name: cluster-operator
     version: ">= 4.3.0"
   - name: chart-operator


### PR DESCRIPTION
This PR prevents feature changes to `app-operator` in patch releases.

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/136)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create appropriate ticket for your release

Ping @sig-product for review of release notes.
--->
