### PR TITLE
CAPI: Stop pushing to app collection.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,7 @@ workflows:
           name: filter
           mapping: |
             aws/.* push-aws true
-            azure/.* push-azure true
             kvm/.* push-kvm true
-            capa/.* push-capa true
-            vsphere/.* push-vsphere true
           base-revision: master
           config-path: .circleci/provider_config.yml
           requires:

--- a/.circleci/provider_config.yml
+++ b/.circleci/provider_config.yml
@@ -8,16 +8,7 @@ parameters:
   push-aws:
     type: boolean
     default: false
-  push-azure:
-    type: boolean
-    default: false
   push-kvm:
-    type: boolean
-    default: false
-  push-capa:
-    type: boolean
-    default: false
-  push-vsphere:
     type: boolean
     default: false
 
@@ -83,35 +74,7 @@ workflows:
             # Trigger the job on merge to master.
             branches:
               only: master
-  azure:
-    when: << pipeline.parameters.push-azure >>
-    jobs:
-      - render:
-          name: render-azure
-          provider: azure
-      - architect/push-to-app-catalog:
-          context: architect
-          name: push-releases-azure-to-releases-catalog
-          app_catalog: releases-catalog
-          app_catalog_test: releases-test-catalog
-          attach_workspace: true
-          chart: releases-azure
-          explicit_allow_chart_name_mismatch: true
-          on_tag: false
-          requires:
-            - render-azure
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-releases-to-azure-app-collection
-          app_catalog: releases
-          app_name: releases-azure
-          app_collection_repo: capz-app-collection
-          requires:
-            - push-releases-azure-to-releases-catalog
-          filters:
-            # Trigger the job on merge to master.
-            branches:
-              only: master
+
   kvm:
     when: << pipeline.parameters.push-kvm >>
     jobs:
@@ -141,61 +104,3 @@ workflows:
             # Trigger the job on merge to master.
             branches:
               only: master
-  capa:
-    when: << pipeline.parameters.push-capa >>
-    jobs:
-    - render:
-        name: render-capa
-        provider: capa
-    - architect/push-to-app-catalog:
-        context: architect
-        name: push-releases-capa-to-releases-catalog
-        app_catalog: releases-catalog
-        app_catalog_test: releases-test-catalog
-        attach_workspace: true
-        chart: releases-capa
-        explicit_allow_chart_name_mismatch: true
-        on_tag: false
-        requires:
-        - render-capa
-    - architect/push-to-app-collection:
-        context: architect
-        name: push-releases-to-capa-app-collection
-        app_catalog: releases
-        app_name: releases-capa
-        app_collection_repo: capa-app-collection
-        requires:
-        - push-releases-capa-to-releases-catalog
-        filters:
-          # Trigger the job on merge to master.
-          branches:
-            only: master
-  vsphere:
-    when: << pipeline.parameters.push-vsphere >>
-    jobs:
-    - render:
-        name: render-vsphere
-        provider: vsphere
-    - architect/push-to-app-catalog:
-        context: architect
-        name: push-releases-vsphere-to-releases-catalog
-        app_catalog: releases-catalog
-        app_catalog_test: releases-test-catalog
-        attach_workspace: true
-        chart: releases-vsphere
-        explicit_allow_chart_name_mismatch: true
-        on_tag: false
-        requires:
-        - render-vsphere
-    - architect/push-to-app-collection:
-        context: architect
-        name: push-releases-to-vsphere-app-collection
-        app_catalog: releases
-        app_name: releases-vsphere
-        app_collection_repo: vsphere-app-collection
-        requires:
-        - push-releases-vsphere-to-releases-catalog
-        filters:
-          # Trigger the job on merge to master.
-          branches:
-            only: master


### PR DESCRIPTION
This PR removes CAPI providers from the CircleCI configuration so we no longer push the generated `releases-<provider>` app to app collections as it will be removed from there in the next step.