### PR TITLE
CRD: Print `state`.

### DIFF
--- a/sdk/api/v1alpha1/release.go
+++ b/sdk/api/v1alpha1/release.go
@@ -26,6 +26,7 @@ func (r ReleaseState) String() string {
 // +kubebuilder:printcolumn:name="Kubernetes version",type=string,JSONPath=`.spec.components[?(@.name=="kubernetes")].version`,description="Kubernetes version in this release"
 // +kubebuilder:printcolumn:name="Flatcar version",type=string,JSONPath=`.spec.components[?(@.name=="flatcar")].version`,description="Flatcar version in this release"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.spec.date`,description="Time since release creation"
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.spec.state`,description="State of this release"
 // +kubebuilder:printcolumn:name="Release notes",type=string,JSONPath=`.metadata.annotations['giantswarm\.io/release-notes']`,priority=1,description="Release notes for this release"
 // +kubebuilder:resource:scope=Cluster,categories=common;giantswarm
 

--- a/sdk/config/crd/bases/release.giantswarm.io_releases.yaml
+++ b/sdk/config/crd/bases/release.giantswarm.io_releases.yaml
@@ -30,6 +30,10 @@ spec:
       jsonPath: .spec.date
       name: Age
       type: date
+    - description: State of this release
+      jsonPath: .spec.state
+      name: State
+      type: string
     - description: Release notes for this release
       jsonPath: .metadata.annotations['giantswarm\.io/release-notes']
       name: Release notes

--- a/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
+++ b/sdk/manifests/apiextensions.k8s.io_v1_customresourcedefinition_releases.release.giantswarm.io.yaml
@@ -29,6 +29,10 @@ spec:
       jsonPath: .spec.date
       name: Age
       type: date
+    - description: State of this release
+      jsonPath: .spec.state
+      name: State
+      type: string
     - description: Release notes for this release
       jsonPath: .metadata.annotations['giantswarm\.io/release-notes']
       name: Release notes


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3651.

```
NAME         KUBERNETES VERSION   FLATCAR VERSION   AGE    STATE        RELEASE NOTES
aws-25.0.0   1.25.16              3815.2.2          159d   deprecated   https://github.com/giantswarm/releases/tree/master/capa/v25.0.0
aws-25.1.0   1.25.16              3815.2.5          146d   deprecated   https://github.com/giantswarm/releases/tree/master/capa/v25.1.0
aws-25.1.1   1.25.16              3815.2.5          68d    deprecated   https://github.com/giantswarm/releases/tree/master/capa/v25.1.1
aws-25.1.2   1.25.16              3815.2.5          42d    deprecated   https://github.com/giantswarm/releases/tree/master/capa/v25.1.2
aws-25.2.0   1.25.16              3815.2.5          120d   active       https://github.com/giantswarm/releases/tree/master/capa/v25.2.0
aws-25.2.1   1.25.16              3815.2.5          68d    active       https://github.com/giantswarm/releases/tree/master/capa/v25.2.1
aws-25.3.0   1.25.16              3815.2.5          42d    active       https://github.com/giantswarm/releases/tree/master/capa/v25.3.0
aws-26.1.0   1.26.15              3815.2.5          120d   active       https://github.com/giantswarm/releases/tree/master/capa/v26.1.0
aws-26.1.1   1.26.15              3815.2.5          68d    active       https://github.com/giantswarm/releases/tree/master/capa/v26.1.1
aws-26.2.0   1.26.15              3815.2.5          42d    active       https://github.com/giantswarm/releases/tree/master/capa/v26.2.0
aws-27.1.0   1.27.14              3815.2.5          120d   active       https://github.com/giantswarm/releases/tree/master/capa/v27.1.0
aws-27.1.1   1.27.14              3815.2.5          68d    active       https://github.com/giantswarm/releases/tree/master/capa/v27.1.1
aws-27.2.0   1.27.16              3815.2.5          57d    active       https://github.com/giantswarm/releases/tree/master/capa/v27.2.0
aws-27.3.0   1.27.16              3815.2.5          42d    active       https://github.com/giantswarm/releases/tree/master/capa/v27.3.0
aws-28.1.1   1.28.11              3815.2.5          92d    active       https://github.com/giantswarm/releases/tree/master/capa/v28.1.1
aws-28.1.2   1.28.11              3815.2.5          68d    active       https://github.com/giantswarm/releases/tree/master/capa/v28.1.2
aws-28.2.0   1.28.14              3815.2.5          57d    active       https://github.com/giantswarm/releases/tree/master/capa/v28.2.0
aws-28.3.0   1.28.14              3815.2.5          42d    active       https://github.com/giantswarm/releases/tree/master/capa/v28.3.0
aws-29.1.0   1.29.8               3975.2.0          92d    deprecated   https://github.com/giantswarm/releases/tree/master/capa/v29.1.0
aws-29.2.0   1.29.9               3975.2.1          63d    deprecated   https://github.com/giantswarm/releases/tree/master/capa/v29.2.0
aws-29.3.0   1.29.9               3975.2.1          57d    active       https://github.com/giantswarm/releases/tree/master/capa/v29.3.0
aws-29.4.0   1.29.10              3975.2.2          13d    active       https://github.com/giantswarm/releases/tree/master/capa/v29.4.0
```