### PR TITLE
CAPA: Warn about breaking changes.

### DIFF
--- a/capa/v29.2.0/README.md
+++ b/capa/v29.2.0/README.md
@@ -13,17 +13,18 @@
 #### ⚠️ Breaking change
 
 - Do not allow additional properties in the following fields in order to avoid unnoticed typos:
-  - global.connectivity.network
-  - global.connectivity.network.pods
-  - global.connectivity.network.services
-  - global.connectivity.subnets[]
-  - global.connectivity.topology
-  - global.controlPlane
-  - global.controlPlane.additionalSecurityGroups[]
-  - global.controlPlane.machineHealthCheck
-  - global.controlPlane.oidc
-  - global.providerSpecific
-  - global.providerSpecific.instanceMetadataOptions
+
+  - `global.connectivity.network`
+  - `global.connectivity.network.pods`
+  - `global.connectivity.network.services`
+  - `global.connectivity.subnets[]`
+  - `global.connectivity.topology`
+  - `global.controlPlane`
+  - `global.controlPlane.additionalSecurityGroups[]`
+  - `global.controlPlane.machineHealthCheck`
+  - `global.controlPlane.oidc`
+  - `global.providerSpecific`
+  - `global.providerSpecific.instanceMetadataOptions`
 
 If you were using values like `global.controlPlane.containerdVolumeSizeGB` and `global.controlPlane.kubeletVolumeSizeGB`, please move to the new `.global.controlPlane.libVolumeSizeGB` which defines the size of disk volume used for `/var/lib` mount point.
 

--- a/capa/v29.2.0/README.md
+++ b/capa/v29.2.0/README.md
@@ -10,6 +10,23 @@
 
 ### cluster-aws [v2.0.0...v2.2.0](https://github.com/giantswarm/cluster-aws/compare/v2.0.0...v2.2.0)
 
+#### ⚠️ Breaking change
+
+- Do not allow additional properties in the following fields in order to avoid unnoticed typos:
+  - global.connectivity.network
+  - global.connectivity.network.pods
+  - global.connectivity.network.services
+  - global.connectivity.subnets[]
+  - global.connectivity.topology
+  - global.controlPlane
+  - global.controlPlane.additionalSecurityGroups[]
+  - global.controlPlane.machineHealthCheck
+  - global.controlPlane.oidc
+  - global.providerSpecific
+  - global.providerSpecific.instanceMetadataOptions
+
+If you were using values like `global.controlPlane.containerdVolumeSizeGB` and `global.controlPlane.kubeletVolumeSizeGB`, please move to the new `.global.controlPlane.libVolumeSizeGB` which defines the size of disk volume used for `/var/lib` mount point.
+
 #### Added
 
 - Allow to enable `auditd` through `global.components.auditd.enabled` helm value.

--- a/capa/v29.3.0/README.md
+++ b/capa/v29.3.0/README.md
@@ -3,3 +3,20 @@
 ## Changes compared to v29.2.0
 
 This release does not contain any changes to components or apps, but makes use of an updated machine image, which includes a fix for accessing private Elastic Container Registries (ECR).
+
+#### ⚠️ Breaking change introduced in v29.2.0 with `cluster-aws` version 2.1.0
+
+- Do not allow additional properties in the following fields in order to avoid unnoticed typos:
+  - global.connectivity.network
+  - global.connectivity.network.pods
+  - global.connectivity.network.services
+  - global.connectivity.subnets[]
+  - global.connectivity.topology
+  - global.controlPlane
+  - global.controlPlane.additionalSecurityGroups[]
+  - global.controlPlane.machineHealthCheck
+  - global.controlPlane.oidc
+  - global.providerSpecific
+  - global.providerSpecific.instanceMetadataOptions
+
+If you were using values like `global.controlPlane.containerdVolumeSizeGB` and `global.controlPlane.kubeletVolumeSizeGB`, please move to the new `.global.controlPlane.libVolumeSizeGB` which defines the size of disk volume used for `/var/lib` mount point.

--- a/capa/v29.3.0/README.md
+++ b/capa/v29.3.0/README.md
@@ -7,16 +7,17 @@ This release does not contain any changes to components or apps, but makes use o
 #### ⚠️ Breaking change introduced in v29.2.0 with `cluster-aws` version 2.1.0
 
 - Do not allow additional properties in the following fields in order to avoid unnoticed typos:
-  - global.connectivity.network
-  - global.connectivity.network.pods
-  - global.connectivity.network.services
-  - global.connectivity.subnets[]
-  - global.connectivity.topology
-  - global.controlPlane
-  - global.controlPlane.additionalSecurityGroups[]
-  - global.controlPlane.machineHealthCheck
-  - global.controlPlane.oidc
-  - global.providerSpecific
-  - global.providerSpecific.instanceMetadataOptions
+
+  - `global.connectivity.network`
+  - `global.connectivity.network.pods`
+  - `global.connectivity.network.services`
+  - `global.connectivity.subnets[]`
+  - `global.connectivity.topology`
+  - `global.controlPlane`
+  - `global.controlPlane.additionalSecurityGroups[]`
+  - `global.controlPlane.machineHealthCheck`
+  - `global.controlPlane.oidc`
+  - `global.providerSpecific`
+  - `global.providerSpecific.instanceMetadataOptions`
 
 If you were using values like `global.controlPlane.containerdVolumeSizeGB` and `global.controlPlane.kubeletVolumeSizeGB`, please move to the new `.global.controlPlane.libVolumeSizeGB` which defines the size of disk volume used for `/var/lib` mount point.


### PR DESCRIPTION
Be more explicit about breaking change introduced in `cluster-aws` version `2.1.0`.