### PR TITLE
Add AWS (CAPA) v25.0.0-alpha.3

### DIFF
--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -3,5 +3,6 @@ commonAnnotations:
 resources:
 - v25.0.0-alpha.1
 - v25.0.0-alpha.2
+- v25.0.0-alpha.3
 transformers:
 - releaseNotesTransformer.yaml

--- a/capa/v25.0.0-alpha.3/kustomization.yaml
+++ b/capa/v25.0.0-alpha.3/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v25.0.0-alpha.3/release.yaml
+++ b/capa/v25.0.0-alpha.3/release.yaml
@@ -111,7 +111,7 @@ spec:
   components:
   - name: cluster-aws
     catalog: cluster-test
-    version: 0.78.2-21b6dfbec0c922adab3b170eecdcae89d8c620f9
+    version: 0.78.2-db7ea9b54f773193700df6dcc648d4a99bb19600
   - name: flatcar
     version: 3815.2.2
   - name: flatcar-variant

--- a/capa/v25.0.0-alpha.3/release.yaml
+++ b/capa/v25.0.0-alpha.3/release.yaml
@@ -1,0 +1,122 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-25.0.0-alpha.3
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - cert-manager
+  - name: aws-pod-identity-webhook
+    version: 1.16.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.0
+    dependsOn:
+    - kyverno
+  - name: cert-manager
+    version: 3.7.6
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.24.0
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.25.14-gs3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.27.3-gs9
+    dependsOn:
+    - kyverno
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.0.1
+    dependsOn:
+    - cert-manager
+  - name: k8s-audit-metrics
+    version: 0.9.0
+    dependsOn:
+    - kyverno
+  - name: k8s-dns-node-cache
+    version: 2.6.2
+    dependsOn:
+    - kyverno
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno
+  - name: net-exporter
+    version: 1.19.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno
+  - name: observability-bundle
+    version: 1.3.4
+    dependsOn:
+    - coredns
+  - name: prometheus-blackbox-exporter
+    version: 0.4.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.7.0
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.0
+  - name: vertical-pod-autoscaler
+    version: 5.2.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-aws
+    catalog: cluster-test
+    version: 0.78.2-21b6dfbec0c922adab3b170eecdcae89d8c620f9
+  - name: flatcar
+    version: 3815.2.2
+  - name: flatcar-variant
+    version: 1.0.0
+  - name: kubernetes
+    version: 1.25.16
+  date: "2024-06-12T16:00:00Z"
+  state: active


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3466

### Changes

- Updated cluster-aws version from https://github.com/giantswarm/cluster-aws/pull/637 with fixes for app dependencies and app catalog.

### Checklist
- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version
