### PR TITLE
CAPA: Release v29.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ to all Giant Swarm installations.
 
 ## AWS
 - v29
+  - v29.1
+    - [v29.1.0](https://github.com/giantswarm/releases/tree/master/capa/v29.1.0)
   - v29.0
     - [v29.0.0](https://github.com/giantswarm/releases/tree/master/capa/v29.0.0)
 - v28

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
 - v28.0.0
 - v28.1.0
 - v29.0.0
+- v29.1.0
 transformers:
 - releaseNotesTransformer.yaml

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -69,6 +69,13 @@
       "releaseTimestamp": "2024-08-07 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.1.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-08-26 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.1.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v29.1.0/README.md
+++ b/capa/v29.1.0/README.md
@@ -1,0 +1,47 @@
+# :zap: Giant Swarm Release v29.1.0 for CAPA :zap:
+
+## Changes compared to v29.0.0
+
+### Components
+
+- Flatcar from v3815.2.5 to [v3975.2.0](https://www.flatcar.org/releases#release-3975.2.0)
+- Kubernetes from v1.29.7 to [v1.29.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#changelog-since-v1297)
+
+### Apps
+
+- cert-exporter from v2.9.1 to v2.9.2
+- node-exporter from v1.19.0 to v1.20.0
+- observability-bundle from v1.5.2 to v1.6.1
+- security-bundle from v1.8.0 to v1.8.1
+
+### cert-exporter [v2.9.1...v2.9.2](https://github.com/giantswarm/cert-exporter/compare/v2.9.1...v2.9.2)
+
+#### Added
+
+- Chart: Add VPA and resources configuration for deployment and daemonset. ([#382](https://github.com/giantswarm/cert-exporter/pull/382))
+
+### node-exporter [v1.19.0...v1.20.0](https://github.com/giantswarm/node-exporter-app/compare/v1.19.0...v1.20.0)
+
+#### Changed
+
+- Synced with upstream chart v4.38.0 (node-exporter 1.8.2).
+
+### observability-bundle [v1.5.2...v1.6.1](https://github.com/giantswarm/observability-bundle/compare/v1.5.2...v1.6.1)
+
+#### Added
+
+- Add `alloy` v0.4.0 as `alloyMetrics`.
+
+#### Changed
+
+- Disable usage reporting to GrafanaLabs by:
+  - Bumping `alloyLogs` and `alloyMetrics` to v0.4.1.
+  - Bumping `grafanaAgent` to v0.4.6.
+- Bump `alloyLogs` to v0.4.0.
+- Rename `alloy-logs` app to camel case `alloyLogs`.
+
+### security-bundle [v1.8.0...v1.8.1](https://github.com/giantswarm/security-bundle/compare/v1.8.0...v1.8.1)
+
+#### Changed
+
+- Update `trivy-operator` (app) to v0.9.1.

--- a/capa/v29.1.0/announcement.md
+++ b/capa/v29.1.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.1.0 for CAPA is available**. This release updates Kubernetes to v1.29.8, Flatcar to v3975.2.0 and several apps and components to their latest minor releases.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-29.1.0).

--- a/capa/v29.1.0/kustomization.yaml
+++ b/capa/v29.1.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v29.1.0/release.diff
+++ b/capa/v29.1.0/release.diff
@@ -1,0 +1,126 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-29.0.0						|         name: aws-29.1.0
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 2.30.1							    version: 2.30.1
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.16.0							    version: 1.16.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.1						|           version: 2.9.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.1							    version: 3.8.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    version: 0.1.0							    version: 0.1.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.29.3-gs1							    version: 1.29.3-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.29.3-gs1							    version: 1.29.3-gs1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: coredns							  - name: coredns
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    version: 0.1.1							    version: 0.1.1
+    catalog: cluster							    catalog: cluster
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.19.0						|           version: 1.20.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.5.2						|           version: 1.6.1
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2							    version: 0.4.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    version: 1.8.0						|           version: 1.8.1
+    catalog: giantswarm							    catalog: giantswarm
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.2							    version: 0.9.2
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.4							    version: 5.2.4
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0							    version: 3.1.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 2.0.0							    version: 2.0.0
+  - name: flatcar							  - name: flatcar
+    version: 3815.2.5						|           version: 3975.2.0
+  - name: kubernetes							  - name: kubernetes
+    version: 1.29.7						|           version: 1.29.8
+  - name: os-tooling							  - name: os-tooling
+    version: 1.15.0						|           version: 1.18.1
+  date: "2024-08-07T12:00:00Z"					|         date: "2024-08-22T12:00:00Z"
+  state: active								  state: active

--- a/capa/v29.1.0/release.yaml
+++ b/capa/v29.1.0/release.yaml
@@ -1,0 +1,126 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-29.1.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-pod-identity-webhook
+    version: 1.16.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.2
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.29.3-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.29.3-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.6.1
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.8.1
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.2
+  - name: vertical-pod-autoscaler
+    version: 5.2.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 2.0.0
+  - name: flatcar
+    version: 3975.2.0
+  - name: kubernetes
+    version: 1.29.8
+  - name: os-tooling
+    version: 1.18.1
+  date: "2024-08-26T12:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version (_for 1.29 minor_)

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=v29.0.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
