### PR TITLE
CAPA: Deprecate multiple releases.

### DIFF
--- a/capa/releases.json
+++ b/capa/releases.json
@@ -9,7 +9,7 @@
     },
     {
       "version": "25.1.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-07-03 18:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v25.1.0/README.md",
       "isStable": true
@@ -23,7 +23,7 @@
     },
     {
       "version": "26.0.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-06-26 09:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v26.0.0/README.md",
       "isStable": true
@@ -37,7 +37,7 @@
     },
     {
       "version": "27.0.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-07-09 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v27.0.0/README.md",
       "isStable": true
@@ -51,21 +51,21 @@
     },
     {
       "version": "28.0.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-07-10 09:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.0.0/README.md",
       "isStable": true
     },
     {
       "version": "28.0.1",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-08-26 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.0.1/README.md",
       "isStable": true
     },
     {
       "version": "28.1.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-07-30 11:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.1.0/README.md",
       "isStable": true
@@ -79,7 +79,7 @@
     },
     {
       "version": "29.0.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-08-07 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.0.0/README.md",
       "isStable": true

--- a/capa/v25.1.0/release.yaml
+++ b/capa/v25.1.0/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.25.16
   date: "2024-07-03T18:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v26.0.0/release.yaml
+++ b/capa/v26.0.0/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.26.15
   date: "2024-06-26T09:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v27.0.0/release.yaml
+++ b/capa/v27.0.0/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.27.14
   date: "2024-07-09T12:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v28.0.0/release.yaml
+++ b/capa/v28.0.0/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.28.11
   date: "2024-07-10T09:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v28.0.1/release.yaml
+++ b/capa/v28.0.1/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.28.11
   date: "2024-08-26T12:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v28.1.0/release.yaml
+++ b/capa/v28.1.0/release.yaml
@@ -119,4 +119,4 @@ spec:
   - name: kubernetes
     version: 1.28.11
   date: "2024-07-30T11:00:00Z"
-  state: active
+  state: deprecated

--- a/capa/v29.0.0/release.yaml
+++ b/capa/v29.0.0/release.yaml
@@ -123,4 +123,4 @@ spec:
   - name: os-tooling
     version: 1.15.0
   date: "2024-08-07T12:00:00Z"
-  state: active
+  state: deprecated


### PR DESCRIPTION
Towards [issue](https://github.com/giantswarm/roadmap/issues/3654).

The following releases are being deprecated because they are not the latest and should not be used in order to simplify the upgrade path and to have an easier time with testing the upgrade from v25.x.x to v29.x.x.
- v25.1.0
- v26.0.0
- v27.0.0
- v28.0.0
- v28.0.1
- v28.1.0
- v29.0.0
