### PR TITLE
Upgrade cert-manager-app to 2.24.1 in AWS v19.0.0

### DIFF
--- a/aws/v19.0.0/README.md
+++ b/aws/v19.0.0/README.md
@@ -303,6 +303,24 @@ We're aiming to provide a comprehensive blackbox monitoring tool that can valida
 - Add overridability to the servicemonitors relabelings and metric_relabelings sections.
 
 
+
+### cert-manager [2.24.1](https://github.com/giantswarm/cert-manager-app/releases/tag/v2.24.1)
+
+### Added
+
+- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`.
+- Add `CiliumNetworkPolicy`.
+
+### Changed
+
+- Update cert-manager container image versions to use v1.12.1
+- Do not try to install PodSecurityPolicies if not available. This will make the Chart compatible with kubernetes >= 1.25
+- Change security contexts to make the chart work with PSS restricted profile
+- Install `giantswarm-selfsigned` ClusterIssuer regardless of `global.giantSwarmClusterIssuer.install` value. It is required as a default component for Giant Swarm cluster installations.
+- Add helm adoption annotations to CRD templates. This change is done in preparation of the next major chart release.
+
+
+
 ### kubernetes [1.24.13](https://github.com/kubernetes/kubernetes/releases/tag/v1.24.13)
 
 #### Changelog since v1.23.0

--- a/aws/v19.0.0/release.diff
+++ b/aws/v19.0.0/release.diff
@@ -26,9 +26,9 @@ spec:                                                              spec:
     - cilium                                                           - cilium
     - coredns                                                          - coredns
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2                                          - componentVersion: 1.8.2
+  - componentVersion: 1.8.2                                     |    - componentVersion: 1.12.1
     name: cert-manager                                                 name: cert-manager
-    version: 2.21.0                                                    version: 2.21.0
+    version: 2.21.0                                             |      version: 2.24.1
     dependsOn:                                                         dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -1,5 +1,5 @@
 # Generated with:
-# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.21.0@1.8.2 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.1@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
+# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.24.1@1.12.1 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.1@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -28,7 +28,7 @@ spec:
     - vertical-pod-autoscaler-crd
   - componentVersion: 1.8.2
     name: cert-manager
-    version: 2.21.0
+    version: 2.24.1
     dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27705

cert-manager-app v2.24.1 contains required changes for upcoming cert-manager-app v3.0.0

This has been tested by changing the App CR + user-override-apps CM