### PR TITLE
Update Release 19

### DIFF
--- a/aws/v19.0.0/README.md
+++ b/aws/v19.0.0/README.md
@@ -144,14 +144,16 @@ We're aiming to provide a comprehensive blackbox monitoring tool that can valida
 
 
 
-### aws-operator [14.17.1-patch1](https://github.com/giantswarm/aws-operator/releases/tag/v14.17.1-patch1)
+### aws-operator [14.17.1-patch2](https://github.com/giantswarm/aws-operator/releases/tag/v14.17.1-patch2)
 
 #### Added
 - Add toleration for new control-plane taint.
 #### Fixed
 - Ensure `net.ipv4.conf.eth0.rp_filter` is set to `2` if aws-CNI is used.
 - Make `routes-fixer` script compatible with alpine.
-
+- Change AWS LB Controller Trust Policy for the new S3 bucket in China clusters.
+### Changed
+- Change Route53 Trust Policy to allow multiple applications to use the role.
 
 ### cluster-operator [5.6.1](https://github.com/giantswarm/cluster-operator/releases/tag/v5.6.1)
 

--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -135,7 +135,7 @@ spec:
   - name: aws-operator
     releaseOperatorDeploy: true
     version: 14.17.1
-    reference: 14.17.1-patch1
+    reference: 14.17.1-patch2
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.0.1


### PR DESCRIPTION
Includes Route53 trust policy fix for China and externalDNS relaxed trust policy

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
