### PR TITLE
CAPI: Fix missing field for release version.

### DIFF
--- a/azure/v25.0.0/README.md
+++ b/azure/v25.0.0/README.md
@@ -6,7 +6,7 @@ We are happy to announce the first release for Azure that uses the new release f
 
 In order to consume the new flow, the following two fields need to be manually adapted:
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `25.0.0`.
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release.version` to the release version, e.g. `25.0.0`.
 * In App `<cluster name>` remove the `spec.version` field. In case of GitOps, Flux might complain that the app manifest is invalid as the `spec.version` field is mandatory. In that case, edit the live App CR and set `spec.version` to an empty string. That will unblock Flux and allow it reconcile successfully.
 
 And if you want to use `kubectl-gs` to create a cluster, you'd need to now specify the release version, e.g.:

--- a/cloud-director/v27.0.0/README.md
+++ b/cloud-director/v27.0.0/README.md
@@ -6,11 +6,11 @@ We are happy to announce the first release for VMware Cloud Director that uses t
 
 In order to consume the new flow, the following two fields need to be manually adapted:
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `27.0.0`.
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release.version` to the release version, e.g. `27.0.0`.
 * In App `<cluster name>` remove the `spec.version` field. In case of GitOps, Flux might complain that the app manifest is invalid as the `spec.version` field is mandatory. In that case, edit the live App CR and set `spec.version` to an empty string. That will unblock Flux and allow it reconcile successfully.
 
 And if you want to use `kubectl-gs` to create a cluster, you'd need to now specify the release version, e.g.:
 
 ```bash
-kubectl-gs template cluster --provider cloud-director --organization my_org --name cluster_name --release v27.0.0
+kubectl-gs template cluster --provider cloud-director --organization my_org --name cluster_name --release 27.0.0
 ```

--- a/vsphere/v27.0.0/README.md
+++ b/vsphere/v27.0.0/README.md
@@ -6,11 +6,11 @@ We are happy to announce the first release for vSphere that uses the new release
 
 In order to consume the new flow, the following two fields need to be manually adapted:
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `27.0.0`.
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release.version` to the release version, e.g. `27.0.0`.
 * In App `<cluster name>` remove the `spec.version` field. In case of GitOps, Flux might complain that the app manifest is invalid as the `spec.version` field is mandatory. In that case, edit the live App CR and set `spec.version` to an empty string. That will unblock Flux and allow it reconcile successfully.
 
 And if you want to use `kubectl-gs` to create a cluster, you'd need to now specify the release version, e.g.:
 
 ```bash
-kubectl-gs template cluster --provider vsphere --organization my_org --name cluster_name -vsphere-network-name network_name --release v27.0.0
+kubectl-gs template cluster --provider vsphere --organization my_org --name cluster_name -vsphere-network-name network_name --release 27.0.0
 ```

--- a/vsphere/v27.0.1/README.md
+++ b/vsphere/v27.0.1/README.md
@@ -6,11 +6,11 @@ We are happy to announce the first release for vSphere that uses the new release
 
 In order to consume the new flow, the following two fields need to be manually adapted:
 
-* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release` to the release version, e.g. `27.0.1`.
+* In ConfigMap `<cluster name>-userconfig` set `.Values.global.release.version` to the release version, e.g. `27.0.1`.
 * In App `<cluster name>` remove the `spec.version` field. In case of GitOps, Flux might complain that the app manifest is invalid as the `spec.version` field is mandatory. In that case, edit the live App CR and set `spec.version` to an empty string. That will unblock Flux and allow it reconcile successfully.
 
 And if you want to use `kubectl-gs` to create a cluster, you'd need to now specify the release version, e.g.:
 
 ```bash
-kubectl-gs template cluster --provider vsphere --organization my_org --name cluster_name -vsphere-network-name network_name --release v27.0.1
+kubectl-gs template cluster --provider vsphere --organization my_org --name cluster_name -vsphere-network-name network_name --release 27.0.1
 ```


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).