### PR TITLE
bump coredns to 1.17.1 on azure v19.1.0

### DIFF
--- a/azure/v19.1.0/README.md
+++ b/azure/v19.1.0/README.md
@@ -130,12 +130,13 @@ _Nothing has changed._
 
 
 
-### coredns [1.17.0](https://github.com/giantswarm/coredns-app/releases/tag/v1.17.0)
+### coredns [1.17.1](https://github.com/giantswarm/coredns-app/releases/tag/v1.17.1)
 
 #### Added
 - Add scaling based on custom metrics ([#209](https://github.com/giantswarm/coredns-app/pull/209)).
 #### Changed
 - Decouple PDB configuration from deployment updateStrategy ([#208](https://github.com/giantswarm/coredns-app/pull/208)).
+- Disable IPV6 queries.
 
 
 

--- a/azure/v19.1.0/release.diff
+++ b/azure/v19.1.0/release.diff
@@ -36,7 +36,7 @@ spec:                                                              spec:
     version: 2.33.2                                             |      version: 2.35.0
   - componentVersion: 1.9.3                                          - componentVersion: 1.9.3
     name: coredns                                                      name: coredns
-    version: 1.13.0                                             |      version: 1.17.0
+    version: 1.13.0                                             |      version: 1.17.1
     dependsOn:                                                         dependsOn:
     - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
     - azure-cloud-node-manager                                         - azure-cloud-node-manager

--- a/azure/v19.1.0/release.yaml
+++ b/azure/v19.1.0/release.yaml
@@ -36,7 +36,7 @@ spec:
     version: 2.35.0
   - componentVersion: 1.9.3
     name: coredns
-    version: 1.17.0
+    version: 1.17.1
     dependsOn:
     - azure-cloud-controller-manager
     - azure-cloud-node-manager


### PR DESCRIPTION
bump coredns app in azure 19.1.0 release to disable ipv6 and prevent azure throttling issues
