### PR TITLE
Add release request for new cert-exporter version

### DIFF
--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,1 +1,5 @@
 releases:
+- name: "> 29.0.0"
+  requests:
+  - name: cert-exporter
+    version: ">= 2.9.2"


### PR DESCRIPTION
Adds request for the new cert-exporter version in the next release.
Currently cert-exporter is crashing on larger cluster (see https://github.com/giantswarm/roadmap/issues/3625) due to OOMKills.