### PR TITLE
v29 update cabbage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ merged to the `master` branch, workload cluster releases get automatically deplo
 to all Giant Swarm installations.
 
 ## AWS
+- v29
+  - v29.0
+    - [v29.0.0](https://github.com/giantswarm/releases/tree/master/capa/v29.0.0)
 - v28
   - v28.0
     - [v28.0.0](https://github.com/giantswarm/releases/tree/master/capa/v28.0.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - v26.0.0
 - v27.0.0
 - v28.0.0
+- v29.0.0
 transformers:
 - releaseNotesTransformer.yaml

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2024-07-10 09:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-07-17 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v29.0.0/README.md
+++ b/capa/v29.0.0/README.md
@@ -1,0 +1,9 @@
+# :zap: Giant Swarm Release v29.0.0 for CAPA :zap:
+
+## Changes compared to v28.0.0
+
+- cluster-aws from 1.0.1 to 1.2.1
+- Flatcar from 3815.2.2 to 3815.2.5
+- Kubernetes from 1.28.11 to 1.29.7
+- cloud-provider-aws (formerly aws-cloud-controller-manager-app) from 1.28.6-gs1 to 1.29.3-gs1
+- cluster-autoscaler from 1.28.5-gs1 to 1.29.3-gs1

--- a/capa/v29.0.0/README.md
+++ b/capa/v29.0.0/README.md
@@ -7,3 +7,32 @@
 - Kubernetes from 1.28.11 to 1.29.7
 - cloud-provider-aws (formerly aws-cloud-controller-manager-app) from 1.28.6-gs1 to 1.29.3-gs1
 - cluster-autoscaler from 1.28.5-gs1 to 1.29.3-gs1
+
+### cilium [v0.25.1](https://github.com/giantswarm/cilium-app/releases/tag/v0.25.1)
+
+#### Changed 
+
+- Fix regression setting Policy BPF Max map `policyMapMax` back to 65536 from 16384.
+- Upgrade cilium to v1.15.6.
+
+### k8s-dns-node-cache [v2.8.1](https://github.com/giantswarm/k8s-dns-node-cache-app/releases/tag/v2.8.1)
+
+### Changed
+
+- Reduce security exceptions.
+  - Enable readOnly FS moving config to emptyDir volume.
+  - Remove `NET_ADMIN` and drop `ALL` capabilities.
+  - Add `NET_BIND_SERVICE` capability.
+  - Add policy exception for `require-non-root-groups/autogen-check-runasgroup`.
+  - Remove disallow-capabilities-* policy exceptions.
+- Update PolicyException CR version to v2beta1.
+
+### net-exporter [v1.21.0](https://github.com/giantswarm/net-exporter/releases/tag/v1.21.0)
+
+### Changed 
+
+- Enable readOnlyRootFilesystem in securityContext.
+- Update module google.golang.org/grpc to v1.65.0. 
+- Update k8s modules to v0.30.2. 
+- Update quay.io/giantswarm/alpine Docker tag to v3.20.1.
+- Add node and app labels in ServiceMonitor.

--- a/capa/v29.0.0/announcement.md
+++ b/capa/v29.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.0.0 for CAPA is available**. This release upgrades Kubernetes version to v1.29.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-29.0.0/).

--- a/capa/v29.0.0/kustomization.yaml
+++ b/capa/v29.0.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -31,7 +31,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cilium
-    version: 0.24.0
+    version: 0.25.1
   - name: cilium-crossplane-resources
     version: 0.1.0
   - name: cilium-servicemonitors
@@ -67,7 +67,7 @@ spec:
     dependsOn:
     - kyverno
   - name: k8s-dns-node-cache
-    version: 2.6.2
+    version: 2.8.1
     dependsOn:
     - kyverno
   - name: metrics-server
@@ -75,7 +75,7 @@ spec:
     dependsOn:
     - kyverno
   - name: net-exporter
-    version: 1.19.0
+    version: 1.21.0
     dependsOn:
     - prometheus-operator-crd
   - name: network-policies

--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -1,0 +1,120 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-29.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - cert-manager
+  - name: aws-pod-identity-webhook
+    version: 1.16.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.0
+    dependsOn:
+    - kyverno
+  - name: cert-manager
+    version: 3.7.6
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.24.0
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.29.3-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.29.3-gs1
+    dependsOn:
+    - kyverno
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.0.1
+    dependsOn:
+    - cert-manager
+  - name: k8s-audit-metrics
+    version: 0.9.0
+    dependsOn:
+    - kyverno
+  - name: k8s-dns-node-cache
+    version: 2.6.2
+    dependsOn:
+    - kyverno
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno
+  - name: net-exporter
+    version: 1.19.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno
+  - name: observability-bundle
+    version: 1.3.4
+    dependsOn:
+    - coredns
+  - name: prometheus-blackbox-exporter
+    version: 0.4.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.7.0
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.0
+  - name: vertical-pod-autoscaler
+    version: 5.2.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 1.2.1
+  - name: flatcar
+    version: 3815.2.5
+  - name: kubernetes
+    version: 1.29.7
+  date: "2024-07-17T12:00:00Z"
+  state: active


### PR DESCRIPTION
- **CAPA: Release v29.0.0.**
- **update cabbage apps in CAPA v29**


<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

### Checklist
- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering e2e tests

To trigger the E2E test for each new Release added in this PR add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests you can do so by adding a comment similar to the following:

`/run conformance-tests RELEASE_VERSION=v28.0.0 PROVIDER=capa`

For more details see the [README.md](/README.md#running-tests-against-prs)
