### PR TITLE
Upgrade observability-bundle to 1.6.2

### DIFF
--- a/capa/v29.1.0/README.md
+++ b/capa/v29.1.0/README.md
@@ -11,7 +11,7 @@
 
 - cert-exporter from v2.9.1 to v2.9.2
 - node-exporter from v1.19.0 to v1.20.0
-- observability-bundle from v1.5.2 to v1.6.1
+- observability-bundle from v1.5.2 to v1.6.2
 - security-bundle from v1.8.0 to v1.8.1
 
 ### cert-exporter [v2.9.1...v2.9.2](https://github.com/giantswarm/cert-exporter/compare/v2.9.1...v2.9.2)
@@ -26,7 +26,7 @@
 
 - Synced with upstream chart v4.38.0 (node-exporter 1.8.2).
 
-### observability-bundle [v1.5.2...v1.6.1](https://github.com/giantswarm/observability-bundle/compare/v1.5.2...v1.6.1)
+### observability-bundle [v1.5.2...v1.6.2](https://github.com/giantswarm/observability-bundle/compare/v1.5.2...v1.6.2)
 
 #### Added
 

--- a/capa/v29.1.0/release.diff
+++ b/capa/v29.1.0/release.diff
@@ -90,7 +90,7 @@ spec:									spec:
     dependsOn:								    dependsOn:
     - kyverno-crds							    - kyverno-crds
   - name: observability-bundle						  - name: observability-bundle
-    version: 1.5.2						|           version: 1.6.1
+    version: 1.5.2						|           version: 1.6.2
     dependsOn:								    dependsOn:
     - coredns								    - coredns
   - name: observability-policies					  - name: observability-policies

--- a/capa/v29.1.0/release.yaml
+++ b/capa/v29.1.0/release.yaml
@@ -89,7 +89,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: observability-bundle
-    version: 1.6.1
+    version: 1.6.2
     dependsOn:
     - coredns
   - name: observability-policies


### PR DESCRIPTION
This PR upgrade the observability-bundle from 1.6.1 to 1.6.2 in CAPA v29.1.0 release.
This is to fix an issue we have with a wrong catalog name for the alloyMetrics app in the observability-bundle.
It's a very small change and would ensure we have CAPA and CAPZ v29.1.0 aligned and ready for shipping alloyMetrics.

I know this does not follow the usual release process but the change is very small and was tested.