### PR TITLE
CAPA: Release v29.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to all Giant Swarm installations.
 ## AWS
 
 - v29
+  - v29.2
+    - [v29.2.0](https://github.com/giantswarm/releases/tree/master/capa/v29.2.0)
   - v29.1
     - [v29.1.0](https://github.com/giantswarm/releases/tree/master/capa/v29.1.0)
   - v29.0

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
 - v28.1.1
 - v28.1.2
 - v29.1.0
+- v29.2.0
 transformers:
 - releaseNotesTransformer.yaml

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -83,6 +83,13 @@
       "releaseTimestamp": "2024-08-26 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.2.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-09-24 18:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.2.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v29.2.0/README.md
+++ b/capa/v29.2.0/README.md
@@ -1,0 +1,100 @@
+# :zap: Giant Swarm Release v29.2.0 for CAPA :zap:
+
+## Changes compared to v29.1.0
+
+### Components
+
+- cluster-aws from v2.0.0 to v2.2.0
+- Flatcar from v3975.2.0 to [v3975.2.1](https://www.flatcar.org/releases#release-3975.2.1)
+- Kubernetes from v1.29.8 to [v1.29.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#changelog-since-v1298)
+
+### cluster-aws [v2.0.0...v2.2.0](https://github.com/giantswarm/cluster-aws/compare/v2.0.0...v2.2.0)
+
+#### Added
+
+- Allow to enable `auditd` through `global.components.auditd.enabled` helm value.
+- Chart: Support multiple service account issuers.\
+  This is used for example in the migration from Vintage AWS clusters to CAPA. Multiple issuers were previously supported only through internal chart values (this change removes `internal.migration.irsaAdditionalDomain`). The internal annotation `aws.giantswarm.io/irsa-additional-domain` on AWSMachineTemplate objects is changed to plural `aws.giantswarm.io/irsa-trust-domains` on the AWSCluster object.
+
+#### Changed
+
+- Chart: Update `cluster` to v1.4.1.
+- Set provider specific configuration for cilium CNI ENI values.
+- Do not allow additional properties in most values in order to avoid unnoticed typos.
+- Validate that machine pool availability zones belong to the selected region.
+- CI: Bump release version.
+- Apps: Use `catalog` from Release CR.
+
+#### Removed
+
+- Remove Cilium app deprecated values.
+- Remove unused kubectl image Helm value.
+
+### Apps
+
+- aws-pod-identity-webhook from v1.16.0 to v1.17.0
+- coredns from v1.21.0 to v1.22.0
+- observability-bundle from v1.6.1 to v1.6.2
+- security-bundle from v1.8.1 to v1.8.2
+- teleport-kube-agent from v0.9.2 to v0.10.3
+- vertical-pod-autoscaler from v5.2.4 to v5.3.0
+- vertical-pod-autoscaler-crd from v3.1.0 to v3.1.1
+
+### aws-pod-identity-webhook [v1.16.0...v1.17.0](https://github.com/giantswarm/aws-pod-identity-webhook-app/compare/v1.16.0...v1.17.0)
+
+#### Changed
+
+- Fix VPA being ineffective due to referring to a non-existing `Deployment` name
+
+### coredns [v1.21.0...v1.22.0](https://github.com/giantswarm/coredns-app/compare/v1.21.0...v1.22.0)
+
+#### Changed
+
+- Update `coredns` image to [1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3).
+
+#### Removed
+
+- Removed legacy Giant Swarm monitoring labels as coredns is monitored through a prometheus-operator generated servicemonitor.
+
+### observability-bundle [v1.6.1...v1.6.2](https://github.com/giantswarm/observability-bundle/compare/v1.6.1...v1.6.2)
+
+#### Changed
+
+- Fixed `alloyMetrics` catalog
+
+### security-bundle [v1.8.1...v1.8.2](https://github.com/giantswarm/security-bundle/compare/v1.8.1...v1.8.2)
+
+#### Changed
+
+- Update `cloudnative-pg` (app) to v0.0.6.
+- Update `trivy-operator` (app) to v0.10.0.
+- Update `kyverno-policy-operator` (app) to v0.0.8.
+- Update `kyverno` (app) to v0.17.16.
+
+### teleport-kube-agent [v0.9.2...v0.10.3](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.9.2...v0.10.3)
+
+#### Changed
+
+- Disable JAMF components on chart templates
+- Fix issues with templates
+- Change ownership to Team Shield
+- Added small fix on `podSecurityContext` for `seccompProfile`.
+- Upgraded to Teleport `version 16`
+
+### vertical-pod-autoscaler [v5.2.4...v5.3.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.2.4...v5.3.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v9.9.0. ([#314](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/314))
+- Chart: Consume `global.imageRegistry`. ([#315](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/315))
+
+#### Removed
+
+- Chart: Do not override `crds.image.tag`. ([#316](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/316))
+
+### vertical-pod-autoscaler-crd [v3.1.0...v3.1.1](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.1.0...v3.1.1)
+
+#### Changed
+
+- Chart: Improve `Chart.yaml`. ([#110](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/110))
+- Repository: Some chores. ([#111](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/111))

--- a/capa/v29.2.0/announcement.md
+++ b/capa/v29.2.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.2.0 for CAPA is available**. This release updates Kubernetes to v1.29.9, Flatcar to v3975.2.1 and several apps and components to their latest minor releases.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-29.2.0).

--- a/capa/v29.2.0/kustomization.yaml
+++ b/capa/v29.2.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/capa/v29.2.0/release.diff
+++ b/capa/v29.2.0/release.diff
@@ -1,0 +1,127 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-29.1.0						|         name: aws-29.2.0
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 2.30.1							    version: 2.30.1
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.16.0						|           version: 1.17.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.2							    version: 2.9.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.1							    version: 3.8.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    catalog: cluster							    catalog: cluster
+    version: 0.1.0							    version: 0.1.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.29.3-gs1							    version: 1.29.3-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.29.3-gs1							    version: 1.29.3-gs1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: coredns							  - name: coredns
+    version: 1.21.0						|           version: 1.22.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.0							    version: 1.20.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.6.1						|           version: 1.6.2
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2							    version: 0.4.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.8.1						|           version: 1.8.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.2						|           version: 0.10.3
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.4						|           version: 5.3.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0						|           version: 3.1.1
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 2.0.0						|           version: 2.2.0
+  - name: flatcar							  - name: flatcar
+    version: 3975.2.0						|           version: 3975.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.29.8						|           version: 1.29.9
+  - name: os-tooling							  - name: os-tooling
+    version: 1.18.1						|           version: 1.19.1
+  date: "2024-08-26T12:00:00Z"					|         date: "2024-09-24T18:00:00Z"
+  state: active								  state: active

--- a/capa/v29.2.0/release.yaml
+++ b/capa/v29.2.0/release.yaml
@@ -1,0 +1,127 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-29.2.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 2.30.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-pod-identity-webhook
+    version: 1.17.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.2
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.29.3-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.29.3-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.22.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.6.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 2.2.0
+  - name: flatcar
+    version: 3975.2.1
+  - name: kubernetes
+    version: 1.29.9
+  - name: os-tooling
+    version: 1.19.1
+  date: "2024-09-24T18:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
