### PR TITLE
CAPA v29.0.0: Update `security-bundle` & dependencies.

### DIFF
--- a/capa/v29.0.0/README.md
+++ b/capa/v29.0.0/README.md
@@ -7,6 +7,7 @@
 - Kubernetes from 1.28.11 to 1.29.7
 - cloud-provider-aws (formerly aws-cloud-controller-manager-app) from 1.28.6-gs1 to 1.29.3-gs1
 - cluster-autoscaler from 1.28.5-gs1 to 1.29.3-gs1
+- security-bundle from 1.7.0 to 1.8.0
 
 ### cilium [v0.25.1](https://github.com/giantswarm/cilium-app/releases/tag/v0.25.1)
 
@@ -36,3 +37,14 @@
 - Update k8s modules to v0.30.2. 
 - Update quay.io/giantswarm/alpine Docker tag to v3.20.1.
 - Add node and app labels in ServiceMonitor.
+
+### security-bundle [v1.7.0...v1.8.0](https://github.com/giantswarm/security-bundle/compare/v1.7.0...v1.8.0)
+
+#### Added
+
+- Add `kyverno-crds` app to handle Kyverno CRD install.
+
+#### Changed
+
+- Update `kyverno` (app) to v0.17.15. This version disables the CRD install job in favor of `kyverno-crds` App.
+- Update `starboard-exporter` (app) to v0.7.11.

--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -21,7 +21,7 @@ spec:
   - name: cert-exporter
     version: 2.9.0
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: cert-manager
     version: 3.7.6
     dependsOn:
@@ -45,7 +45,7 @@ spec:
   - name: cluster-autoscaler
     version: 1.29.3-gs1
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: coredns
     version: 1.21.0
     dependsOn:
@@ -53,7 +53,7 @@ spec:
   - name: etcd-k8s-res-count-exporter
     version: 1.10.0
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: external-dns
     version: 3.1.0
     dependsOn:
@@ -65,15 +65,15 @@ spec:
   - name: k8s-audit-metrics
     version: 0.9.0
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: k8s-dns-node-cache
     version: 2.8.1
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: metrics-server
     version: 2.4.2
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: net-exporter
     version: 1.21.0
     dependsOn:
@@ -86,7 +86,7 @@ spec:
   - name: node-exporter
     version: 1.19.0
     dependsOn:
-    - kyverno
+    - kyverno-crds
   - name: observability-bundle
     version: 1.3.4
     dependsOn:
@@ -96,7 +96,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: security-bundle
-    version: 1.7.0
+    version: 1.8.0
     catalog: giantswarm
     dependsOn:
     - prometheus-operator-crd


### PR DESCRIPTION
Internal Shield issue: https://github.com/giantswarm/giantswarm/issues/30018

This PR updates the security-bundle to v1.8.0 on the CAPA v29.0.0 release.

The bundle version v1.8.0 introduces a new `kyverno-crds` App that will host the necessary Kyverno CRDs for Apps to run without requiring Kyverno directly. This should help speedup cluster creation.