### PR TITLE
CAPZ: Request `observability-bundle` >= v1.6.1.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: cert-exporter
     version: ">= 2.9.2"
+  - name: observability-bundle
+    version: ">= 1.6.1"
   - name: security-bundle
     version: ">= 1.8.1"
 - name: "< 30.0.0"


### PR DESCRIPTION
@giantswarm/team-atlas: In response to [my question here](https://github.com/giantswarm/releases/pull/1346#issuecomment-2299060920). Just approve if it was intended for CAPZ, too.