### PR TITLE
Add vpa-crd dependency to more default apps

### DIFF
--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -12,9 +12,13 @@ spec:
   - componentVersion: 1.24.1
     name: aws-cloud-controller-manager
     version: 1.24.1-gs7
+    dependsOn:
+    - vertical-pod-autoscaler-crd
   - componentVersion: 1.15.0
     name: aws-ebs-csi-driver
     version: 2.21.1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
   - name: cert-exporter
     version: 2.5.1
     dependsOn:
@@ -94,6 +98,8 @@ spec:
     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter
     version: 1.2.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
   - name: observability-bundle
     version: 0.5.1
     dependsOn:


### PR DESCRIPTION
We want to stop using `helm` `Capabilities` object to install dependencies that are really required, otherwise the apps may get installed without the VPA resources if the VPA crd hasn't been installed yet.

- [aws-ebs-csi-driver-app](https://github.com/giantswarm/aws-ebs-csi-driver-app/blob/master/helm/aws-ebs-csi-driver-app/templates/controller-vpa.yaml#L1)
- [aws-cloud-controller-manager-app](https://github.com/giantswarm/aws-cloud-controller-manager-app/blob/main/helm/aws-cloud-controller-manager-app/templates/vpa.yaml#L1)
- [etcd-kubernetes-resources-count-exporter](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/blob/main/helm/etcd-kubernetes-resources-count-exporter/templates/vpa.yaml)