### PR TITLE
Remove transformer plugin requirement

### DIFF
--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -1,5 +1,6 @@
 commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io/
+
 resources:
 - v25.0.0
 - v26.0.0
@@ -8,5 +9,23 @@ resources:
 - v29.0.0
 - v29.1.0
 - v29.2.0
+
 transformers:
-- releaseNotesTransformer.yaml
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: namePrefixer
+  prefix: "azure-"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/name
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: releaseNotesPrefixer
+  prefix: "https://github.com/giantswarm/releases/tree/master/azure/v"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/annotations/giantswarm.io\/release-notes

--- a/azure/releaseNotesTransformer.yaml
+++ b/azure/releaseNotesTransformer.yaml
@@ -1,6 +1,0 @@
-apiVersion: giantswarm.io/v1
-kind: releaseNotesURLAnnotationTransformer
-metadata:
-  name: azureReleaseNotesURLAnnotationTransformer
-# provider annotationKey
-argsOneLiner: azure giantswarm.io/release-notes

--- a/azure/v25.0.0/kustomization.yaml
+++ b/azure/v25.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v25.0.0/release.yaml
+++ b/azure/v25.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-25.0.0
+  name: 25.0.0
 spec:
   apps:
   - name: azuredisk-csi-driver

--- a/azure/v26.0.0/kustomization.yaml
+++ b/azure/v26.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v26.0.0/release.yaml
+++ b/azure/v26.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-26.0.0
+  name: 26.0.0
 spec:
   apps:
   - name: azuredisk-csi-driver

--- a/azure/v27.0.0/kustomization.yaml
+++ b/azure/v27.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v27.0.0/release.yaml
+++ b/azure/v27.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-27.0.0
+  name: 27.0.0
 spec:
   apps:
   - name: azure-cloud-controller-manager

--- a/azure/v28.0.0/kustomization.yaml
+++ b/azure/v28.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v28.0.0/release.yaml
+++ b/azure/v28.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-28.0.0
+  name: 28.0.0
 spec:
   apps:
   - name: azure-cloud-controller-manager

--- a/azure/v29.0.0/kustomization.yaml
+++ b/azure/v29.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v29.0.0/release.yaml
+++ b/azure/v29.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-29.0.0
+  name: 29.0.0
 spec:
   apps:
   - name: azure-cloud-controller-manager

--- a/azure/v29.1.0/kustomization.yaml
+++ b/azure/v29.1.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v29.1.0/release.yaml
+++ b/azure/v29.1.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-29.1.0
+  name: 29.1.0
 spec:
   apps:
   - name: azure-cloud-controller-manager

--- a/azure/v29.2.0/kustomization.yaml
+++ b/azure/v29.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v29.2.0/release.yaml
+++ b/azure/v29.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: azure-29.2.0
+  name: 29.2.0
 spec:
   apps:
   - name: azure-cloud-controller-manager

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,5 +1,6 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/
+
 resources:
 - v25.0.0
 - v25.1.0
@@ -22,5 +23,23 @@ resources:
 - v29.1.0
 - v29.2.0
 - v29.3.0
+
 transformers:
-- releaseNotesTransformer.yaml
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: namePrefixer
+  prefix: "aws-"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/name
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: releaseNotesPrefixer
+  prefix: "https://github.com/giantswarm/releases/tree/master/capa/v"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/annotations/giantswarm.io\/release-notes

--- a/capa/releaseNotesTransformer.yaml
+++ b/capa/releaseNotesTransformer.yaml
@@ -1,6 +1,0 @@
-apiVersion: giantswarm.io/v1
-kind: releaseNotesURLAnnotationTransformer
-metadata:
-  name: capaReleaseNotesURLAnnotationTransformer
-# provider annotationKey
-argsOneLiner: capa giantswarm.io/release-notes

