### PR TITLE
patch external-dns in aws v19

### DIFF
--- a/aws/v19.0.0/README.md
+++ b/aws/v19.0.0/README.md
@@ -215,7 +215,7 @@ We're aiming to provide a comprehensive blackbox monitoring tool that can valida
 
 
 
-### external-dns [2.37.0](https://github.com/giantswarm/external-dns-app/releases/tag/v2.37.0)
+### external-dns [2.37.1](https://github.com/giantswarm/external-dns-app/releases/tag/v2.37.1)
 
 #### Changed
 - Disable PSPs for k8s 1.25 and newer.

--- a/aws/v19.0.0/release.diff
+++ b/aws/v19.0.0/release.diff
@@ -53,7 +53,7 @@ spec:                                                              spec:
     - cilium                                                           - cilium
   - componentVersion: 0.11.0                                         - componentVersion: 0.11.0
     name: external-dns                                                 name: external-dns
-    version: 2.35.0                                             |      version: 2.37.0
+    version: 2.35.0                                             |      version: 2.37.1
     dependsOn:                                                  <
     - aws-cloud-controller-manager                              <
     - cilium                                                    <

--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -1,5 +1,5 @@
 # Generated with:
-# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.21.0@1.8.2 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.0@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
+# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.21.0@1.8.2 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.1@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -57,7 +57,7 @@ spec:
     - cilium
   - componentVersion: 0.11.0
     name: external-dns
-    version: 2.37.0
+    version: 2.37.1
     dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

Coming from this [thread](https://gigantic.slack.com/archives/C02EVLE9W/p1686814697921809?thread_ts=1686751793.540999&cid=C02EVLE9W). This PR patches the v19 release to include a hotfix of external-dns-app that blocks China installations upgrade to v19.

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
