### PR TITLE
bump security bundle to 0.19.2 on 19.1.1 and 19.2.0

### DIFF
--- a/aws/v19.1.1/README.md
+++ b/aws/v19.1.1/README.md
@@ -4,7 +4,7 @@ This is a patch release that provides new `security-bundle` version consisting o
 
 ## Change details
 
-### security-bundle [0.18.0](https://github.com/giantswarm/security-bundle/releases/tag/v0.18.0)
+### security-bundle [0.19.2](https://github.com/giantswarm/security-bundle/releases/tag/v0.19.2)
 
 #### Added
 - Add `exception-recommender` (app) to the security bundle to create Giant Swarm PolicyException recommendations.

--- a/aws/v19.1.1/release.diff
+++ b/aws/v19.1.1/release.diff
@@ -143,7 +143,7 @@ spec:                                                              spec:
     - prometheus-operator-crd                                          - prometheus-operator-crd
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: security-bundle                                              name: security-bundle
-    version: 0.17.0                                             |      version: 0.18.0
+    version: 0.17.0                                             |      version: 0.19.2
     catalog: giantswarm                                         <
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager

--- a/aws/v19.1.1/release.yaml
+++ b/aws/v19.1.1/release.yaml
@@ -143,7 +143,7 @@ spec:
     - prometheus-operator-crd
     - vertical-pod-autoscaler-crd
     name: security-bundle
-    version: 0.18.0
+    version: 0.19.2
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium

--- a/aws/v19.2.0/release.diff
+++ b/aws/v19.2.0/release.diff
@@ -147,7 +147,7 @@ spec:                                                              spec:
     - prometheus-operator-crd                                          - prometheus-operator-crd
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: security-bundle                                              name: security-bundle
-    version: 0.18.0                                                    version: 0.18.0
+    version: 0.19.2                                                    version: 0.19.2
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v19.2.0/release.yaml
+++ b/aws/v19.2.0/release.yaml
@@ -147,7 +147,7 @@ spec:
     - prometheus-operator-crd
     - vertical-pod-autoscaler-crd
     name: security-bundle
-    version: 0.18.0
+    version: 0.19.2
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
