### PR TITLE
 AWS (CAPA) v28.0.0

### DIFF
--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - v25.0.0
 - v26.0.0
 - v27.0.0
+- v28.0.0
 transformers:
 - releaseNotesTransformer.yaml

--- a/capa/v28.0.0/README.md
+++ b/capa/v28.0.0/README.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v28.0.0 for CAPA :zap:
+
+## Changes compared to v27.0.0
+
+- Kubernetes version change from 1.27.14 to 1.28.11
+- cloud-provider-aws (formerly aws-cloud-controller-manager-app) from 1.27.7-gs1 to 1.28.6-gs1
+- cluster-autoscaler from 1.27.3-gs9 to 1.28.5-gs1

--- a/capa/v28.0.0/announcement.md
+++ b/capa/v28.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v28.0.0 for CAPA is available**. This release upgrades Kubernetes version to v1.28.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-28.0.0/).

--- a/capa/v28.0.0/kustomization.yaml
+++ b/capa/v28.0.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v28.0.0/release.yaml
+++ b/capa/v28.0.0/release.yaml
@@ -1,0 +1,122 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-28.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - cert-manager
+  - name: aws-pod-identity-webhook
+    version: 1.16.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.0
+    dependsOn:
+    - kyverno
+  - name: cert-manager
+    version: 3.7.6
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.24.0
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.28.6-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.28.5-gs1
+    dependsOn:
+    - kyverno
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.0.1
+    dependsOn:
+    - cert-manager
+  - name: k8s-audit-metrics
+    version: 0.9.0
+    dependsOn:
+    - kyverno
+  - name: k8s-dns-node-cache
+    version: 2.6.2
+    dependsOn:
+    - kyverno
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno
+  - name: net-exporter
+    version: 1.19.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno
+  - name: observability-bundle
+    version: 1.3.4
+    dependsOn:
+    - coredns
+  - name: prometheus-blackbox-exporter
+    version: 0.4.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.7.0
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.0
+  - name: vertical-pod-autoscaler
+    version: 5.2.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 1.0.1
+  - name: flatcar
+    version: 3815.2.2
+  - name: flatcar-variant
+    version: 1.0.0
+  - name: kubernetes
+    version: 1.28.11
+  date: "2024-07-10T09:00:00Z"
+  state: active


### PR DESCRIPTION
## Diff from aws-27.0.0

**App diffs**

| app \ release | v27.0.0 | v28.0.0 | change |
| --- | --- | --- | --- |
| cloud-provider-aws | 1.27.7-gs1|1.28.6-gs1 | **minor** |
| cluster-autoscaler | 1.27.3-gs9 |1.28.5-gs1 | **minor** |

**Component diffs**

| component \ release | v27.0.0 | v28.0.0 | change |
| --- | --- | --- | --- |
| kubernetes | 1.27.14 | 1.28.11 |**minor** |
