### PR TITLE
CAPV: Deprecate v29.0.0.

### DIFF
--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -30,7 +30,7 @@
     },
     {
       "version": "29.0.0",
-      "isDeprecated": false,
+      "isDeprecated": true,
       "releaseTimestamp": "2024-10-23 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.0.0/README.md",
       "isStable": true

--- a/vsphere/v29.0.0/release.diff
+++ b/vsphere/v29.0.0/release.diff
@@ -101,4 +101,4 @@ spec:									spec:
   - name: os-tooling							  - name: os-tooling
     version: 1.20.1							    version: 1.20.1
   date: "2024-10-23T12:00:00Z"						  date: "2024-10-23T12:00:00Z"
-  state: active								  state: active
+  state: active							|         state: deprecated

--- a/vsphere/v29.0.0/release.yaml
+++ b/vsphere/v29.0.0/release.yaml
@@ -101,4 +101,4 @@ spec:
   - name: os-tooling
     version: 1.20.1
   date: "2024-10-23T12:00:00Z"
-  state: active
+  state: deprecated


### PR DESCRIPTION
vsphere v29.0.0 should not be used (see https://github.com/giantswarm/cluster-vsphere/pull/311)

