### PR TITLE
Update requests for security-bundle, some cleanup

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,12 @@
 releases:
+- name: ">= 19.3.0"
+  requests:
+  - name: security-bundle
+    version: ">= 1.3.0"
+- name: ">= 19.2.0 < 19.3.0"
+  requests:
+  - name: security-bundle
+    version: ">= 0.18.0 < 1.0.0"
 - name: ">= 19.2.0"
   requests:
   - name: cert-manager
@@ -8,8 +16,6 @@ releases:
   # chart-operator-extensions depends on the `ServiceMonitor` CRD and thus on `prometheus-operator-crd`
   - name: chart-operator-extensions
     version: ">= 1.1.1"
-  - name: security-bundle
-    version: ">= 0.18.0"
   # Add psp disabling + PSS fixes
   - name: metrics-server
     version: ">= 2.3.0"
@@ -179,12 +185,6 @@ releases:
   requests:
   - name: external-dns
     version: ">= 2.9.0"
-- name: "> 16.3.1 < 16.4.0"
-  requests:
-  - name: cert-manager
-    version: ">= 2.13.0"
-  - name: external-dns
-    version: ">= 2.10.0"
 - name: "> 16.2.0 < 17.0.0-alpha1"
   requests:
   - name: cert-exporter
@@ -199,21 +199,7 @@ releases:
     version: ">= 2.1.0"
   - name: cert-operator
     version: ">= 1.3.0"
-- name: "> 16.1.1 < 16.2.0"
-  requests:
-  - name: cert-manager
-    version: ">= 2.13.0"
-  - name: external-dns
-    version: ">= 2.10.0"
 - name: "> 16.0.2"
   requests:
   - name: cluster-operator
     version: ">= 3.11.0"
-- name: "> 16.0.1"
-  requests:
-  - name: aws-ebs-csi-driver
-    version: ">= 2.7.1"
-- name: "> 16.0.0"
-  requests:
-  - name: cert-operator
-    version: ">= 1.2.0"


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

Requests `security-bundle` 1.3.0 and above for AWS v19.3.0.
Tightens the `security-bundle` request scope for 19.2.x to only that minor.
Removes some v16 requests.

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
