### PR TITLE
patch aws 18.4.2 to remove cilium migration stuff

### DIFF
--- a/aws/v18.4.2/README.md
+++ b/aws/v18.4.2/README.md
@@ -8,7 +8,11 @@ The minimal requirement for the IAM permissions is [Version 3.3.0](https://githu
 ## Change details
 
 
-### aws-operator [14.13.3](https://github.com/giantswarm/aws-operator/releases/tag/v14.13.3)
+### aws-operator [14.13.3-patch1](https://github.com/giantswarm/aws-operator/releases/tag/v14.13.3-patch1)
+
+#### Removed
+
+- Remove implementation of `prepareawscniformigration` and `restrictawsnodedaemonset` to avoid race condition issues during cluster upgrades.
 
 #### Fixed
 - Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.

--- a/aws/v18.4.2/release.diff
+++ b/aws/v18.4.2/release.diff
@@ -87,7 +87,7 @@ spec:                                                              spec:
     version: 1.12.6                                                    version: 1.12.6
   - name: aws-operator                                               - name: aws-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
-    version: 14.13.2                                            |      version: 14.13.3
+    version: 14.13.2                                            |      version: 14.13.3-patch1
   - name: calico                                                     - name: calico
     version: 3.21.5                                                    version: 3.21.5
   - name: cert-operator                                              - name: cert-operator

--- a/aws/v18.4.2/release.diff
+++ b/aws/v18.4.2/release.diff
@@ -87,7 +87,8 @@ spec:                                                              spec:
     version: 1.12.6                                                    version: 1.12.6
   - name: aws-operator                                               - name: aws-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
-    version: 14.13.2                                            |      version: 14.13.3-patch1
+    version: 14.13.2                                            |      version: 14.13.3
+                                                                >      reference: 14.13.3-patch1
   - name: calico                                                     - name: calico
     version: 3.21.5                                                    version: 3.21.5
   - name: cert-operator                                              - name: cert-operator

--- a/aws/v18.4.2/release.yaml
+++ b/aws/v18.4.2/release.yaml
@@ -87,7 +87,7 @@ spec:
     version: 1.12.6
   - name: aws-operator
     releaseOperatorDeploy: true
-    version: 14.13.3
+    version: 14.13.3-patch1
   - name: calico
     version: 3.21.5
   - name: cert-operator

--- a/aws/v18.4.2/release.yaml
+++ b/aws/v18.4.2/release.yaml
@@ -87,7 +87,8 @@ spec:
     version: 1.12.6
   - name: aws-operator
     releaseOperatorDeploy: true
-    version: 14.13.3-patch1
+    version: 14.13.3
+    reference: 14.13.3-patch1
   - name: calico
     version: 3.21.5
   - name: cert-operator


### PR DESCRIPTION
Patch 18.4.2 in place to use hotfix version of aws operator

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
