### PR TITLE
Deprecate AWS release v20.1.0

### DIFF
--- a/aws/v20.1.0/release.yaml
+++ b/aws/v20.1.0/release.yaml
@@ -182,7 +182,7 @@ spec:
   - name: kubernetes
     version: 1.25.16
   date: "2024-04-24T14:26:26Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C053JHJC99Q/p1715684794562669

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
