### PR TITLE
bump cluster operator on v20.1.0

### DIFF
--- a/aws/v20.0.0/release.yaml
+++ b/aws/v20.0.0/release.yaml
@@ -180,7 +180,7 @@ spec:
   - name: kubernetes
     version: 1.25.16
   date: "2024-03-11T07:39:11Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false

--- a/aws/v20.1.0/README.md
+++ b/aws/v20.1.0/README.md
@@ -19,14 +19,15 @@ This release provides security updates for container linux and a fix for IMDSv2 
 
 
 
-### cluster-operator [5.11.0](https://github.com/giantswarm/cluster-operator/releases/tag/v5.11.0)
+### cluster-operator [5.11.1](https://github.com/giantswarm/cluster-operator/releases/tag/v5.11.1)
 
 #### Changed
 - Configure `gsoci.azurecr.io` as the default container image registry.
 #### Added
 - Add team label in resources.
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
-
+### Fixed
+- Fix release version check for PSS enforcement.
 
 
 ### containerlinux [3815.2.2](https://www.flatcar-linux.org/releases/#release-3815.2.2)

--- a/aws/v20.1.0/release.diff
+++ b/aws/v20.1.0/release.diff
@@ -175,7 +175,7 @@ spec:                                                              spec:
     reference: 3.2.1-patch1                                     <
   - name: cluster-operator                                           - name: cluster-operator
     releaseOperatorDeploy: true                                        releaseOperatorDeploy: true
-    version: 5.10.0                                             |      version: 5.11.0
+    version: 5.10.0                                             |      version: 5.11.1
     reference: 5.10.0-patch1                                    <
   - name: containerlinux                                             - name: containerlinux
     version: 3815.2.0                                           |      version: 3815.2.2

--- a/aws/v20.1.0/release.yaml
+++ b/aws/v20.1.0/release.yaml
@@ -174,7 +174,7 @@ spec:
     version: 3.4.0
   - name: cluster-operator
     releaseOperatorDeploy: true
-    version: 5.11.0
+    version: 5.11.1
   - name: containerlinux
     version: 3815.2.2
   - name: etcd


### PR DESCRIPTION
Blocked by https://github.com/giantswarm/cluster-operator/pull/1714

needed to fix check for PSS enforcement on v20 clusters