### PR TITLE
Request bump security-bundle to 0.16.2

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 19.1.0 < 19.999.999"
+  requests:
+  - name: security-bundle
+    version: ">= 0.16.2"
 - name: ">= 19.0.1"
   requests:
   - name: cluster-operator

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -8,6 +8,8 @@ releases:
   # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
     version: ">= 0.7.1"
+  - name: security-bundle
+    version: ">= 0.16.2"
 - name: "> 19.0.2 < 19.999.999"
   requests:
   - name: coredns


### PR DESCRIPTION
Request bumping security-bundle to latest release 0.16.2, that adds the dependsOn feature to prevent 
installing Kyverno Policies before CRDs are present.



### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
