### PR TITLE
Request bump for `chart-operator` and adding `chart-operator-extensions` that depends on `prometheus-operator-crd`

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "> 19.1.0"
+- name: "> 19.1.1"
   requests:
     - name: chart-operator
       version: ">= 3.0.0"

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,11 @@
 releases:
+- name: "> 19.1.0"
+  requests:
+    - name: chart-operator
+      version: ">= 3.0.0"
+    # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
+    - name: chart-operator-extensions
+      version: ">= 1.1.1"
 - name: ">= 19.1.0 < 19.999.999"
   requests:
   - name: security-bundle
@@ -11,11 +18,6 @@ releases:
     version: ">= 2.25.0 < 3.0.0"
   - name: cilium-servicemonitors
     version: ">= 0.1.2"
-  - name: chart-operator
-    version: ">= 3.0.0"
-  # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
-  - name: chart-operator-extensions
-    version: ">= 1.1.1"
   - name: aws-ebs-csi-driver
     version: ">= 2.25.0"
   - name: external-dns

--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -11,6 +11,11 @@ releases:
     version: ">= 2.25.0 < 3.0.0"
   - name: cilium-servicemonitors
     version: ">= 0.1.2"
+  - name: chart-operator
+    version: ">= 3.0.0"
+  # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
+  - name: chart-operator-extensions
+    version: ">= 1.1.1"
   - name: aws-ebs-csi-driver
     version: ">= 2.25.0"
   - name: external-dns

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,6 +1,11 @@
 releases:
 - name: "> 19.1.0 < 19.999.999"
   requests:
+  - name: chart-operator
+    version: ">= 3.0.0"
+  # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
+  - name: chart-operator-extensions
+    version: ">= 1.1.1"
   - name: k8s-audit-metrics
     version: ">= 0.5.3"
   - name: vertical-pod-autoscaler

--- a/kvm/requests.yaml
+++ b/kvm/requests.yaml
@@ -2,7 +2,10 @@ releases:
 - name: "> 16.2.1"
   requests:
   - name: chart-operator
-    version: ">= 2.20.1"
+    version: ">= 3.0.0"
+  # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
+  - name: chart-operator-extensions
+    version: ">= 1.1.1"
   - name: coredns
     version: ">= 1.14.2"
   - name: kube-state-metrics


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27558

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
