### PR TITLE
Fix release Builder and add func for forcing random pre-releases

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Client` gets Release resources from GitHub `giantswarm/releases` repo
+  - `GetRelease` func to get a Release resource for the specified provider and release version
+  - `GetLatestRelease` to get a Release resource for the latest release version for the specified provider
+- `Builder` builds Release resources for the new releases based on the existing releases, with functions:
+  - `WithClusterApp` to override `cluster-$provider` app,
+  - `WithApp` to override a default app,
+  - `WithPreReleasePrefix` to set a custom prefix that is prepended to the pre-release of the custom release version,
+  - `WithRandomPreRelease` to specify that custom release version will have a random pre-release with specified length.
+
 ## [0.1.0] - 2024-06-05
 
 ### Added

--- a/sdk/api/v1alpha1/release.go
+++ b/sdk/api/v1alpha1/release.go
@@ -169,6 +169,6 @@ func (r *Release) getResourceNameParts() (Provider, string, error) {
 	if !IsProviderSupported(provider) {
 		return "", "", microerror.Maskf(UnsupportedProviderError, "Provider '%s' is not supported. Supported providers are: %s.", provider, SupportedProviders)
 	}
-
+	releaseVersion = strings.TrimPrefix(releaseVersion, "v")
 	return provider, releaseVersion, nil
 }

--- a/sdk/builder.go
+++ b/sdk/builder.go
@@ -18,6 +18,7 @@ const (
 	preReleaseHashLength = 10
 )
 
+// Builder builds custom Releases by overriding a base release with custom cluster app and default apps.
 type Builder struct {
 	client      *Client
 	provider    Provider
@@ -31,6 +32,8 @@ type Builder struct {
 	apps       []ReleaseSpecApp
 }
 
+// NewBuilder creates a new Builder with specified releases Client, provider and base release.
+// If a base release is an empty string it will use the latest available release for the provider.
 func NewBuilder(client *Client, provider Provider, baseRelease string) (*Builder, error) {
 	if client == nil {
 		return nil, microerror.Maskf(InvalidConfigError, "client must not be empty")
@@ -50,6 +53,7 @@ func NewBuilder(client *Client, provider Provider, baseRelease string) (*Builder
 	}, nil
 }
 
+// WithClusterApp overrides the cluster-<provider> app in the base release.
 func (b *Builder) WithClusterApp(version, catalog string) *Builder {
 	b.clusterApp = &ReleaseSpecComponent{
 		Name:    fmt.Sprintf("cluster-%s", b.provider),
@@ -59,6 +63,7 @@ func (b *Builder) WithClusterApp(version, catalog string) *Builder {
 	return b
 }
 
+// WithApp overrides the default app in the base release.
 func (b *Builder) WithApp(name, version, catalog string, dependsOn []string) *Builder {
 	app := ReleaseSpecApp{
 		Name:      name,
@@ -70,17 +75,21 @@ func (b *Builder) WithApp(name, version, catalog string, dependsOn []string) *Bu
 	return b
 }
 
+// WithPreReleasePrefix adds a custom prefix that is prepended to the pre-release suffix of the custom release version.
 func (b *Builder) WithPreReleasePrefix(prefix string) *Builder {
 	b.preRelease.prefix = prefix
 	return b
 }
 
+// WithRandomPreRelease specifies that custom release version will have a random pre-release with specified length. The
+// specified length does not include the length of the optionally specified pre-release prefix.
 func (b *Builder) WithRandomPreRelease(length int) *Builder {
 	b.preRelease.isRandom = true
 	b.preRelease.length = length
 	return b
 }
 
+// Build a custom release.
 func (b *Builder) Build(ctx context.Context) (*Release, error) {
 	var release *Release
 	var err error

--- a/sdk/builder.go
+++ b/sdk/builder.go
@@ -75,7 +75,7 @@ func (b *Builder) WithApp(name, version, catalog string, dependsOn []string) *Bu
 	return b
 }
 
-// WithPreReleasePrefix adds a custom prefix that is prepended to the pre-release suffix of the custom release version.
+// WithPreReleasePrefix sets a custom prefix that is prepended to the pre-release of the custom release version.
 func (b *Builder) WithPreReleasePrefix(prefix string) *Builder {
 	b.preRelease.prefix = prefix
 	return b

--- a/sdk/builder_test.go
+++ b/sdk/builder_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Builder", func() {
 		Expect(newReleaseVersion.Prerelease()).To(HaveLen(expectedPreReleaseLength))
 	})
 
-	It("Overrides cluster app and creates a new minor release without pre-release", func() {
+	It("Overrides cluster app and creates a new minor release with pre-release", func() {
 		// set a cluster app override where the pre-release is different
 		releasesBuilder = releasesBuilder.
 			WithClusterApp("0.77.0", "")
@@ -72,11 +72,11 @@ var _ = Describe("Builder", func() {
 		newReleaseVersion, err := semver.NewVersion(newReleaseVersionString)
 		Expect(err).NotTo(HaveOccurred())
 
-		// check the new release version, expected is 25.2.0
+		// check the new release version, expected is 25.2.0-<10-char pre-release suffix>
 		Expect(newReleaseVersion.Major()).To(Equal(uint64(25)))
 		Expect(newReleaseVersion.Minor()).To(Equal(uint64(2)))
 		Expect(newReleaseVersion.Patch()).To(Equal(uint64(0)))
-		Expect(newReleaseVersion.Prerelease()).To(BeEmpty())
+		Expect(newReleaseVersion.Prerelease()).To(HaveLen(10))
 	})
 
 	AfterEach(func() {

--- a/sdk/builder_test.go
+++ b/sdk/builder_test.go
@@ -72,10 +72,70 @@ var _ = Describe("Builder", func() {
 		newReleaseVersion, err := semver.NewVersion(newReleaseVersionString)
 		Expect(err).NotTo(HaveOccurred())
 
-		// check the new release version, expected is 25.2.0-<10-char pre-release suffix>
+		// Check the new release version.
+		//
+		// Since the builder will use the latest release, which is v25.1.0-demo.0, it is expected that the custom
+		// release version has a minor bump (because we are building a newer release with a new cluster-aws minor
+		// version), so the new release version is 25.2.0-<random 10-char pre-release suffix>.
+		//
+		// New release also has a pre-release because the base release is a pre-release.
 		Expect(newReleaseVersion.Major()).To(Equal(uint64(25)))
 		Expect(newReleaseVersion.Minor()).To(Equal(uint64(2)))
 		Expect(newReleaseVersion.Patch()).To(Equal(uint64(0)))
+		Expect(newReleaseVersion.Prerelease()).To(HaveLen(10))
+	})
+
+	It("Overrides cluster app and creates a new minor release with random pre-release", func() {
+		// set a cluster app override where the pre-release is different
+		const preReleaseLength = 10
+		releasesBuilder = releasesBuilder.
+			WithClusterApp("0.77.0", "").
+			WithRandomPreRelease(preReleaseLength)
+
+		// build the new release
+		newRelease, err := releasesBuilder.Build(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		// get the new release version string
+		newReleaseVersionString, err := newRelease.GetVersion()
+		Expect(err).NotTo(HaveOccurred())
+		newReleaseVersion, err := semver.NewVersion(newReleaseVersionString)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check the new release version.
+		//
+		// Since the builder will use the latest release, which is v25.1.0-demo.0, it is expected that the custom
+		// release version has a minor bump (because we are building a newer release with a new cluster-aws minor
+		// version), so the new release version is 25.2.0-<random 10-char pre-release suffix>.
+		//
+		// New release also has a pre-release because the base release is a pre-release.
+		Expect(newReleaseVersion.Major()).To(Equal(uint64(25)))
+		Expect(newReleaseVersion.Minor()).To(Equal(uint64(2)))
+		Expect(newReleaseVersion.Patch()).To(Equal(uint64(0)))
+		Expect(newReleaseVersion.Prerelease()).To(HaveLen(preReleaseLength))
+	})
+
+	It("Creates a new release with random pre-release", func() {
+		// set a cluster app override where the pre-release is different
+		const preReleaseLength = 10
+		releasesBuilder = releasesBuilder.WithRandomPreRelease(preReleaseLength)
+
+		// build the new release
+		newRelease, err := releasesBuilder.Build(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		// get the new release version string
+		newReleaseVersionString, err := newRelease.GetVersion()
+		Expect(err).NotTo(HaveOccurred())
+		newReleaseVersion, err := semver.NewVersion(newReleaseVersionString)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check the new release version. Since the builder will use the latest release, which is v25.1.0-demo.0,
+		// expected is custom release version has a patch bump (because we are building a newer release),
+		// so the new release version is 25.1.1-<random 10-char pre-release suffix>.
+		Expect(newReleaseVersion.Major()).To(Equal(uint64(25)))
+		Expect(newReleaseVersion.Minor()).To(Equal(uint64(1)))
+		Expect(newReleaseVersion.Patch()).To(Equal(uint64(1)))
 		Expect(newReleaseVersion.Prerelease()).To(HaveLen(10))
 	})
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -19,12 +19,6 @@ type Client struct {
 	gitHubClient *github.Client
 }
 
-func NewClient() *Client {
-	return &Client{
-		gitHubClient: github.NewClient(nil),
-	}
-}
-
 // NewClientWithHttpClient creates a new instance of Client with a specified http.Client.
 // It returns a pointer to Client and an error. If the httpClient is nil, it returns
 // an error of type InvalidConfigError indicating that gitHubClient must be specified.
@@ -41,6 +35,7 @@ func NewClientWithHttpClient(httpClient *http.Client) (*Client, error) {
 	}, nil
 }
 
+// NewClientWithGitHubClient creates a releases Client with the specified GitHub client.
 func NewClientWithGitHubClient(gitHubClient *github.Client) (*Client, error) {
 	if gitHubClient == nil {
 		return nil, microerror.Maskf(InvalidConfigError, "gitHubClient must be specified")
@@ -50,6 +45,8 @@ func NewClientWithGitHubClient(gitHubClient *github.Client) (*Client, error) {
 	}, nil
 }
 
+// NewClientWithGitHubToken creates a releases Client that is internally using a GitHub client which is created with the specified
+// GitHub token.
 func NewClientWithGitHubToken(gitHubToken string) *Client {
 	gitHubClient := github.NewClient(nil)
 	if gitHubToken != "" {
@@ -61,6 +58,8 @@ func NewClientWithGitHubToken(gitHubToken string) *Client {
 	}
 }
 
+// GetRelease returns a release with the specified release version for the specified provider. Specified release version
+// can contain the 'v' prefix, but it doesn't have to.
 func (c *Client) GetRelease(ctx context.Context, provider Provider, releaseVersion string) (*Release, error) {
 	// First we get GitHub release for the specified provider and release version.
 	releaseVersion = strings.TrimPrefix(releaseVersion, "v")
@@ -77,6 +76,7 @@ func (c *Client) GetRelease(ctx context.Context, provider Provider, releaseVersi
 	return release, nil
 }
 
+// GetLatestRelease returns the latest release for the specified provider.
 func (c *Client) GetLatestRelease(ctx context.Context, provider Provider) (*Release, error) {
 	const releasesPerRequest = 30
 	providerTagPrefix := fmt.Sprintf("%s/", provider)

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Client", func() {
 
 	It("Gets release for the specified provider and release version", func() {
 		ctx := context.Background()
-		const releaseVersion = "v25.0.0-demo.0"
+		const releaseVersion = "25.0.0-demo.0"
 		release, err := releasesClient.GetRelease(ctx, ProviderAws, releaseVersion)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -111,7 +111,7 @@ var _ = Describe("Client", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Check release version
-		const expectedLatestReleaseVersion = "v25.1.0-demo.0"
+		const expectedLatestReleaseVersion = "25.1.0-demo.0"
 		resultReleaseVersion, err := release.GetVersion()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resultReleaseVersion).To(Equal(expectedLatestReleaseVersion))

--- a/sdk/testdata/capa/v25.0.0-demo.0/release.yaml
+++ b/sdk/testdata/capa/v25.0.0-demo.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-v25.0.0-demo.0
+  name: aws-25.0.0-demo.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/sdk/testdata/capa/v25.1.0-demo.0/release.yaml
+++ b/sdk/testdata/capa/v25.1.0-demo.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-v25.1.0-demo.0
+  name: aws-25.1.0-demo.0
 spec:
   apps:
   - name: aws-ebs-csi-driver


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3466 and https://github.com/giantswarm/roadmap/issues/3473

### Fixed
- Fix pre-release building.

### Added
- Update CHANGELOG.
- `Builder` `WithRandomPreRelease` func that enforces building a custom Release with a random pre-release of the specified length.