### PR TITLE
CAPA: Test giantswarm/cluster-aws#836.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ to all Giant Swarm installations.
   - v25.2
     - [v25.2.0](https://github.com/giantswarm/releases/tree/master/capa/v25.2.0)
   - v25.1
+    - [v25.1.1](https://github.com/giantswarm/releases/tree/master/capa/v25.1.1)
     - [v25.1.0](https://github.com/giantswarm/releases/tree/master/capa/v25.1.0)
   - v25.0
     - [v25.0.0](https://github.com/giantswarm/releases/tree/master/capa/v25.0.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -3,6 +3,7 @@ commonAnnotations:
 resources:
 - v25.0.0
 - v25.1.0
+- v25.1.1
 - v25.2.0
 - v26.1.0
 - v27.1.0

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -15,6 +15,13 @@
       "isStable": true
     },
     {
+      "version": "25.1.1",
+      "isDeprecated": true,
+      "releaseTimestamp": "2024-07-03 18:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v25.1.1/README.md",
+      "isStable": true
+    },
+    {
       "version": "25.2.0",
       "isDeprecated": false,
       "releaseTimestamp": "2024-07-30 09:00:00 +0000 UTC",

--- a/capa/v25.1.1/README.md
+++ b/capa/v25.1.1/README.md
@@ -1,0 +1,1 @@
+# :zap: Giant Swarm Release v25.1.1 for CAPA :zap:

--- a/capa/v25.1.1/announcement.md
+++ b/capa/v25.1.1/announcement.md
@@ -1,0 +1,1 @@
+**Workload cluster release v25.1.1 for CAPA is available**.

--- a/capa/v25.1.1/kustomization.yaml
+++ b/capa/v25.1.1/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v25.1.1/release.diff
+++ b/capa/v25.1.1/release.diff
@@ -1,0 +1,122 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-25.1.0						|         name: aws-25.1.1
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 2.30.1							    version: 2.30.1
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.16.0							    version: 1.16.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.0							    version: 2.9.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: cert-manager							  - name: cert-manager
+    version: 3.7.9 # aligning with Vintage, fixing bugs			    version: 3.7.9 # aligning with Vintage, fixing bugs
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1 # as per Cabbage request fixing bugs		    version: 0.25.1 # as per Cabbage request fixing bugs
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    version: 0.1.0							    version: 0.1.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.25.14-gs3						    version: 1.25.14-gs3
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.27.3-gs9							    version: 1.27.3-gs9
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: coredns							  - name: coredns
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.9.0							    version: 0.9.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.6.2							    version: 2.6.2
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: net-exporter							  - name: net-exporter
+    version: 1.19.0							    version: 1.19.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    version: 0.1.1							    version: 0.1.1
+    catalog: cluster							    catalog: cluster
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.19.0							    version: 1.19.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.3.4							    version: 1.3.4
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.1							    version: 0.4.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    version: 1.7.0							    version: 1.7.0
+    catalog: giantswarm							    catalog: giantswarm
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.0							    version: 0.9.0
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.2							    version: 5.2.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0							    version: 3.1.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster						|           catalog: cluster-test
+    version: 1.1.0						|           version: 2.1.0-7caf2d9338ee5c49bd4f13af79d646251c5df4
+  - name: flatcar							  - name: flatcar
+    version: 3815.2.5 # CVEs OpenSSH fixed				    version: 3815.2.5 # CVEs OpenSSH fixed
+  - name: flatcar-variant						  - name: flatcar-variant
+    version: 1.0.0							    version: 1.0.0
+  - name: kubernetes							  - name: kubernetes
+    version: 1.25.16							    version: 1.25.16
+  date: "2024-07-03T18:00:00Z"					|         date: "2024-09-17T18:00:00Z"
+  state: deprecated							  state: deprecated

--- a/capa/v25.1.1/release.yaml
+++ b/capa/v25.1.1/release.yaml
@@ -1,0 +1,122 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-25.1.1
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - cert-manager
+  - name: aws-pod-identity-webhook
+    version: 1.16.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.0
+    dependsOn:
+    - kyverno
+  - name: cert-manager
+    version: 3.7.9 # aligning with Vintage, fixing bugs
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1 # as per Cabbage request fixing bugs
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.25.14-gs3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.27.3-gs9
+    dependsOn:
+    - kyverno
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.0.1
+    dependsOn:
+    - cert-manager
+  - name: k8s-audit-metrics
+    version: 0.9.0
+    dependsOn:
+    - kyverno
+  - name: k8s-dns-node-cache
+    version: 2.6.2
+    dependsOn:
+    - kyverno
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno
+  - name: net-exporter
+    version: 1.19.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno
+  - name: observability-bundle
+    version: 1.3.4
+    dependsOn:
+    - coredns
+  - name: prometheus-blackbox-exporter
+    version: 0.4.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.7.0
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.0
+  - name: vertical-pod-autoscaler
+    version: 5.2.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-aws
+    catalog: cluster-test
+    version: 2.1.0-7caf2d9338ee5c49bd4f13af79d646251c5df48b
+  - name: flatcar
+    version: 3815.2.5 # CVEs OpenSSH fixed
+  - name: flatcar-variant
+    version: 1.0.0
+  - name: kubernetes
+    version: 1.25.16
+  date: "2024-09-17T18:00:00Z"
+  state: deprecated


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
