### PR TITLE
Request observability-bundle bump

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -21,15 +21,22 @@ releases:
     version: ">= 1.16.2"
   - name: node-exporter
     version: ">= 1.16.1"
-  # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.7.1"
+    version: ">= 0.7.3"
   - name: vertical-pod-autoscaler
     version: ">= 3.5.3"
   - name: vertical-pod-autoscaler-crd
     version: ">= 2.0.0"
   - name: k8s-dns-node-cache-app
     version: ">= 1.1.0"
+- name: "> 19.0.2 < 19.999.999"
+  requests:
+  - name: observability-bundle
+    version: ">= 0.7.3"
+  - name: vertical-pod-autoscaler
+    version: ">= 3.5.3"
+  - name: vertical-pod-autoscaler-crd
+    version: ">= 2.0.0"
 - name: "> 18.2.2"
   requests:
   - name: coredns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -5,9 +5,8 @@ releases:
     version: ">= 0.5.3"
   - name: vertical-pod-autoscaler
     version: ">= 3.5.3"
-  # This also requires the removal of the kube-state-metrics app as it is now included in the bundle.
   - name: observability-bundle
-    version: ">= 0.7.1"
+    version: ">= 0.7.3"
   - name: security-bundle
     version: ">= 0.16.2"
 - name: "> 19.0.2 < 19.999.999"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27646

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version


@T-Kukawka  do you think it makes sense to create a patch release for v19.0.2 or is 19.1.0 out of the corner?