### PR TITLE
CAPV: Release v28.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,9 @@ to all Giant Swarm installations.
 
 ## Vsphere
 
+- v28
+  - v28.0
+    - [v28.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v28.0.0)
 - v27
   - v27.0
     - [v27.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v27.0.0)

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -2,5 +2,6 @@ commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/
 resources:
 - v27.0.0
+- v28.0.0
 transformers:
 - releaseNotesTransformer.yaml

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -6,6 +6,13 @@
       "releaseTimestamp": "2024-08-12 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v27.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "28.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-10-18 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v28.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v28.0.0/README.md
+++ b/vsphere/v28.0.0/README.md
@@ -1,0 +1,7 @@
+# :zap: Giant Swarm Release v28.0.0 for vSphere :zap:
+
+## Changes compared to v27.0.0
+
+### Components
+
+- Kubernetes from v1.27.16 to v1.28.12

--- a/vsphere/v28.0.0/announcement.md
+++ b/vsphere/v28.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v28.0.0 for vSphere is available**. This release upgrades Kubernetes to v1.28.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-azure/releases/vsphere-28.0.0).

--- a/vsphere/v28.0.0/kustomization.yaml
+++ b/vsphere/v28.0.0/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- release.yaml

--- a/vsphere/v28.0.0/release.diff
+++ b/vsphere/v28.0.0/release.diff
@@ -1,0 +1,102 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: vsphere-27.0.0						|         name: vsphere-28.0.0
+spec:									spec:
+  apps:									  apps:
+  - name: cloud-provider-vsphere				- name: cloud-provider-vsphere
+    version: 1.11.0							    version: 1.11.0
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.1							    version: 2.9.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.1							    version: 3.8.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: coredns							  - name: coredns
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    version: 0.1.1							    version: 0.1.1
+    catalog: cluster							    catalog: cluster
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.19.0							    version: 1.19.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.5.3							    version: 1.5.3
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2							    version: 0.4.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    version: 1.8.0							    version: 1.8.0
+    catalog: giantswarm							    catalog: giantswarm
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.2							    version: 0.9.2
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.4							    version: 5.2.4
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0							    version: 3.1.0
+  components:								  components:
+  - name: cluster-azure							  - name: cluster-azure
+    catalog: cluster							    catalog: cluster
+    version: 1.0.0							    version: 1.0.0
+  - name: flatcar							  - name: flatcar
+    version: 3815.2.5							    version: 3815.2.5
+  - name: kubernetes							  - name: kubernetes
+    version: 1.27.16						|           version: 1.28.12
+  - name: os-tooling							  - name: os-tooling
+    version: 1.15.0							    version: 1.15.0
+  date: "2024-08-12T12:00:00Z"					|         date: "2024-10-18T12:00:00Z"
+  state: active								  state: active

--- a/vsphere/v28.0.0/release.diff
+++ b/vsphere/v28.0.0/release.diff
@@ -97,6 +97,6 @@ spec:									spec:
   - name: kubernetes							  - name: kubernetes
     version: 1.27.16						|           version: 1.28.12
   - name: os-tooling							  - name: os-tooling
-    version: 1.15.0							    version: 1.15.0
+    version: 1.15.0						|           version: 1.20.1
   date: "2024-08-12T12:00:00Z"					|         date: "2024-10-18T12:00:00Z"
   state: active								  state: active

--- a/vsphere/v28.0.0/release.yaml
+++ b/vsphere/v28.0.0/release.yaml
@@ -1,0 +1,102 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-28.0.0
+spec:
+  apps:
+  - name: cloud-provider-vsphere
+    version: 1.11.0
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: coredns
+    version: 1.21.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.5.3
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    version: 1.8.0
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.9.2
+  - name: vertical-pod-autoscaler
+    version: 5.2.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 0.65.0
+  - name: flatcar
+    version: 3815.2.5
+  - name: kubernetes
+    version: 1.28.12
+  - name: os-tooling
+    version: 1.15.0
+  date: "2024-10-18T12:00:00Z"
+  state: active

--- a/vsphere/v28.0.0/release.yaml
+++ b/vsphere/v28.0.0/release.yaml
@@ -97,6 +97,6 @@ spec:
   - name: kubernetes
     version: 1.28.12
   - name: os-tooling
-    version: 1.15.0
+    version: 1.20.1
   date: "2024-10-18T12:00:00Z"
   state: active


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3716

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).