### PR TITLE
CAPI: Request `coredns` v1.23.0.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -7,6 +7,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.4.0"
+  requests:
+  - name: coredns
+    version: ">= 1.23.0"
 - name: ">= 29.3.0"
   requests:
   - name: observability-bundle

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -7,6 +7,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.5.0"
+  requests:
+  - name: coredns
+    version: ">= 1.23.0"
 - name: ">= 29.4.0"
   requests:
   - name: observability-bundle

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -7,6 +7,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.2.0"
+  requests:
+  - name: coredns
+    version: ">= 1.23.0"
 - name: ">= 29.1.0"
   requests:
   - name: observability-bundle

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -7,6 +7,10 @@ releases:
   requests:
   - name: cilium
     version: "< 0.26.0"
+- name: ">= 29.2.0"
+  requests:
+  - name: coredns
+    version: ">= 1.23.0"
 - name: ">= 29.1.0"
   requests:
   - name: observability-bundle


### PR DESCRIPTION
Some background: We are currently in the process of releasing CAPA v29.4.0 and CAPZ v29.3.0. CAPV v29.1.0 has been releases just today. To keep these three releases as much in sync as possible, we won't introduce CoreDNS v1.23.0 in CAPA v29.4.0 and CAPZ v29.3.0.

I therefore requested it to be introduced in CAPA v29.5.0, CAPZ v29.4.0 and CAPV v29.2.0 earliest.

For Cloud Director we do not have any v29.x.x releases yet. At best we release them with the same changes as the other providers and do not directly introduce the bump in Observability Bundle and CoreDNS together in a v29.0.0.