### PR TITLE
CAPI: Request `observability-bundle` v1.8.0.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.3.0"
   requests:
   - name: observability-bundle
-    version: ">= 1.7.0"
+    version: ">= 1.8.0"
 - name: "> 29.1.0"
   requests:
   - name: observability-bundle

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.4.0"
   requests:
   - name: observability-bundle
-    version: ">= 1.7.0"
+    version: ">= 1.8.0"
 - name: "> 29.1.0"
   requests:
   - name: observability-bundle

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.1.0"
   requests:
   - name: observability-bundle
-    version: ">= 1.7.0"
+    version: ">= 1.8.0"
 - name: "> 29.0.0"
   requests:
   - name: observability-bundle


### PR DESCRIPTION
This version add a missing dependency annotation on alloy-logs and alloy metrics to wait for the prometheus-operator-crds to be there before the apps get deployed

<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
