### PR TITLE
request observability-bundle >= 1.6.1 for CAPA > 29.0.0

### DIFF
--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: cert-exporter
     version: ">= 2.9.2"
+  - name: observability-bundle
+    version: ">= 1.6.1"
   - name: security-bundle
     version: ">= 1.8.1"
 - name: "< 30.0.0"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522, https://github.com/giantswarm/roadmap/issues/3524

This PR request observability-bundle to be upgraded to >= 1.6.1 version for the next CAPA > 29.0.0 release