### PR TITLE
bump aws operator on 19.3.1 and 19.3.2

### DIFF
--- a/aws/v19.3.1/release.diff
+++ b/aws/v19.3.1/release.diff
@@ -166,6 +166,7 @@ spec:                                                              spec:
   - name: aws-operator                                               - name: aws-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 14.24.1                                            |      version: 15.0.0
+                                                                >      reference: 15.0.0-patch2
   - name: cert-operator                                              - name: cert-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 3.2.1                                                     version: 3.2.1

--- a/aws/v19.3.1/release.yaml
+++ b/aws/v19.3.1/release.yaml
@@ -166,7 +166,7 @@ spec:
   - name: aws-operator
     releaseOperatorDeploy: true
     version: 15.0.0
-    reference: 15.0.0-patch1
+    reference: 15.0.0-patch2
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1

--- a/aws/v19.3.2/release.diff
+++ b/aws/v19.3.2/release.diff
@@ -164,7 +164,7 @@ spec:                                                              spec:
   - name: app-operator                                               - name: app-operator
     version: 6.10.2                                                    version: 6.10.2
   - name: aws-operator                                               - name: aws-operator
-                                                                >      reference: 15.0.0-patch1
+                                                                >      reference: 15.0.0-patch2
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
     version: 15.0.0                                                    version: 15.0.0
     reference: 15.0.0-patch1                                    <

--- a/aws/v19.3.2/release.yaml
+++ b/aws/v19.3.2/release.yaml
@@ -164,7 +164,7 @@ spec:
   - name: app-operator
     version: 6.10.2
   - name: aws-operator
-    reference: 15.0.0-patch1
+    reference: 15.0.0-patch2
     releaseOperatorDeploy: true
     version: 15.0.0
   - name: cert-operator


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30092

patch aws-operator on 19.3.1 and 19.3.2 to make node-problem-detector work with karpenter nodes.

tested on gaia:

- it didn't roll node on existing cluster
- it worked for a karpenter node after filling disk
- it worked for a traditional node after filling disk

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
