### PR TITLE
CAPA v29.0.0: Update `cluster-aws` and add OS tooling.

### DIFF
--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -110,10 +110,12 @@ spec:
     version: 3.1.0
   components:
   - name: cluster-aws
-    catalog: cluster
-    version: 1.3.0
+    catalog: cluster-test
+    version: 1.3.0-ab5ba518d0dd85c17a57fc26e8a589d37d3fb4ed
   - name: flatcar
     version: 3815.2.5
+  - name: os-tooling
+    version: 1.15.0
   - name: kubernetes
     version: 1.29.7
   date: "2024-07-17T12:00:00Z"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3592

Changes:
- Update cluster-aws version (currently set to test version in draft PR, will update the PR once there is a new cluster-aws release)
- Add `os-tooling` component. New cluster-aws version uses it to build the OS image name with the new format.

### Checklist
- [x] Roadmap issue created

### Triggering e2e tests

To trigger the E2E test for each new Release added in this PR add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests you can do so by adding a comment similar to the following:

`/run conformance-tests RELEASE_VERSION=v28.0.0 PROVIDER=capa`

For more details see the [README.md](/README.md#running-tests-against-prs)
