### PR TITLE
Update version of observability-bundle in aws and azure requests

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -17,7 +17,7 @@ releases:
   - name: observability-bundle
     version: ">= 0.7.0"
   - name: vertical-pod-autoscaler
-    version: ">= 3.3.0"
+    version: ">= 3.5.3"
   - name: vertical-pod-autoscaler-crd
     version: ">= 2.0.0"
   - name: k8s-dns-node-cache-app

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -15,7 +15,7 @@ releases:
     version: ">= 1.16.1"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.7.0"
+    version: ">= 0.7.1"
   - name: vertical-pod-autoscaler
     version: ">= 3.5.3"
   - name: vertical-pod-autoscaler-crd

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -11,8 +11,12 @@ releases:
   - name: observability-bundle
     version: ">= 0.7.0"
   - name: vertical-pod-autoscaler
-    version: ">= 3.5.3"
+    version: ">= 3.3.0"
   - name: vertical-pod-autoscaler-crd
     version: ">= 2.0.0"
   - name: app-operator
     version: ">= 6.6.3"
+- name: "> 19.1.0 < 19.999.999"
+  requests:
+  - name: vertical-pod-autoscaler
+    version: ">= 3.5.3"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -11,7 +11,7 @@ releases:
   - name: observability-bundle
     version: ">= 0.7.0"
   - name: vertical-pod-autoscaler
-    version: ">= 3.3.0"
+    version: ">= 3.5.3"
   - name: vertical-pod-autoscaler-crd
     version: ">= 2.0.0"
   - name: app-operator

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -20,3 +20,6 @@ releases:
   requests:
   - name: vertical-pod-autoscaler
     version: ">= 3.5.3"
+  # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
+  - name: observability-bundle
+    version: ">= 0.7.1"


### PR DESCRIPTION
- Update request for vpa app to 3.5.3
- Update azure request to use a separate block for 19.1.0+
- Update version of observability bundle in aws and azure requests


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
