### PR TITLE
patch cert-operator 3.2.1 in all releases

### DIFF
--- a/aws/v19.1.0/release.yaml
+++ b/aws/v19.1.0/release.yaml
@@ -161,6 +161,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.8.0

--- a/aws/v19.1.1/release.yaml
+++ b/aws/v19.1.1/release.yaml
@@ -161,6 +161,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     reference: 5.8.0-patch1
     releaseOperatorDeploy: true

--- a/aws/v19.2.0/release.yaml
+++ b/aws/v19.2.0/release.yaml
@@ -165,6 +165,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.9.0

--- a/aws/v19.2.1/release.yaml
+++ b/aws/v19.2.1/release.yaml
@@ -166,6 +166,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.9.0

--- a/aws/v19.3.1/release.yaml
+++ b/aws/v19.3.1/release.yaml
@@ -170,6 +170,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.10.0

--- a/aws/v19.3.2/release.yaml
+++ b/aws/v19.3.2/release.yaml
@@ -170,6 +170,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.10.0

--- a/aws/v19.3.3/release.yaml
+++ b/aws/v19.3.3/release.yaml
@@ -169,6 +169,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.10.0

--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -168,6 +168,7 @@ spec:
   - name: cert-operator
     releaseOperatorDeploy: true
     version: 3.2.1
+    reference: 3.2.1-patch1
   - name: cluster-operator
     releaseOperatorDeploy: true
     version: 5.10.0


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28607

bump releases to patched version of cert-operator 3.2.1