### PR TITLE
Custom renovate datasource

### DIFF
--- a/.github/workflows/renovate-release-json.yaml
+++ b/.github/workflows/renovate-release-json.yaml
@@ -1,0 +1,63 @@
+name: Fetch Releases and Generate JSON
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: "Setup Go Env"
+        uses: "actions/setup-go@v4"
+        with:
+          cache: true
+          go-version: "1.19.2"
+
+      - name: Generate JSON File
+        run: |
+          go run renovate.go
+
+      - name: "Ensure Private Key"
+        env:
+          BOT_SSH_KEY: '${{ secrets.BOT_SSH_KEY }}'
+        run: |
+          echo "$BOT_SSH_KEY" > /tmp/id_ed25519
+
+      - name: "Setup SSH Agent"
+        env:
+          SSH_AUTH_SOCK: "/tmp/ssh_agent.sock"
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a ${SSH_AUTH_SOCK} > /dev/null
+          chmod 0600 /tmp/id_ed25519
+          ssh-add /tmp/id_ed25519
+
+      - name: "Setup Git Config"
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
+
+      - name: "Commit And Push"
+        env:
+          SSH_AUTH_SOCK: "/tmp/ssh_agent.sock"
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            git add */*.json
+            git commit -m "Update releases.json"
+            git push
+          fi
+
+      - name: "Cleanup Build Container"
+        env:
+          SSH_AUTH_SOCK: "/tmp/ssh_agent.sock"
+        run: |
+          ssh-add -D
+          rm -Rf *

--- a/renovate.go
+++ b/renovate.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"gopkg.in/yaml.v2"
+)
+
+type Release struct {
+	Version          string `yaml:"version"`
+	IsDeprecated     bool   `yaml:"isDeprecated"`
+	ReleaseTimestamp string `json:"releaseTimestamp"`
+	ChangelogUrl     string `json:"changelogUrl"`
+	IsStable         bool   `json:"isStable"`
+}
+
+type Releases struct {
+	Releases     []Release `json:"releases"`
+	SourceUrl    string    `json:"sourceUrl"`
+	ChangelogUrl string    `json:"changelogUrl"`
+	Homepage     string    `json:"homepage"`
+}
+
+type GiantSwarmRelease struct {
+	Metadata struct {
+		Name string `json:"name"`
+	}
+	Spec v1alpha1.ReleaseSpec `json:"spec"`
+}
+
+func main() {
+	directories := []string{"capa", "azure"}
+	for _, dir := range directories {
+		releases := Releases{
+			SourceUrl:    "https://github.com/giantswarm/releases",
+			ChangelogUrl: "https://github.com/giantswarm/releases/blob/main/README.md",
+			Homepage:     "https://giantswarm.io",
+		}
+
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			fmt.Printf("Error reading directory %s: %v\n", dir, err)
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				releaseFile := filepath.Join(dir, f.Name(), "release.yaml")
+				if _, err := os.Stat(releaseFile); os.IsNotExist(err) {
+					continue
+				}
+
+				data, err := os.ReadFile(releaseFile)
+				if err != nil {
+					continue
+				}
+
+				var gsRelease = GiantSwarmRelease{}
+				if err := yaml.Unmarshal(data, &gsRelease); err != nil {
+					continue
+				}
+
+				// Use regex to extract MAJOR.MINOR.PATCH from the version
+				versionRegex := regexp.MustCompile(`(?:provider-)?(\d+\.\d+\.\d+)`)
+				matches := versionRegex.FindStringSubmatch(gsRelease.Metadata.Name)
+				if len(matches) < 2 { // matches[0] is the full match, matches[1] is the first capture group
+					continue
+				}
+
+				// Set additional fields not in YAML
+				release := Release{
+					Version:          matches[1],
+					IsDeprecated:     gsRelease.Spec.State == "deprecated",
+					ChangelogUrl:     fmt.Sprintf("https://github.com/giantswarm/releases/blob/master/%s/v%s/README.md", dir, matches[1]),
+					IsStable:         !strings.Contains(matches[1], "alpha") || !strings.Contains(matches[1], "beta") || !strings.Contains(matches[1], "rc"),
+					ReleaseTimestamp: gsRelease.Spec.Date.String(),
+				}
+
+				releases.Releases = append(releases.Releases, release)
+			}
+		}
+		jsonData, err := json.MarshalIndent(releases, "", "  ")
+		if err != nil {
+			fmt.Printf("Error marshalling JSON: %v\n", err)
+			return
+		}
+
+		if err := os.WriteFile(fmt.Sprintf("%s/releases.json", dir), jsonData, 0644); err != nil {
+			fmt.Printf("Error writing JSON to file: %v\n", err)
+		}
+	}
+
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3547

Using release version in multiple repos via renovate wouldn't work the way how we use it right now because we need to distinguish the provider and also modifying the release version ([see example](https://github.com/giantswarm/workload-clusters-fleet/blob/main/management-clusters/gazelle/organizations/giantswarm-production/workload-clusters/operations.yaml#L17))

The idea here is to generate JSON via GH Action (Custom Renovate Datasource requires certain structure) for each provider so we can use it in each repo, example (not 100% accurate):

How the JSON looks like:

```
{
  "releases": [
    {
      "Version": "25.0.0",
      "IsDeprecated": false,
      "releaseTimestamp": "2024-06-20 18:00:00 +0000 UTC",
      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v25.0.0/README.md",
      "isStable": true
    },
    {
      "Version": "26.0.0",
      "IsDeprecated": false,
      "releaseTimestamp": "2024-06-26 09:00:00 +0000 UTC",
      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v26.0.0/README.md",
      "isStable": true
    }
  ],
  "sourceUrl": "https://github.com/giantswarm/releases",
  "changelogUrl": "https://github.com/giantswarm/releases/blob/main/README.md",
  "homepage": "https://giantswarm.io"
}
```


What's needed in repos to update `cluster_version`:
```
{
  "customDatasources": {
    "releases-capa": {
      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/giantswarm/releases/master/capa/releases.json"
    }
  },
  "regexManagers": [
    {
      "fileMatch": ["something"],
      "matchStrings": ["cluster_release"],
      "datasourceTemplate": "custom.releases-capa",
      "depNameTemplate": "releases-capa",
      "extractVersionTemplate": "^(?<version>.*)$"
    }
  ]
}
```

The benefit is it can also be used by customer to update their repos when using Gitops.

The other idea was to use Github Tags as Datasource but you cannot rewrite the release version (e.g. capa-v26.0.0 -> 26.0.0).