### PR TITLE
CAPA v29.1.0: Define catalog for `cilium-crossplane-resources`.

### DIFF
--- a/capa/v29.1.0/release.diff
+++ b/capa/v29.1.0/release.diff
@@ -33,6 +33,7 @@ spec:									spec:
   - name: cilium							  - name: cilium
     version: 0.25.1							    version: 0.25.1
   - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+								>           catalog: cluster
     version: 0.1.0							    version: 0.1.0
   - name: cilium-servicemonitors					  - name: cilium-servicemonitors
     version: 0.1.2							    version: 0.1.2
@@ -79,8 +80,9 @@ spec:									spec:
     dependsOn:								    dependsOn:
     - prometheus-operator-crd						    - prometheus-operator-crd
   - name: network-policies						  - name: network-policies
-    version: 0.1.1							    version: 0.1.1
+    version: 0.1.1						<
     catalog: cluster							    catalog: cluster
+								>           version: 0.1.1
     dependsOn:								    dependsOn:
     - cilium								    - cilium
   - name: node-exporter							  - name: node-exporter
@@ -100,8 +102,9 @@ spec:									spec:
     dependsOn:								    dependsOn:
     - prometheus-operator-crd						    - prometheus-operator-crd
   - name: security-bundle						  - name: security-bundle
-    version: 1.8.0						|           version: 1.8.1
+    version: 1.8.0						<
     catalog: giantswarm							    catalog: giantswarm
+								>           version: 1.8.1
     dependsOn:								    dependsOn:
     - prometheus-operator-crd						    - prometheus-operator-crd
   - name: teleport-kube-agent						  - name: teleport-kube-agent

--- a/capa/v29.1.0/release.yaml
+++ b/capa/v29.1.0/release.yaml
@@ -33,6 +33,7 @@ spec:
   - name: cilium
     version: 0.25.1
   - name: cilium-crossplane-resources
+    catalog: cluster
     version: 0.1.0
   - name: cilium-servicemonitors
     version: 0.1.2
@@ -79,8 +80,8 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: network-policies
-    version: 0.1.1
     catalog: cluster
+    version: 0.1.1
     dependsOn:
     - cilium
   - name: node-exporter
@@ -100,8 +101,8 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: security-bundle
-    version: 1.8.1
     catalog: giantswarm
+    version: 1.8.1
     dependsOn:
     - prometheus-operator-crd
   - name: teleport-kube-agent


### PR DESCRIPTION
This PR explicitly defines the catalog for the `cilium-crossplane-resources` app.

At the moment, `cluster-aws` is hard-coding this catalog anyways. So merging this PR will effectively not change any existing clusters running on this release.

But as I'm currently about to implement the same logic of looking up catalogs from the Release CR in the `cluster-aws` chart as we already have in the `cluster` chart, the Cluster Test Suites might fail as they are picking the latest available Release CR, patch the `cluster-aws` chart version to test and then execute their tests.

In this specific scenario `cilium-crossplane-resources` would be rendered with `catalog: default` as without this PR the latest Release CR does not explicitly define a catalog for it and therefore falls back to `default`.

**tl;dr:** This PR has no effect on production clusters, it is only required for development.

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=v29.0.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
