### PR TITLE
Update observability bundle requirement

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -10,7 +10,7 @@ releases:
   - name: cert-manager
     version: ">= 2.17.1"
   - name: observability-bundle
-    version: ">= 0.1.9"
+    version: ">= 0.2.0"
   - name: k8s-dns-node-cache-app
     version: ">= 1.1.0"
 - name: "> 18.2.0"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: coredns
     version: ">= 1.14.2"
+  - name: observability-bundle
+    version: ">= 0.2.0"
 - name: ">= 19.0.0"
   requests:
   - name: cluster-operator


### PR DESCRIPTION
This version of the observability bundle uses are more stable setup for the agent to prevent it from flooding prometheus on the MC

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
