### PR TITLE
CAPV: Release v29.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,10 @@ to all Giant Swarm installations.
 
 ## vSphere
 
+- v29
+  - v29.0
+    - [v29.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v29.0.0)
+
 - v28
   - v28.0
     - [v28.0.1](https://github.com/giantswarm/releases/tree/master/vsphere/v28.0.1)

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - v27.0.1
 - v28.0.0
 - v28.0.1
+- v29.0.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2024-10-23 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v28.0.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-10-23 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v29.0.0/README.md
+++ b/vsphere/v29.0.0/README.md
@@ -1,0 +1,98 @@
+# :zap: Giant Swarm Release v29.0.0 for vSphere :zap:
+
+## Changes compared to v28.0.1
+
+### Components
+
+- cluster-vsphere from v0.65.1 to v0.65.2.
+- Flatcar from v3815.2.5 to [v3975.2.2](https://www.flatcar.org/releases#release-3975.2.2)
+- Kubernetes from v1.28.15 to [v1.29.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md)
+
+### cluster-vsphere [v0.65.1...v0.65.2](https://github.com/giantswarm/cluster-vsphere/compare/v0.65.1...v0.65.2)
+
+#### Changed
+
+- Fix `kube-vip` static pod manifest for Kubernetes `1.29` onwards.
+
+### Apps
+
+- cert-exporter from v2.9.1 to v2.9.2
+- coredns from v1.21.0 to v1.22.0
+- node-exporter from v1.19.0 to v1.20.0
+- observability-bundle from v1.5.3 to v1.6.2
+- security-bundle from v1.8.0 to v1.8.2
+- teleport-kube-agent from v0.9.2 to v0.10.3
+- vertical-pod-autoscaler from v5.2.4 to v5.3.0
+- vertical-pod-autoscaler-crd from v3.1.0 to v3.1.1
+
+### cert-exporter [v2.9.1...v2.9.2](https://github.com/giantswarm/cert-exporter/compare/v2.9.1...v2.9.2)
+
+#### Added
+
+- Chart: Add VPA and resources configuration for deployment and daemonset. ([#382](https://github.com/giantswarm/cert-exporter/pull/382))
+
+### coredns [v1.21.0...v1.22.0](https://github.com/giantswarm/coredns-app/compare/v1.21.0...v1.22.0)
+
+#### Changed
+
+- Update `coredns` image to [1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3).
+
+#### Removed
+
+- Removed legacy Giant Swarm monitoring labels as coredns is monitored through a prometheus-operator generated servicemonitor.
+
+### node-exporter [v1.19.0...v1.20.0](https://github.com/giantswarm/node-exporter-app/compare/v1.19.0...v1.20.0)
+
+#### Changed
+
+- Synced with upstream chart v4.38.0 (node-exporter 1.8.2).
+
+### observability-bundle [v1.5.3...v1.6.2](https://github.com/giantswarm/observability-bundle/compare/v1.5.3...v1.6.2)
+
+#### Added
+
+- Add `alloy` v0.4.0 as `alloyMetrics`.
+
+#### Changed
+
+- Fixed `alloyMetrics` catalog
+- Disable usage reporting to GrafanaLabs by:
+  - Bumping `alloyLogs` and `alloyMetrics` to v0.4.1.
+  - Bumping `grafanaAgent` to v0.4.6.
+
+### security-bundle [v1.8.0...v1.8.2](https://github.com/giantswarm/security-bundle/compare/v1.8.0...v1.8.2)
+
+#### Changed
+
+- Update `cloudnative-pg` (app) to v0.0.6.
+- Update `trivy-operator` (app) to v0.10.0.
+- Update `kyverno-policy-operator` (app) to v0.0.8.
+- Update `kyverno` (app) to v0.17.16.
+
+### teleport-kube-agent [v0.9.2...v0.10.3](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.9.2...v0.10.3)
+
+#### Changed
+
+- Disable JAMF components on chart templates
+- Fix issues with templates
+- Change ownership to Team Shield
+- Added small fix on `podSecurityContext` for `seccompProfile`.
+- Upgraded to Teleport `version 16`
+
+### vertical-pod-autoscaler [v5.2.4...v5.3.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.2.4...v5.3.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v9.9.0. ([#314](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/314))
+- Chart: Consume `global.imageRegistry`. ([#315](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/315))
+
+#### Removed
+
+- Chart: Do not override `crds.image.tag`. ([#316](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/316))
+
+### vertical-pod-autoscaler-crd [v3.1.0...v3.1.1](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.1.0...v3.1.1)
+
+#### Changed
+
+- Chart: Improve `Chart.yaml`. ([#110](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/110))
+- Repository: Some chores. ([#111](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/111))

--- a/vsphere/v29.0.0/announcement.md
+++ b/vsphere/v29.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.0.0 for vSphere is available**. This release upgrades Kubernetes to v1.29.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-29.0.0).

--- a/vsphere/v29.0.0/kustomization.yaml
+++ b/vsphere/v29.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v29.0.0/release.diff
+++ b/vsphere/v29.0.0/release.diff
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: vsphere-28.0.1						|         name: vsphere-29.0.0
+spec:									spec:
+  apps:									  apps:
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.1						|           version: 2.9.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.1							    version: 3.8.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-vsphere					  - name: cloud-provider-vsphere
+    version: 1.11.0							    version: 1.11.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns							  - name: coredns
+    version: 1.21.0						|           version: 1.22.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.19.0						|           version: 1.20.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.5.3						|           version: 1.6.2
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2							    version: 0.4.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.8.0						|           version: 1.8.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.2						|           version: 0.10.3
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.4						|           version: 5.3.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0						|           version: 3.1.1
+  components:								  components:
+  - name: cluster-vsphere						  - name: cluster-vsphere
+    catalog: cluster							    catalog: cluster
+    version: 0.65.1						|           version: 0.65.2
+  - name: flatcar							  - name: flatcar
+    version: 3815.2.5						|           version: 3975.2.2
+  - name: kubernetes							  - name: kubernetes
+    version: 1.28.15						|           version: 1.29.10
+  - name: os-tooling							  - name: os-tooling
+    version: 1.20.1							    version: 1.20.1
+  date: "2024-10-23T12:00:00Z"						  date: "2024-10-23T12:00:00Z"
+  state: active								  state: active

--- a/vsphere/v29.0.0/release.yaml
+++ b/vsphere/v29.0.0/release.yaml
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-29.0.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.2
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 1.11.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.22.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.6.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 0.65.2
+  - name: flatcar
+    version: 3975.2.2
+  - name: kubernetes
+    version: 1.29.10
+  - name: os-tooling
+    version: 1.20.1
+  date: "2024-10-23T12:00:00Z"
+  state: active


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3710

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).