### PR TITLE
bump etcd resources exporter

### DIFF
--- a/aws/v17.4.4/README.md
+++ b/aws/v17.4.4/README.md
@@ -34,5 +34,6 @@ This is a patch release to add missing Elastic File System (EFS) IAM permissions
 #### Changed
 - Update init container image to v3.16.2([#182](https://github.com/giantswarm/external-dns-app/pull/182))
 
+### etcd-kubernetes-resources-count-exporter [1.8.0](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v1.8.0)
 
-
+Bump to latest version to address security and performance issues. 

--- a/aws/v17.4.4/release.diff
+++ b/aws/v17.4.4/release.diff
@@ -48,7 +48,7 @@ spec:                                                            spec:
   - name: vertical-pod-autoscaler-crd                              - name: vertical-pod-autoscaler-crd
     version: 1.0.1                                                   version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter                 - name: etcd-kubernetes-resources-count-exporter
-    version: 0.5.0                                                   version: 0.5.0
+    version: 0.5.0                                             |     version: 1.8.0
   components:                                                      components:
   - name: app-operator                                             - name: app-operator
     version: 6.1.0                                                   version: 6.1.0

--- a/aws/v17.4.4/release.yaml
+++ b/aws/v17.4.4/release.yaml
@@ -48,7 +48,7 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 0.5.0
+    version: 1.8.0
   components:
   - name: app-operator
     version: 6.1.0

--- a/aws/v18.1.0/release.diff
+++ b/aws/v18.1.0/release.diff
@@ -48,7 +48,7 @@ spec:                                                            spec:
   - name: vertical-pod-autoscaler-crd                              - name: vertical-pod-autoscaler-crd
     version: 1.0.1                                                   version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter                 - name: etcd-kubernetes-resources-count-exporter
-    version: 0.5.1                                             |     version: 1.0.0
+    version: 1.8.0                                                   version: 1.8.0
   components:                                                      components:
   - name: app-operator                                             - name: app-operator
     version: 6.3.0                                             |     version: 6.4.1

--- a/aws/v18.1.0/release.yaml
+++ b/aws/v18.1.0/release.yaml
@@ -48,7 +48,7 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0
+    version: 1.8.0
   components:
   - name: app-operator
     version: 6.4.1

--- a/aws/v18.1.1/release.diff
+++ b/aws/v18.1.1/release.diff
@@ -48,7 +48,7 @@ spec:                                                            spec:
   - name: vertical-pod-autoscaler-crd                              - name: vertical-pod-autoscaler-crd
     version: 1.0.1                                                   version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter                 - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0                                                   version: 1.0.0
+    version: 1.8.0                                                   version: 1.8.0
   components:                                                      components:
   - name: app-operator                                             - name: app-operator
     version: 6.4.1                                                   version: 6.4.1

--- a/aws/v18.1.1/release.yaml
+++ b/aws/v18.1.1/release.yaml
@@ -48,7 +48,7 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0
+    version: 1.8.0
   components:
   - name: app-operator
     version: 6.4.1

--- a/aws/v18.2.2/release.diff
+++ b/aws/v18.2.2/release.diff
@@ -48,7 +48,7 @@ spec:                                                            spec:
   - name: vertical-pod-autoscaler-crd                              - name: vertical-pod-autoscaler-crd
     version: 1.0.1                                                   version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter                 - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0                                                   version: 1.0.0
+    version: 1.8.0                                                   version: 1.8.0
   - name: observability-bundle                                     - name: observability-bundle
     version: 0.1.9                                                   version: 0.1.9
   components:                                                      components:

--- a/aws/v18.2.2/release.yaml
+++ b/aws/v18.2.2/release.yaml
@@ -48,7 +48,7 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 1.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0
+    version: 1.8.0
   - name: observability-bundle
     version: 0.1.9
   components:

--- a/aws/v18.4.2/release.diff
+++ b/aws/v18.4.2/release.diff
@@ -75,7 +75,7 @@ spec:                                                              spec:
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 2.0.1                                                     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter                   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0                                                     version: 1.0.0
+    version: 1.8.0                                                     version: 1.8.0
   - name: observability-bundle                                       - name: observability-bundle
     version: 0.4.3                                                     version: 0.4.3
   - name: cilium-prerequisites                                       - name: cilium-prerequisites

--- a/aws/v18.4.2/release.yaml
+++ b/aws/v18.4.2/release.yaml
@@ -75,7 +75,7 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0
+    version: 1.8.0
   - name: observability-bundle
     version: 0.4.3
   - name: cilium-prerequisites

--- a/aws/v19.0.0/README.md
+++ b/aws/v19.0.0/README.md
@@ -277,11 +277,6 @@ We're aiming to provide a comprehensive blackbox monitoring tool that can valida
 
 
 
-### etcd-kubernetes-resources-count-exporter [1.2.0](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v1.2.0)
-
-#### Changed
-- Disable PSPs for k8s 1.25 and newer.
-
 
 
 ### observability-bundle [0.5.1](https://github.com/giantswarm/observability-bundle/releases/tag/v0.5.1)

--- a/aws/v19.0.0/release.diff
+++ b/aws/v19.0.0/release.diff
@@ -105,9 +105,11 @@ spec:                                                              spec:
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 2.0.0                                              |      version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter                   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.0.0                                              |      version: 1.2.0
+    version: 1.8.0                                                     version: 1.8.0
                                                                 >      dependsOn:
                                                                 >      - vertical-pod-autoscaler-crd
+                                                                >      - cilium
+                                                                >      - coredns
   - name: observability-bundle                                       - name: observability-bundle
     version: 0.3.0                                              |      version: 0.5.1
     dependsOn:                                                         dependsOn:

--- a/aws/v19.0.0/release.yaml
+++ b/aws/v19.0.0/release.yaml
@@ -97,9 +97,11 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.2.0
+    version: 1.8.0
     dependsOn:
     - vertical-pod-autoscaler-crd
+    - cilium
+    - coredns
   - name: observability-bundle
     version: 0.5.1
     dependsOn:

--- a/aws/v19.0.1/release.diff
+++ b/aws/v19.0.1/release.diff
@@ -97,9 +97,11 @@ spec:                                                              spec:
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 2.0.1                                                     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter                   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.2.0                                                     version: 1.2.0
+    version: 1..0                                                     version: 1.8.0
     dependsOn:                                                         dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+    - cilium                                                           - cilium
+    - coredns                                                          - coredns
   - name: observability-bundle                                       - name: observability-bundle
     version: 0.5.1                                                     version: 0.5.1
     dependsOn:                                                         dependsOn:

--- a/aws/v19.0.1/release.diff
+++ b/aws/v19.0.1/release.diff
@@ -97,7 +97,7 @@ spec:                                                              spec:
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 2.0.1                                                     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter                   - name: etcd-kubernetes-resources-count-exporter
-    version: 1..0                                                     version: 1.8.0
+    version: 1.8.0                                                     version: 1.8.0
     dependsOn:                                                         dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     - cilium                                                           - cilium

--- a/aws/v19.0.1/release.yaml
+++ b/aws/v19.0.1/release.yaml
@@ -97,9 +97,11 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter
-    version: 1.2.0
+    version: 1.8.0
     dependsOn:
     - vertical-pod-autoscaler-crd
+    - cilium
+    - coredns
   - name: observability-bundle
     version: 0.5.1
     dependsOn:

--- a/aws/v19.1.0/README.md
+++ b/aws/v19.1.0/README.md
@@ -223,13 +223,6 @@ WARNING: this version requires Cilium to run because of the dependency on the Ci
 
 
 
-### etcd-kubernetes-resources-count-exporter [1.4.0](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v1.4.0)
-
-#### Changed
-- Add Max memory (default 500Mi) for VPA.
-
-
-
 ### cert-exporter [2.6.0](https://github.com/giantswarm/cert-exporter/releases/tag/v2.6.0)
 
 ### Changed

--- a/aws/v19.1.0/README.md
+++ b/aws/v19.1.0/README.md
@@ -119,14 +119,6 @@ _Nothing has changed._
 - fix apparmor annotation
 
 
-
-### etcd-kubernetes-resources-count-exporter [1.5.0](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v1.5.0)
-
-#### Changed
-- Add Max memory (default 500Mi) for VPA.
-- Set `priorityClassName` to the deployment to mitigate scheduling issues.
-
-
 ### cilium-servicemonitors [0.1.2](https://github.com/giantswarm/cilium-servicemonitors-app/releases/tag/v0.1.2)
 
 #### Changed

--- a/aws/v19.1.0/release.diff
+++ b/aws/v19.1.0/release.diff
@@ -119,11 +119,11 @@ spec:                                                              spec:
   - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
     version: 2.0.1                                                     version: 2.0.1
   - name: etcd-kubernetes-resources-count-exporter              |    - dependsOn:
-    version: 1.2.0                                              <
+    version: 1.8.0                                              <
     dependsOn:                                                  <
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
   - name: observability-bundle                                  |      name: etcd-kubernetes-resources-count-exporter
-    version: 0.5.1                                              |      version: 1.5.0
+    version: 0.5.1                                              |      version: 1.8.0
     dependsOn:                                                  |    - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.1.0/release.yaml
+++ b/aws/v19.1.0/release.yaml
@@ -104,7 +104,7 @@ spec:
   - dependsOn:
     - vertical-pod-autoscaler-crd
     name: etcd-kubernetes-resources-count-exporter
-    version: 1.5.0
+    version: 1.8.0
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium

--- a/aws/v19.1.1/release.diff
+++ b/aws/v19.1.1/release.diff
@@ -104,7 +104,7 @@ spec:                                                              spec:
   - dependsOn:                                                       - dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: etcd-kubernetes-resources-count-exporter                     name: etcd-kubernetes-resources-count-exporter
-    version: 1.5.0                                                     version: 1.5.0
+    version: 1.8.0                                                     version: 1.8.0
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.1.1/release.yaml
+++ b/aws/v19.1.1/release.yaml
@@ -104,7 +104,7 @@ spec:
   - dependsOn:
     - vertical-pod-autoscaler-crd
     name: etcd-kubernetes-resources-count-exporter
-    version: 1.5.0
+    version: 1.8.0
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium

--- a/aws/v19.2.0/README.md
+++ b/aws/v19.2.0/README.md
@@ -182,12 +182,6 @@ _Changes compared to **Stable 3510.2.8**_
 
 
 
-### etcd-kubernetes-resources-count-exporter [1.7.0](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/releases/tag/v1.7.0)
-
-#### Changed
-- Replace condition for PSP CR installation.
-- Disable debugging.
-
 
 
 ### coredns [1.19.0](https://github.com/giantswarm/coredns-app/releases/tag/v1.19.0)

--- a/aws/v19.2.0/release.diff
+++ b/aws/v19.2.0/release.diff
@@ -108,7 +108,7 @@ spec:                                                              spec:
   - dependsOn:                                                       - dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: etcd-kubernetes-resources-count-exporter                     name: etcd-kubernetes-resources-count-exporter
-    version: 1.5.0                                              |      version: 1.7.0
+    version: 1.8.0                                                     version: 1.8.0
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.2.0/release.yaml
+++ b/aws/v19.2.0/release.yaml
@@ -108,7 +108,7 @@ spec:
   - dependsOn:
     - vertical-pod-autoscaler-crd
     name: etcd-kubernetes-resources-count-exporter
-    version: 1.7.0
+    version: 1.8.0
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28812

Due to known issues in the older version of the app, we want to bump it to latest in all releases.

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
