### PR TITLE
cert-manager 2.24.0 in upcoming AWS releases

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,7 +6,7 @@ releases:
   - name: app-operator
     version: ">= 6.6.3"
   - name: cert-manager
-    version: ">= 2.23.2"
+    version: ">= 2.24.0"
   - name: external-dns
     version: ">= 2.37.0"
   - name: net-exporter


### PR DESCRIPTION
Please include cert-manager-app 2.24.0 in upcoming AWS releases