### PR TITLE
Request cert-manager-app in upcoming AWS platform release

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,7 +6,7 @@ releases:
   - name: app-operator
     version: ">= 6.6.3"
   - name: cert-manager
-    version: ">= 2.22.0"
+    version: ">= 2.23.0"
   - name: external-dns
     version: ">= 2.37.0"
   - name: net-exporter


### PR DESCRIPTION
Please include cert-manager-app 2.23.0 in upcoming AWS platform release. Thanks