### PR TITLE
CAPI: Request `observability-bundle` >= 1.7.0.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,6 +3,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.3.0"
+  requests:
+  - name: observability-bundle
+    version: ">= 1.7.0"
 - name: "> 29.1.0"
   requests:
   - name: observability-bundle

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -3,6 +3,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.4.0"
+  requests:
+  - name: observability-bundle
+    version: ">= 1.7.0"
 - name: "> 29.1.0"
   requests:
   - name: observability-bundle

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -3,7 +3,11 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
-- name: "> 29.1.0"
+- name: ">= 29.1.0"
+  requests:
+  - name: observability-bundle
+    version: ">= 1.7.0"
+- name: "> 29.0.0"
   requests:
   - name: observability-bundle
     version: ">= 1.6.2"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

This PR update the releases requests to make sure we upgrade observability-bundle to v1.7.0 in newer releases