### PR TITLE
add aws 18.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ to all Giant Swarm installations.
     - [v20.0.0-alpha1](https://github.com/giantswarm/releases/tree/master/aws/v20.0.0-alpha1)
 - v18
   - v18.0
+    - [v18.0.2](https://github.com/giantswarm/releases/tree/master/aws/v18.0.2)
     - [v18.0.1](https://github.com/giantswarm/releases/tree/master/aws/v18.0.1)
     - [v18.0.0](https://github.com/giantswarm/releases/tree/master/aws/v18.0.0)
     - [v18.0.0-alpha1](https://github.com/giantswarm/releases/tree/master/aws/archived/v18.0.0-alpha1)

--- a/aws/kustomization.yaml
+++ b/aws/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - v17.4.3
 - v18.0.0
 - v18.0.1
+- v18.0.2
 - v20.0.0-alpha1
 transformers:
 - releaseNotesTransformer.yaml

--- a/aws/v18.0.2/README.md
+++ b/aws/v18.0.2/README.md
@@ -2,6 +2,16 @@
 
 This release fixes incompability with Cgroups V1 that was introduced in v18.0.0. The issue came from dropping dockershim and switching to containerd.
 
+***IRSA highlights***
+- Please read the [updated documentation](https://docs.giantswarm.io/advanced/iam-roles-for-service-accounts/)
+- Prior to upgrades please reach out to your Account Engineer and GiantSwarm team will help you in seemless migration if you have already enabled IRSA.
+- Please remember to adapt the IAM policies prior to upgrade as specified in the [documentation](https://docs.giantswarm.io/advanced/iam-roles-for-service-accounts/)
+
+***Features removed from v18.0.0***
+
+- Cilium CNI was rolled back, and this release once again uses AWS CNI. This was done because of an upstream bug that prevented some advanced networking features to work properly.
+- Out-of-tree cloud controller manager was removed, and in-tree alternative was enabled again because of an upstream bug regarding AWS CNI. Bug is already fixed in 1.24 version of upstream repo. 
+
 ## Change details
 
 

--- a/aws/v18.0.2/README.md
+++ b/aws/v18.0.2/README.md
@@ -1,0 +1,12 @@
+# :zap: Giant Swarm Release v18.0.2 for AWS :zap:
+
+<< Add description here >>
+
+## Change details
+
+
+### aws-operator [13.2.1-dev](https://github.com/giantswarm/aws-operator/releases/tag/v13.2.1-dev)
+
+Not found
+
+

--- a/aws/v18.0.2/README.md
+++ b/aws/v18.0.2/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v18.0.2 for AWS :zap:
 
-<< Add description here >>
+This release fixes incompability with Cgroups V1 that was introduced in v18.0.0. The issue came from dropping dockershim and switching to containerd.
 
 ## Change details
 

--- a/aws/v18.0.2/README.md
+++ b/aws/v18.0.2/README.md
@@ -15,8 +15,10 @@ This release fixes incompability with Cgroups V1 that was introduced in v18.0.0.
 ## Change details
 
 
-### aws-operator [13.2.1-dev](https://github.com/giantswarm/aws-operator/releases/tag/v13.2.1-dev)
+### aws-operator [13.2.1](https://github.com/giantswarm/aws-operator/releases/tag/v13.2.1)
 
-Not found
+### Fixed
+
+- Fixed regression on cgroups v1 support after switching to containerd.
 
 

--- a/aws/v18.0.2/announcement.md
+++ b/aws/v18.0.2/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v18.0.2 for AWS is available**. This release fixes incompability with Cgroups V1 that was introduced in v18.0.0. The issue came from dropping dockershim and switching to containerd. Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/aws-v18.0.2/).
+
+> **_Info:_** Cilium support that was introduced in 18.0.0 was rolled back to AWS CNI because of an unresolved upstream bug. Cilium support is postponed to version v19.0.0.

--- a/aws/v18.0.2/kustomization.yaml
+++ b/aws/v18.0.2/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/aws/v18.0.2/release.diff
+++ b/aws/v18.0.2/release.diff
@@ -1,0 +1,78 @@
+# Generated with:                                                  # Generated with:
+# /home/whites/workspace/devctl/devctl release create --provide |  # /home/whites/workspace/devctl/devctl release create --provide
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  annotations:                                                       annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp        giantswarm.io/docs: https://docs.giantswarm.io/reference/cp
+  creationTimestamp: null                                            creationTimestamp: null
+  name: v18.0.1                                                 |    name: v18.0.2
+spec:                                                              spec:
+  apps:                                                              apps:
+  - componentVersion: 1.8.0                                          - componentVersion: 1.8.0
+    name: aws-ebs-csi-driver                                           name: aws-ebs-csi-driver
+    version: 2.16.1                                                    version: 2.16.1
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.2.0                                                     version: 2.2.0
+  - componentVersion: 1.7.3                                          - componentVersion: 1.7.3
+    name: cert-manager                                                 name: cert-manager
+    version: 2.15.3                                                    version: 2.15.3
+  - name: chart-operator                                             - name: chart-operator
+    version: 2.27.0                                                    version: 2.27.0
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.23.1                                                    version: 1.23.1
+  - componentVersion: 1.9.3                                          - componentVersion: 1.9.3
+    name: coredns                                                      name: coredns
+    version: 1.11.0                                                    version: 1.11.0
+  - componentVersion: 0.11.0                                         - componentVersion: 0.11.0
+    name: external-dns                                                 name: external-dns
+    version: 2.15.2                                                    version: 2.15.2
+  - componentVersion: 4.2.0                                          - componentVersion: 4.2.0
+    name: kiam                                                         name: kiam
+    version: 2.5.0                                                     version: 2.5.0
+  - name: kiam-watchdog                                              - name: kiam-watchdog
+    version: 0.7.0                                                     version: 0.7.0
+  - componentVersion: 2.5.0                                          - componentVersion: 2.5.0
+    name: kube-state-metrics                                           name: kube-state-metrics
+    version: 1.11.0                                                    version: 1.11.0
+  - componentVersion: 0.6.1                                          - componentVersion: 0.6.1
+    name: metrics-server                                               name: metrics-server
+    version: 1.8.0                                                     version: 1.8.0
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.12.0                                                    version: 1.12.0
+  - componentVersion: 1.3.1                                          - componentVersion: 1.3.1
+    name: node-exporter                                                name: node-exporter
+    version: 1.13.0                                                    version: 1.13.0
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 2.5.0                                                     version: 2.5.0
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 1.0.1                                                     version: 1.0.1
+  - name: etcd-kubernetes-resources-count-exporter                   - name: etcd-kubernetes-resources-count-exporter
+    version: 0.5.1                                                     version: 0.5.1
+  components:                                                        components:
+  - name: app-operator                                               - name: app-operator
+    version: 6.3.0                                                     version: 6.3.0
+  - name: aws-cni                                                    - name: aws-cni
+    version: 1.11.2-nftables                                           version: 1.11.2-nftables
+  - name: aws-operator                                               - name: aws-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 13.2.0                                             |      version: 13.2.1-dev
+  - name: calico                                                     - name: calico
+    version: 3.21.5                                                    version: 3.21.5
+  - name: cert-operator                                              - name: cert-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 2.0.1                                                     version: 2.0.1
+  - name: cluster-operator                                           - name: cluster-operator
+    releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
+    version: 4.5.2                                                     version: 4.5.2
+  - name: containerlinux                                             - name: containerlinux
+    version: 3227.2.1                                                  version: 3227.2.1
+  - name: etcd                                                       - name: etcd
+    version: 3.5.4                                                     version: 3.5.4
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.23.9                                                    version: 1.23.9
+  date: "2022-08-24T08:28:27Z"                                  |    date: "2022-08-31T13:42:44Z"
+  state: active                                                      state: active
+status:                                                            status:
+  inUse: false                                                       inUse: false
+  ready: false                                                       ready: false

--- a/aws/v18.0.2/release.diff
+++ b/aws/v18.0.2/release.diff
@@ -56,7 +56,7 @@ spec:                                                              spec:
     version: 1.11.2-nftables                                           version: 1.11.2-nftables
   - name: aws-operator                                               - name: aws-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
-    version: 13.2.0                                             |      version: 13.2.1-dev
+    version: 13.2.0                                             |      version: 13.2.1
   - name: calico                                                     - name: calico
     version: 3.21.5                                                    version: 3.21.5
   - name: cert-operator                                              - name: cert-operator

--- a/aws/v18.0.2/release.yaml
+++ b/aws/v18.0.2/release.yaml
@@ -1,0 +1,80 @@
+# Generated with:
+# /home/whites/workspace/devctl/devctl release create --provider aws --base 18.0.1 --name 18.0.2 --component aws-operator@13.2.1-dev --overwrite
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/cp-k8s-api/releases.release.giantswarm.io/
+  creationTimestamp: null
+  name: v18.0.2
+spec:
+  apps:
+  - componentVersion: 1.8.0
+    name: aws-ebs-csi-driver
+    version: 2.16.1
+  - name: cert-exporter
+    version: 2.2.0
+  - componentVersion: 1.7.3
+    name: cert-manager
+    version: 2.15.3
+  - name: chart-operator
+    version: 2.27.0
+  - name: cluster-autoscaler
+    version: 1.23.1
+  - componentVersion: 1.9.3
+    name: coredns
+    version: 1.11.0
+  - componentVersion: 0.11.0
+    name: external-dns
+    version: 2.15.2
+  - componentVersion: 4.2.0
+    name: kiam
+    version: 2.5.0
+  - name: kiam-watchdog
+    version: 0.7.0
+  - componentVersion: 2.5.0
+    name: kube-state-metrics
+    version: 1.11.0
+  - componentVersion: 0.6.1
+    name: metrics-server
+    version: 1.8.0
+  - name: net-exporter
+    version: 1.12.0
+  - componentVersion: 1.3.1
+    name: node-exporter
+    version: 1.13.0
+  - name: vertical-pod-autoscaler
+    version: 2.5.0
+  - name: vertical-pod-autoscaler-crd
+    version: 1.0.1
+  - name: etcd-kubernetes-resources-count-exporter
+    version: 0.5.1
+  components:
+  - name: app-operator
+    version: 6.3.0
+  - name: aws-cni
+    version: 1.11.2-nftables
+  - catalog: control-plane-test-catalog
+    name: aws-operator
+    releaseOperatorDeploy: true
+    version: 13.2.1-dev
+    reference: 13.2.0-1d5e1e554193197d81752377502ed7910d8a2cdf
+  - name: calico
+    version: 3.21.5
+  - name: cert-operator
+    releaseOperatorDeploy: true
+    version: 2.0.1
+  - name: cluster-operator
+    releaseOperatorDeploy: true
+    version: 4.5.2
+  - name: containerlinux
+    version: 3227.2.1
+  - name: etcd
+    version: 3.5.4
+  - name: kubernetes
+    version: 1.23.9
+  date: "2022-08-31T13:42:44Z"
+  state: active
+status:
+  inUse: false
+  ready: false

--- a/aws/v18.0.2/release.yaml
+++ b/aws/v18.0.2/release.yaml
@@ -54,11 +54,9 @@ spec:
     version: 6.3.0
   - name: aws-cni
     version: 1.11.2-nftables
-  - catalog: control-plane-test-catalog
-    name: aws-operator
+  - name: aws-operator
     releaseOperatorDeploy: true
-    version: 13.2.1-dev
-    reference: 13.2.0-1d5e1e554193197d81752377502ed7910d8a2cdf
+    version: 13.2.1
   - name: calico
     version: 3.21.5
   - name: cert-operator


### PR DESCRIPTION
emergency release to fix cgroups v1 issue in v18.0.1