### PR TITLE
Deprecate AWS release v20.1.1

### DIFF
--- a/aws/v20.1.1/release.yaml
+++ b/aws/v20.1.1/release.yaml
@@ -181,7 +181,7 @@ spec:
   - name: kubernetes
     version: 1.25.16
   date: "2024-05-16T14:57:50Z"
-  state: active
+  state: deprecated
 status:
   inUse: false
   ready: false

--- a/aws/v20.1.2/announcement.md
+++ b/aws/v20.1.2/announcement.md
@@ -1,0 +1,4 @@
+**Workload cluster release v20.1.2 for AWS is available**. This release improves cert-manager CA injector on demanding clusters.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/aws-v20.1.2/).
+


### PR DESCRIPTION
- Deprecate AWS release v20.1.1
- Add announcement for AWS release v20.1.2

<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
