### PR TITLE
Bump security-bundle in v19.1.1 release

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -6,6 +6,8 @@ releases:
     # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
     - name: chart-operator-extensions
       version: ">= 1.1.1"
+    - name: security-bundle
+      version: ">= 0.18.0"
 - name: ">= 19.1.0 < 19.999.999"
   requests:
   - name: security-bundle

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "> 19.1.1 < 19.999.999"
+  requests:
+    - name: security-bundle
+      version: ">= 0.18.0"
 - name: "> 19.1.0 < 19.999.999"
   requests:
   - name: chart-operator


### PR DESCRIPTION
Bumps the security-bundle to v0.18.0 in v19.1.1 release, this release adds the new exception-recommender and kyverno-policy-operator.