### PR TITLE
Bump security bundle to v1.6.4 in AWS v20.1.0

### DIFF
--- a/aws/v20.1.0/release.diff
+++ b/aws/v20.1.0/release.diff
@@ -154,7 +154,7 @@ spec:                                                              spec:
     - prometheus-operator-crd                                          - prometheus-operator-crd
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
     name: security-bundle                                              name: security-bundle
-    version: 1.6.3                                                     version: 1.6.3
+    version: 1.6.3                                              |      version: 1.6.4
   - dependsOn:                                                       - dependsOn:
     - aws-cloud-controller-manager                                     - aws-cloud-controller-manager
     - cilium                                                           - cilium

--- a/aws/v20.1.0/release.yaml
+++ b/aws/v20.1.0/release.yaml
@@ -154,7 +154,7 @@ spec:
     - prometheus-operator-crd
     - vertical-pod-autoscaler-crd
     name: security-bundle
-    version: 1.6.3
+    version: 1.6.4
   - dependsOn:
     - aws-cloud-controller-manager
     - cilium


### PR DESCRIPTION
The normal devctl release automation seems to have not been used to create this release initially and running it resulted in more changes. This PR bumps only the security bundle, without using the release automation

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
