### PR TITLE
CAPI: Empty resource policy.

### DIFF
--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-  helm.sh/resource-policy: keep
+  helm.sh/resource-policy: ""
 
 transformers:
 - |

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-  helm.sh/resource-policy: keep
+  helm.sh/resource-policy: ""
 
 transformers:
 - |

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-  helm.sh/resource-policy: keep
+  helm.sh/resource-policy: ""
 
 transformers:
 - |


### PR DESCRIPTION
As CAPI releases are now being managed by Flux, we first need to set this empty so Flux becomes the owner of the field. Before it was managed by Helm and simply removing it from the resources would remove the field without changing ownership.