### PR TITLE
Fix CAPA announcement links

### DIFF
--- a/capa/v25.0.0/announcement.md
+++ b/capa/v25.0.0/announcement.md
@@ -1,3 +1,3 @@
 **Workload cluster release v25.0.0 for CAPA is available**. We are happy to announce our first `Cluster API for AWS` (CAPA) release v25. This is the first Giant Swarm supported CAPA release. It is available on CAPA Management Clusters and will be used as a first release to be upgraded to from `Vintage` workload clusters.
 
-Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/capa-v25.0.0/).
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-25.0.0/).

--- a/capa/v26.0.0/announcement.md
+++ b/capa/v26.0.0/announcement.md
@@ -1,4 +1,4 @@
 **Workload cluster release v26.0.0 for CAPA is available**. This release upgrades Kubernetes version to v26.
 
-Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/aws-26.0.0/).
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-26.0.0/).
 


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering e2e tests

To trigger the E2E test for each new Release added in this PR add a comment with the following:

`/run releases-test-suites`

For more details see the [README.md](/README.md#running-tests-against-prs)
