### PR TITLE
Patch v19 releases to use cert manager-app v2.25.0

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -8,7 +8,7 @@ releases:
   - name: app-operator
     version: ">= 6.6.3"
   - name: cert-manager
-    version: ">= 2.24.1 < 3.0.0"
+    version: ">= 2.25.0 < 3.0.0"
   - name: cilium-servicemonitors
     version: ">= 0.1.2"
   - name: aws-ebs-csi-driver

--- a/aws/v19.0.0/README.md
+++ b/aws/v19.0.0/README.md
@@ -305,20 +305,12 @@ We're aiming to provide a comprehensive blackbox monitoring tool that can valida
 
 
 
-### cert-manager [2.24.1](https://github.com/giantswarm/cert-manager-app/releases/tag/v2.24.1)
-
-### Added
-
-- Add `cluster-autoscaler safe-to-evict` annotation to `controller` and `cainjector`.
-- Add `CiliumNetworkPolicy`.
+### cert-manager [2.25.0](https://github.com/giantswarm/cert-manager-app/releases/tag/v2.25.0)
 
 ### Changed
 
-- Update cert-manager container image versions to use v1.12.1
-- Do not try to install PodSecurityPolicies if not available. This will make the Chart compatible with kubernetes >= 1.25
-- Change security contexts to make the chart work with PSS restricted profile
-- Install `giantswarm-selfsigned` ClusterIssuer regardless of `global.giantSwarmClusterIssuer.install` value. It is required as a default component for Giant Swarm cluster installations.
-- Add helm adoption annotations to CRD templates. This change is done in preparation of the next major chart release.
+- Remove control plane node toleration of CA injector deployment. This caused problems on single control plane node clusters. ([#362](https://github.com/giantswarm/cert-manager-app/pull/362))
+- Update container image versions to use [v1.12.4](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.4)
 
 
 

--- a/aws/v19.0.0/release.diff
+++ b/aws/v19.0.0/release.diff
@@ -26,9 +26,9 @@ spec:                                                              spec:
     - cilium                                                           - cilium
     - coredns                                                          - coredns
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2                                     |    - componentVersion: 1.12.1
+  - componentVersion: 1.8.2                                     |    - componentVersion: 1.12.4
     name: cert-manager                                                 name: cert-manager
-    version: 2.21.0                                             |      version: 2.24.1
+    version: 2.21.0                                             |      version: 2.25.0
     dependsOn:                                                         dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -1,5 +1,5 @@
 # Generated with:
-# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.24.1@1.12.1 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.1@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
+# devctl release create --name 19.0.0 --base 19.0.0-beta1 --provider aws --overwrite --app aws-cloud-controller-manager@1.24.1-gs7@1.24.1 --app aws-ebs-csi-driver@2.21.1 --app cert-exporter@2.5.1 --app cert-manager@2.25.0@1.12.4 --app chart-operator@2.35.0 --app cilium@0.10.0@1.13.0 --app cluster-autoscaler@1.24.0-gs2@1.24.0 --app coredns@1.17.0@1.9.3 --app external-dns@2.37.1@0.11.0 --app metrics-server@2.2.0@0.6.1 --app net-exporter@1.15.0 --app node-exporter@1.16.0@1.3.1 --app vertical-pod-autoscaler@3.4.2@0.13.0 --app vertical-pod-autoscaler-crd@2.0.1 --app etcd-kubernetes-resources-count-exporter@1.2.0 --app observability-bundle@0.5.1 --app k8s-dns-node-cache@2.1.0 --app prometheus-blackbox-exporter@0.3.2 --app cilium-servicemonitors@0.1.1 --app irsa-servicemonitors@0.0.1 --component app-operator@6.7.0 --component aws-operator@14.17.1 --component cert-operator@3.0.1 --component cluster-operator@5.6.1 --component containerlinux@3510.2.0 --component etcd@3.5.7 --component kubernetes@1.24.13
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -26,9 +26,9 @@ spec:
     - cilium
     - coredns
     - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2
+  - componentVersion: 1.12.4
     name: cert-manager
-    version: 2.24.1
+    version: 2.25.0
     dependsOn:
     - aws-cloud-controller-manager
     - cilium

--- a/aws/v19.0.1/release.diff
+++ b/aws/v19.0.1/release.diff
@@ -26,9 +26,9 @@ spec:                                                              spec:
     - cilium                                                           - cilium
     - coredns                                                          - coredns
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2                                          - componentVersion: 1.8.2
+  - componentVersion: 1.12.4                                         - componentVersion: 1.12.4
     name: cert-manager                                                 name: cert-manager
-    version: 2.24.1                                                    version: 2.24.1
+    version: 2.25.0                                                    version: 2.25.0
     dependsOn:                                                         dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.0.1/release.yaml
+++ b/aws/v19.0.1/release.yaml
@@ -26,9 +26,9 @@ spec:
     - cilium
     - coredns
     - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2
+  - componentVersion: 1.12.4
     name: cert-manager
-    version: 2.24.1
+    version: 2.25.0
     dependsOn:
     - aws-cloud-controller-manager
     - cilium

--- a/aws/v19.1.0/release.diff
+++ b/aws/v19.1.0/release.diff
@@ -29,16 +29,16 @@ spec:                                                              spec:
     - cilium                                                           - cilium
     - coredns                                                          - coredns
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - componentVersion: 1.8.2                                     |      name: cert-exporter
+  - componentVersion: 1.12.4                                    |      name: cert-exporter
     name: cert-manager                                          |      version: 2.6.0
-    version: 2.24.1                                             |    - componentVersion: 1.12.3
+    version: 2.25.0                                             |    - componentVersion: 1.12.4
     dependsOn:                                                         dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium
     - coredns                                                          - coredns
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
                                                                 >      name: cert-manager
-                                                                >      version: 2.24.1
+                                                                >      version: 2.25.0
   - name: chart-operator                                             - name: chart-operator
     version: 2.35.0                                                    version: 2.35.0
   - componentVersion: 1.13.0                                    |    - componentVersion: 1.13.6

--- a/aws/v19.1.0/release.yaml
+++ b/aws/v19.1.0/release.yaml
@@ -26,14 +26,14 @@ spec:
     - vertical-pod-autoscaler-crd
     name: cert-exporter
     version: 2.6.0
-  - componentVersion: 1.12.3
+  - componentVersion: 1.12.4
     dependsOn:
     - aws-cloud-controller-manager
     - cilium
     - coredns
     - vertical-pod-autoscaler-crd
     name: cert-manager
-    version: 2.24.1
+    version: 2.25.0
   - name: chart-operator
     version: 2.35.0
   - componentVersion: 1.13.6


### PR DESCRIPTION
This PR changes releases v19.0.0, v19.0.1 and v19.1.0 to use [cert-manager-app v2.25.0](https://github.com/giantswarm/cert-manager-app/releases/tag/v2.25.0)


cert-manager-app v2.25.0 contains fixes for these issues:

- Bump cert-manager from v1.12.1 to v1.12.4. It contains an upstream fix for cainjector using more resources than required https://github.com/giantswarm/giantswarm/issues/28309
- Removal of control plane node toleration for cainjector deployment. This caused issues on single control plane node cluster https://github.com/giantswarm/giantswarm/issues/28283