### PR TITLE
bump aws ebs csi driver in v20

### DIFF
--- a/aws/v20.0.0/README.md
+++ b/aws/v20.0.0/README.md
@@ -67,12 +67,20 @@ This release will also be used as a base for the migration from `Giant Swarm Vin
 
 
 
-### aws-ebs-csi-driver [2.28.1](https://github.com/giantswarm/aws-ebs-csi-driver-app/releases/tag/v2.28.1)
+### aws-ebs-csi-driver [2.30.1](https://github.com/giantswarm/aws-ebs-csi-driver-app/releases/tag/v2.30.1)
 
 #### Changed
 - Configure `gsoci.azurecr.io` as the default container image registry.
 
+### Fixed
 
+- Disable PSPs for CRD job when `podSecurityStandards` are enforced.
+
+### Removed
+
+- Remove unused service for controller.
+- Add `Port` definition for metrics port in controller.
+- Remove legacy monitoring labels.
 
 ### cluster-autoscaler [1.25.1-gs2](https://github.com/giantswarm/cluster-autoscaler-app/releases/tag/v1.25.1-gs2)
 

--- a/aws/v20.0.0/release.diff
+++ b/aws/v20.0.0/release.diff
@@ -18,7 +18,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: aws-ebs-csi-driver                                           name: aws-ebs-csi-driver
-    version: 2.28.0                                             |      version: 2.28.1
+    version: 2.28.0                                             |      version: 2.30.1
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -18,7 +18,7 @@ spec:
     dependsOn:
     - vertical-pod-autoscaler-crd
     name: aws-ebs-csi-driver
-    version: 2.28.1
+    version: 2.30.1
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
