### PR TITLE
CAPA v29.0.0: Update `observability-bundle`.

### DIFF
--- a/capa/v29.0.0/README.md
+++ b/capa/v29.0.0/README.md
@@ -30,6 +30,7 @@
 - k8s-audit-metrics from v0.9.0 to v0.10.0
 - k8s-dns-node-cache from v2.6.2 to v2.8.1
 - net-exporter from v1.19.0 to v1.21.0
+- observability-bundle from v1.3.4 to v1.5.2
 - prometheus-blackbox-exporter from v0.4.1 to v0.4.2
 - security-bundle from v1.7.0 to v1.8.0
 - teleport-kube-agent from v0.9.0 to v0.9.2
@@ -102,6 +103,30 @@
 - Update k8s modules to v0.30.2 (#375).
 - Update quay.io/giantswarm/alpine Docker tag to v3.20.1 (#372).
 - Add `node` and `app` labels in ServiceMonitor.
+
+### observability-bundle [v1.3.4...v1.5.2](https://github.com/giantswarm/observability-bundle/compare/v1.3.4...v1.5.2)
+
+#### Added
+
+- Add `alloy` v0.3.0 as `alloy-logs`
+
+#### Changed
+
+- Fix CNP issues (allow traffic from pods in kube-system to nginx-ingress-controller)
+  - Upgrade `grafana-agent` to 0.4.5.
+  - Upgrade `alloy` to 0.3.1.
+  - Upgrade `promtail` to 1.5.4.
+- Upgrade `prometheus-operator-crd` to 11.0.1.
+- prometheus-operator will not check promql syntax for prometheusRules that are labelled `application.giantswarm.io/prometheus-rule-kind: loki`
+- Upgrade `kube-prometheus-stack` to 11.0.0 and `prometheus-operator-crd` to 11.0.0. This upgrade mainly consists in:
+  - kube-prometheus-stack dependency chart upgraded from [56.21.2](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-56.21.2) to [61.0.0](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-61.0.0)
+  - prometheus upgrade from 2.50.1 to [2.53.0](https://github.com/prometheus-community/helm-charts/releases/tag/prometheus-25.22.0)
+  - thanos ruler upgrade from 0.34.1 to [0.35.1](https://github.com/thanos-io/thanos/releases/tag/v0.35.1)
+  - kube-state-metrics from 2.10.0 to 2.12.0
+  - prometheus-operator from 0.71.2 [0.75.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.75.0) - adding remoteWrite.proxyFromEnvironment and Scrape Class support
+  - prometheus-node-exporter upgraded from 1.8.0 to [1.8.1](https://github.com/prometheus/node_exporter/releases/tag/v1.8.1)
+- Upgrade `grafana-agent` from 0.4.3 to 0.4.4
+  - This version enables the override the grafana agent `CiliumNetworkPolicy` egress and ingress sections.
 
 ### prometheus-blackbox-exporter [v0.4.1...v0.4.2](https://github.com/giantswarm/prometheus-blackbox-exporter-app/compare/v0.4.1...v0.4.2)
 

--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -88,7 +88,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: observability-bundle
-    version: 1.3.4
+    version: 1.5.2
     dependsOn:
     - coredns
   - name: prometheus-blackbox-exporter


### PR DESCRIPTION
<!--
If this is a PR with details for new release please review [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365)
- if there's an issue for this release open in "Planned" column without team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release/))
- otherwise create an appropriate ticket for your release in https://github.com/giantswarm/roadmap and add it to the releases board

Ping @sig-product for review of release notes.
--->

This PR updates the `observability-bundle` to `v1.5.2` on the CAPA v29.0.0 release.
Previous release deployed the `observability-bundle@1.3.4`.
Here the CHANGELOG: https://github.com/giantswarm/observability-bundle/blob/main/CHANGELOG.md

Main changes are:
- kube-prometheus-stack updated with an upgrade of prometheus-operator CRDs
- `alloy` app added to the bundle
- fix CNP issues
- add `observability-policies` app to deploy Observability Kyverno Policies https://github.com/giantswarm/giantswarm/issues/31155

### Checklist
- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering e2e tests

To trigger the E2E test for each new Release added in this PR add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests you can do so by adding a comment similar to the following:

`/run conformance-tests RELEASE_VERSION=v29.0.0 PROVIDER=capa`

For more details see the [README.md](/README.md#running-tests-against-prs)
