### PR TITLE
bump cluster operator to 5.8.0-patch1 on 19.1.0

### DIFF
--- a/aws/v19.1.0/README.md
+++ b/aws/v19.1.0/README.md
@@ -77,13 +77,14 @@ _Nothing has changed._
 
     
 
-### cluster-operator [5.8.0](https://github.com/giantswarm/cluster-operator/releases/tag/v5.8.0)
+### cluster-operator [5.8.0-patch1](https://github.com/giantswarm/cluster-operator/releases/tag/v5.8.0-patch1)
 
 #### Added
 - Add ENI mode for Cilium on AWS.
 - Consider new control-plane label.
+- Create external-dns-cluster-values configmap on cluster creation.
 #### Changed
-- Propagate `global.podSecurityStandards.enforced` value set to `true` for PSS migration
+- Propagate `global.podSecurityStandards.enforced` value set to `false` for PSS migration
 - Rename function for better readbility.
 
 

--- a/aws/v19.1.0/release.diff
+++ b/aws/v19.1.0/release.diff
@@ -184,7 +184,7 @@ spec:                                                              spec:
   - name: cluster-operator                                           - name: cluster-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 5.6.1                                              |      version: 5.8.0
-    reference: 5.6.1-patch1                                     <
+    reference: 5.6.1-patch1                                     |      reference: 5.8.0-patch1
   - name: containerlinux                                             - name: containerlinux
     version: 3510.2.0                                           |      version: 3510.2.7
   - name: etcd                                                       - name: etcd

--- a/aws/v19.1.0/release.yaml
+++ b/aws/v19.1.0/release.yaml
@@ -164,6 +164,7 @@ spec:
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.8.0
+    reference: 5.8.0-patch1
   - name: containerlinux
     version: 3510.2.7
   - name: etcd


### PR DESCRIPTION
cluster-operator 5.8.0 has PSS mode enabled, but 19.1.0 does not support it yet.
We released 5.8.0-patch1 with PSS disabled and this PR is patching 19.1.0 to the new patch

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
