### PR TITLE
Request cert-manager 2.22.0 in upcoming releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,7 +6,7 @@ releases:
   - name: app-operator
     version: ">= 6.6.3"
   - name: cert-manager
-    version: ">= 2.17.1"
+    version: ">= 2.22.0"
   - name: external-dns
     version: ">= 2.37.0"
   - name: net-exporter


### PR DESCRIPTION
cert-manager 2.22.0 contains a fix for https://github.com/giantswarm/giantswarm/issues/27170
