### PR TITLE
Add observability-bundle 1.0.0 to release 20

### DIFF
--- a/aws/requests.yaml
+++ b/aws/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 20.0.0"
+  requests:
+  - name: observability-bundle
+    version: ">= 1.0.0"
 - name: ">= 19.3.0"
   requests:
   - name: security-bundle


### PR DESCRIPTION
This PR bumps the observability bundle to 1.0.0 in release 20 as per https://github.com/giantswarm/roadmap/issues/2879

@giantswarm/team-phoenix and especially @T-Kukawka, know that this is a breaking change (in user values) so the changelog will have to be written properly. How should we proceed with the release notes in that case?

We're currently in the process of writing an upgrade doc https://github.com/giantswarm/observability-bundle/pull/153


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

cc @giantswarm/team-atlas once release is merged

### Checklist
- [x] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
