### PR TITLE
Bump observability-bundle to 0.4.2

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -13,7 +13,7 @@ releases:
     version: ">= 2.35.1"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.4.0"
+    version: ">= 0.4.1"
   - name: vertical-pod-autoscaler
     version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -13,7 +13,7 @@ releases:
     version: ">= 2.35.1"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.4.1"
+    version: ">= 0.4.2"
   - name: vertical-pod-autoscaler
     version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,7 +5,7 @@ releases:
     version: ">= 1.14.2"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.4.0"
+    version: ">= 0.4.1"
   - name: vertical-pod-autoscaler-app
     version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,7 +5,7 @@ releases:
     version: ">= 1.14.2"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.4.1"
+    version: ">= 0.4.2"
   - name: vertical-pod-autoscaler-app
     version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->
towards https://github.com/giantswarm/giantswarm/issues/26629
towards https://github.com/giantswarm/giantswarm/issues/26674

Bump observability-bundle to 0.4.2: fix the watchdog and the data lost + fix preStop with removing the wal directory in the prometheus-agent

### Checklist
- [x] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
