### PR TITLE
bump coredns to 1.18.0 on azure 19.1.0 release

### DIFF
--- a/azure/v19.1.0/README.md
+++ b/azure/v19.1.0/README.md
@@ -130,13 +130,20 @@ _Nothing has changed._
 
 
 
-### coredns [1.17.1](https://github.com/giantswarm/coredns-app/releases/tag/v1.17.1)
+### coredns [1.18.0](https://github.com/giantswarm/coredns-app/releases/tag/v1.18.0)
 
 #### Added
 - Add scaling based on custom metrics ([#209](https://github.com/giantswarm/coredns-app/pull/209)).
+- Add a new field additionalLocalZones which can be used to introduce more internal local zones, e.g. linkerd.
 #### Changed
 - Decouple PDB configuration from deployment updateStrategy ([#208](https://github.com/giantswarm/coredns-app/pull/208)).
-- Disable IPV6 queries.
+- Disable IPV6.
+- Create a coredns zone for each cluster domain.
+- Adjust the settings for upscaling HPA when hitting 60% CPU.
+- Adjust the settings for downscaling HPA to 30 minutes.
+- Adjust the min and max memory settings per Pod.
+- Enable cache inconditionaly for . and local zones.
+- Adjust the settings for upscaling HPA when hitting 80% Memory.
 
 
 

--- a/azure/v19.1.0/release.diff
+++ b/azure/v19.1.0/release.diff
@@ -36,7 +36,7 @@ spec:                                                              spec:
     version: 2.33.2                                             |      version: 2.35.0
   - componentVersion: 1.9.3                                          - componentVersion: 1.9.3
     name: coredns                                                      name: coredns
-    version: 1.13.0                                             |      version: 1.17.1
+    version: 1.13.0                                             |      version: 1.18.0
     dependsOn:                                                         dependsOn:
     - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
     - azure-cloud-node-manager                                         - azure-cloud-node-manager

--- a/azure/v19.1.0/release.yaml
+++ b/azure/v19.1.0/release.yaml
@@ -36,7 +36,7 @@ spec:
     version: 2.35.0
   - componentVersion: 1.9.3
     name: coredns
-    version: 1.17.1
+    version: 1.18.0
     dependsOn:
     - azure-cloud-controller-manager
     - azure-cloud-node-manager


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27695
