### PR TITLE
Update observability bundle in aws and azure

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -15,7 +15,7 @@ releases:
     version: ">= 1.16.1"
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.7.0"
+    version: ">= 0.7.1"
   - name: vertical-pod-autoscaler
     version: ">= 3.5.3"
   - name: vertical-pod-autoscaler-crd

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,11 @@
 releases:
+- name: "> 19.1.0 < 19.999.999"
+  requests:
+  - name: vertical-pod-autoscaler
+    version: ">= 3.5.3"
+  # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
+  - name: observability-bundle
+    version: ">= 0.7.1"
 - name: "> 19.0.2 < 19.999.999"
   requests:
   - name: coredns
@@ -16,7 +23,3 @@ releases:
     version: ">= 2.0.0"
   - name: app-operator
     version: ">= 6.6.3"
-- name: "> 19.1.0 < 19.999.999"
-  requests:
-  - name: vertical-pod-autoscaler
-    version: ">= 3.5.3"


### PR DESCRIPTION
Also reorg blocks in azure moving most recent up to the top


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