--- a/capa/v25.0.0/kustomization.yaml
+++ b/capa/v25.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.0.0/release.yaml
+++ b/capa/v25.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.0.0
+  name: 25.0.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.1.0/kustomization.yaml
+++ b/capa/v25.1.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.1.0/release.yaml
+++ b/capa/v25.1.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.1.0
+  name: 25.1.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.1.1/kustomization.yaml
+++ b/capa/v25.1.1/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.1.1/release.yaml
+++ b/capa/v25.1.1/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.1.1
+  name: 25.1.1
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.1.2/kustomization.yaml
+++ b/capa/v25.1.2/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.1.2/release.yaml
+++ b/capa/v25.1.2/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.1.2
+  name: 25.1.2
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.2.0/kustomization.yaml
+++ b/capa/v25.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.2.0/release.yaml
+++ b/capa/v25.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.2.0
+  name: 25.2.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.2.1/kustomization.yaml
+++ b/capa/v25.2.1/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.2.1/release.yaml
+++ b/capa/v25.2.1/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.2.1
+  name: 25.2.1
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v25.3.0/kustomization.yaml
+++ b/capa/v25.3.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v25.3.0/release.yaml
+++ b/capa/v25.3.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-25.3.0
+  name: 25.3.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v26.1.0/kustomization.yaml
+++ b/capa/v26.1.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v26.1.0/release.yaml
+++ b/capa/v26.1.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-26.1.0
+  name: 26.1.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v26.1.1/kustomization.yaml
+++ b/capa/v26.1.1/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v26.1.1/release.yaml
+++ b/capa/v26.1.1/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-26.1.1
+  name: 26.1.1
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v26.2.0/kustomization.yaml
+++ b/capa/v26.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v26.2.0/release.yaml
+++ b/capa/v26.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-26.2.0
+  name: 26.2.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v27.1.0/kustomization.yaml
+++ b/capa/v27.1.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v27.1.0/release.yaml
+++ b/capa/v27.1.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-27.1.0
+  name: 27.1.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v27.1.1/kustomization.yaml
+++ b/capa/v27.1.1/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v27.1.1/release.yaml
+++ b/capa/v27.1.1/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-27.1.1
+  name: 27.1.1
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v27.2.0/kustomization.yaml
+++ b/capa/v27.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v27.2.0/release.yaml
+++ b/capa/v27.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-27.2.0
+  name: 27.2.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v27.3.0/kustomization.yaml
+++ b/capa/v27.3.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v27.3.0/release.yaml
+++ b/capa/v27.3.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-27.3.0
+  name: 27.3.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v28.1.1/kustomization.yaml
+++ b/capa/v28.1.1/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v28.1.1/release.yaml
+++ b/capa/v28.1.1/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-28.1.1
+  name: 28.1.1
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v28.1.2/kustomization.yaml
+++ b/capa/v28.1.2/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v28.1.2/release.yaml
+++ b/capa/v28.1.2/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-28.1.2
+  name: 28.1.2
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v28.2.0/kustomization.yaml
+++ b/capa/v28.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v28.2.0/release.yaml
+++ b/capa/v28.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-28.2.0
+  name: 28.2.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v28.3.0/kustomization.yaml
+++ b/capa/v28.3.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v28.3.0/release.yaml
+++ b/capa/v28.3.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-28.3.0
+  name: 28.3.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v29.1.0/kustomization.yaml
+++ b/capa/v29.1.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v29.1.0/release.yaml
+++ b/capa/v29.1.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-29.1.0
+  name: 29.1.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v29.2.0/kustomization.yaml
+++ b/capa/v29.2.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v29.2.0/release.yaml
+++ b/capa/v29.2.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-29.2.0
+  name: 29.2.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v29.3.0/kustomization.yaml
+++ b/capa/v29.3.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v29.3.0/release.yaml
+++ b/capa/v29.3.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-29.3.0
+  name: 29.3.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,18 @@ go 1.23.2
 
 require (
 	github.com/blang/semver/v4 v4.0.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/giantswarm/microerror v0.4.1
 	github.com/giantswarm/release-operator/v4 v4.2.0
 	github.com/giantswarm/versionbundle v1.1.0
 	gopkg.in/yaml.v3 v3.0.1
+	sigs.k8s.io/kustomize/api v0.18.0
 	sigs.k8s.io/kustomize/kustomize/v5 v5.5.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/giantswarm/k8smetadata v0.24.0 // indirect
 	github.com/giantswarm/micrologger v1.1.1 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
@@ -56,7 +57,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20231129212854-f0671cc7e66a // indirect
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
-	sigs.k8s.io/kustomize/api v0.18.0 // indirect
 	sigs.k8s.io/kustomize/cmd/config v0.15.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.18.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-- release.yaml

--- a/releases_test.go
+++ b/releases_test.go
@@ -12,14 +12,11 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/release-operator/v4/api/v1alpha1"
 	"github.com/giantswarm/versionbundle"
+	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/yaml"
 )
 
