### PR TITLE
CAPI: Keep resources.

### DIFF
--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
+  helm.sh/resource-policy: keep
 
 transformers:
 - |

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
+  helm.sh/resource-policy: keep
 
 transformers:
 - |

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
+  helm.sh/resource-policy: keep
 
 transformers:
 - |


### PR DESCRIPTION
This change makes Helm keep the releases upon uninstalling the Helm release. This is needed for handing over Release CRs into Flux management.