### PR TITLE
CAPV: Release v29.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ to all Giant Swarm installations.
 
 - v29
   - v29.0
+    - [v29.0.1](https://github.com/giantswarm/releases/tree/master/vsphere/v29.0.1)
     - [v29.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v29.0.0)
 
 - v28

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - v28.0.0
 - v28.0.1
 - v29.0.0
+- v29.0.1
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -34,6 +34,13 @@
       "releaseTimestamp": "2024-10-23 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.0.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-11-14 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.0.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v29.0.1/README.md
+++ b/vsphere/v29.0.1/README.md
@@ -1,0 +1,18 @@
+# :zap: Giant Swarm Release v29.0.1 for vSphere :zap:
+
+## Changes compared to v29.0.0
+
+### cluster-vsphere [v0.65.2...v0.66.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.65.2...v0.66.0)
+
+### Components
+
+- cluster-vsphere from v0.65.2 to v0.66.0
+
+### cluster-vsphere [v0.65.1...v0.65.2](https://github.com/giantswarm/cluster-vsphere/compare/v0.65.1...v0.65.2)
+
+#### Changed
+
+- Use Renovate to update `kube-vip` static pod manifest.
+- Updated `giantswarm/cluster` to `v1.6.0`.
+- Update `kubectl` image used by IPAM job to `1.29.9`.
+- Use init-container to prepare `/etc/hosts` file for `kube-vip`.

--- a/vsphere/v29.0.1/announcement.md
+++ b/vsphere/v29.0.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.0.1 for vSphere is available**. These release contains minor bugfixes and improvements.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-29.0.1).

--- a/vsphere/v29.0.1/kustomization.yaml
+++ b/vsphere/v29.0.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v29.0.1/release.diff
+++ b/vsphere/v29.0.1/release.diff
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
+kind: Release							kind: Release
+metadata:							metadata:
+  name: vsphere-29.0.0					      |	  name: vsphere-29.0.1
+spec:								spec:
+  apps:								  apps:
+  - name: capi-node-labeler					  - name: capi-node-labeler
+    version: 0.5.0						    version: 0.5.0
+  - name: cert-exporter						  - name: cert-exporter
+    version: 2.9.2						    version: 2.9.2
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: cert-manager						  - name: cert-manager
+    version: 3.8.1						    version: 3.8.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: chart-operator-extensions				  - name: chart-operator-extensions
+    version: 1.1.2						    version: 1.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cilium						  - name: cilium
+    version: 0.25.1						    version: 0.25.1
+  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cloud-provider-vsphere				  - name: cloud-provider-vsphere
+    version: 1.11.0						    version: 1.11.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns						  - name: coredns
+    version: 1.22.0						    version: 1.22.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0						    version: 1.10.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: external-dns						  - name: external-dns
+    version: 3.1.0						    version: 3.1.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
+    version: 0.10.0						    version: 0.10.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
+    version: 2.8.1						    version: 2.8.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: metrics-server					  - name: metrics-server
+    version: 2.4.2						    version: 2.4.2
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: net-exporter						  - name: net-exporter
+    version: 1.21.0						    version: 1.21.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: network-policies					  - name: network-policies
+    catalog: cluster						    catalog: cluster
+    version: 0.1.1						    version: 0.1.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: node-exporter						  - name: node-exporter
+    version: 1.20.0						    version: 1.20.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: observability-bundle					  - name: observability-bundle
+    version: 1.6.2						    version: 1.6.2
+    dependsOn:							    dependsOn:
+    - coredns							    - coredns
+  - name: observability-policies				  - name: observability-policies
+    version: 0.0.1						    version: 0.0.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
+    version: 0.4.2						    version: 0.4.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: security-bundle					  - name: security-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 1.8.2						    version: 1.8.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: teleport-kube-agent					  - name: teleport-kube-agent
+    version: 0.10.3						    version: 0.10.3
+  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
+    version: 5.3.0						    version: 5.3.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1						    version: 3.1.1
+  components:							  components:
+  - name: cluster-vsphere					  - name: cluster-vsphere
+    catalog: cluster						    catalog: cluster
+    version: 0.65.2					      |	    version: 0.66.0
+  - name: flatcar						  - name: flatcar
+    version: 3975.2.2						    version: 3975.2.2
+  - name: kubernetes						  - name: kubernetes
+    version: 1.29.10						    version: 1.29.10
+  - name: os-tooling						  - name: os-tooling
+    version: 1.20.1						    version: 1.20.1
+  date: "2024-10-23T12:00:00Z"				      |	  date: "2024-11-14T12:00:00Z"
+  state: active							  state: active

--- a/vsphere/v29.0.1/release.yaml
+++ b/vsphere/v29.0.1/release.yaml
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-29.0.1
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.2
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 1.11.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.22.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.6.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 0.66.0
+  - name: flatcar
+    version: 3975.2.2
+  - name: kubernetes
+    version: 1.29.10
+  - name: os-tooling
+    version: 1.20.1
+  date: "2024-11-14T12:00:00Z"
+  state: active


### PR DESCRIPTION
This is a patch release to address further issues with vsphere clusters not coming up on kubernetes 1.29+ (see https://github.com/giantswarm/cluster-vsphere/pull/311)

<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

I will do this manually.