-type kustomizationFile struct {
-	CommonAnnotations map[string]string `yaml:"commonAnnotations"`
-	Resources         []string          `yaml:"resources"`
-	Transformers      []string          `yaml:"transformers"`
-}
+type kustomizationFile types.Kustomization
 
 // requestException represents a single release exception to a request.
 type requestException struct {
@@ -149,6 +146,12 @@ func findReleases(provider string, archived bool) ([]v1alpha1.Release, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
+
+		// Handle CAPI release naming
+		if provider == "vsphere" || provider == "azure" || provider == "capa" {
+			release.Name = "v" + strings.TrimPrefix(release.Name, "v")
+		}
+
 		if strings.Contains(release.Name, "azure") || strings.Contains(release.Name, "aws") || strings.Contains(release.Name, "vsphere") {
 			parts := strings.Split(release.Name, "-")
 			release.Name = "v" + parts[len(parts)-1] //

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -1,8 +1,39 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/
+
 resources:
 - v27.0.0
 - v27.0.1
 - v28.0.0
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true
+
 transformers:
-- releaseNotesTransformer.yaml
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: namePrefixer
+  prefix: "vsphere-"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/name
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+  metadata:
+    name: releaseNotesPrefixer
+  prefix: "https://github.com/giantswarm/releases/tree/master/vsphere/v"
+  fieldSpecs:
+  - kind: Release
+    path: metadata/annotations/giantswarm.io\/release-notes

--- a/vsphere/releaseNotesTransformer.yaml
+++ b/vsphere/releaseNotesTransformer.yaml
@@ -1,6 +1,0 @@
-apiVersion: giantswarm.io/v1
-kind: releaseNotesURLAnnotationTransformer
-metadata:
-  name: vsphereReleaseNotesURLAnnotationTransformer
-# provider annotationKey
-argsOneLiner: vsphere giantswarm.io/release-notes

--- a/vsphere/v27.0.0/kustomization.yaml
+++ b/vsphere/v27.0.0/kustomization.yaml
@@ -1,2 +1,14 @@
 resources:
 - release.yaml
+
+replacements:
+- source:
+    kind: Release
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Release
+    fieldPaths:
+      - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v27.0.0/release.yaml
+++ b/vsphere/v27.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: vsphere-27.0.0
+  name: "27.0.0"
 spec:
   apps:
   - name: capi-node-labeler


### PR DESCRIPTION
This is a refactor our CAPI releases to remove their requirement on the archived https://github.com/giantswarm/kustomize-plugin-releasenotesurlannotationtransformer Kustomize plugin so that we can migrate to using Flux to deploy these resources.

This change also fixes the docs URL and the release-notes URL we add as annotations to the Releases as both of these were incorrect and pointing to 404s.

The changes result in the following Release CR being generated:

```
apiVersion: release.giantswarm.io/v1alpha1
kind: Release
metadata:
  annotations:
    giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io/
    giantswarm.io/release-notes: https://github.com/giantswarm/releases/tree/master/vsphere/v27.0.0
  name: vsphere-27.0.0
spec:
  apps:
  - name: cloud-provider-vsphere
    version: 1.11.0
  - name: capi-node-labeler
    version: 0.5.0
  - dependsOn:
    - kyverno-crds
    name: cert-exporter
    version: 2.9.1
  - dependsOn:
    - prometheus-operator-crd
    name: cert-manager
    version: 3.8.1
  - dependsOn:
    - prometheus-operator-crd
    name: chart-operator-extensions
    version: 1.1.2
  - name: cilium
    version: 0.25.1
  - dependsOn:
    - prometheus-operator-crd
    name: cilium-servicemonitors
    version: 0.1.2
  - dependsOn:
    - cilium
    name: coredns
    version: 1.21.0
  - dependsOn:
    - kyverno-crds
    name: etcd-k8s-res-count-exporter
    version: 1.10.0
  - dependsOn:
    - prometheus-operator-crd
    name: external-dns
    version: 3.1.0
  - dependsOn:
    - kyverno-crds
    name: k8s-audit-metrics
    version: 0.10.0
  - dependsOn:
    - kyverno-crds
    name: k8s-dns-node-cache
    version: 2.8.1
  - dependsOn:
    - kyverno-crds
    name: metrics-server
    version: 2.4.2
  - dependsOn:
    - prometheus-operator-crd
    name: net-exporter
    version: 1.21.0
  - catalog: cluster
    dependsOn:
    - cilium
    name: network-policies
    version: 0.1.1
  - dependsOn:
    - kyverno-crds
    name: node-exporter
    version: 1.19.0
  - dependsOn:
    - coredns
    name: observability-bundle
    version: 1.5.3
  - dependsOn:
    - kyverno-crds
    name: observability-policies
    version: 0.0.1
  - dependsOn:
    - prometheus-operator-crd
    name: prometheus-blackbox-exporter
    version: 0.4.2
  - catalog: giantswarm
    dependsOn:
    - prometheus-operator-crd
    name: security-bundle
    version: 1.8.0
  - name: teleport-kube-agent
    version: 0.9.2
  - dependsOn:
    - prometheus-operator-crd
    name: vertical-pod-autoscaler
    version: 5.2.4
  - name: vertical-pod-autoscaler-crd
    version: 3.1.0
  components:
  - catalog: cluster
    name: cluster-vsphere
    version: 0.65.0
  - name: flatcar
    version: 3815.2.5
  - name: kubernetes
    version: 1.27.16
  - name: os-tooling
    version: 1.15.0
  date: "2024-08-12T12:00:00Z"
  state: active
```