### PR TITLE
Request `cluster-operator` >= 4.6.1

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -5,6 +5,8 @@ releases:
     version: ">= 2.0.0"
   - name: kube-state-metrics
     version: ">= 1.13.0"
+  - name: cluster-operator
+    version: ">= 4.6.1"
 - name: "> 18.0.0"
   requests:
   - name: cert-manager

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,6 +5,8 @@ releases:
     version: ">= 2.0.0"
   - name: kube-state-metrics
     version: ">= 1.13.0"
+  - name: cluster-operator
+    version: ">= 4.6.1"
 - name: "> 17.2.0"
   requests:
   - name: app-operator


### PR DESCRIPTION
`kube-state-metrics` >= 1.12.1 got renamed from `kube-state-metrics-app` to `kube-state-metrics` only. We therefore need at least `cluster-operator` 4.6.0.