### PR TITLE
Update CHANGELOG for sdk/v0.1.0 release

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-06-05
+
 ### Added
 
 - `Release` type that represents a Giant Swarm workload cluster release.
 
-[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/main
+[Unreleased]: https://github.com/giantswarm/releases/compare/sdk/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/releases/releases/tag/sdk/v0.1.0


### PR DESCRIPTION
Will see how to setup CODEOWNERS automation for the Releases SDK, since it's in the repo subdirectory.

