### PR TITLE
Requests to bump app-operator to v6.6.3

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -4,7 +4,7 @@ releases:
   - name: cluster-operator
     version: ">= 5.3.0"
   - name: app-operator
-    version: ">= 6.4.1"
+    version: ">= 6.6.3"
   - name: kube-state-metrics
     version: ">= 1.14.0"
   - name: cert-manager

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -14,7 +14,7 @@ releases:
   - name: cluster-operator
     version: ">= 5.0.0"
   - name: app-operator
-    version: ">= 6.4.1"
+    version: ">= 6.6.3"
   - name: observability-bundle
     version: ">= 0.1.4"
   - name: vertical-pod-autoscaler

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -9,12 +9,14 @@ releases:
     version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd
     version: ">= 2.0.0"
+  - name: app-operator
+    version: ">= 6.6.3"
 - name: ">= 19.0.0"
   requests:
   - name: cluster-operator
     version: ">= 5.0.0"
   - name: app-operator
-    version: ">= 6.6.3"
+    version: ">= 6.4.1"
   - name: observability-bundle
     version: ">= 0.1.4"
   - name: vertical-pod-autoscaler


### PR DESCRIPTION
With `app-operator` version `v6.6.3` we adjusted resource usage and VPA: https://github.com/giantswarm/app-operator/releases/tag/v6.6.3

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
