### PR TITLE
CAPZ: Release v29.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ to all Giant Swarm installations.
 ## Azure
 
 - v29
+  - v29.4
+    - [v29.4.0](https://github.com/giantswarm/releases/tree/master/azure/v29.4.0)
   - v29.3
     - [v29.3.0](https://github.com/giantswarm/releases/tree/master/azure/v29.3.0)
   - v29.2

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - v29.1.0
 - v29.2.0
 - v29.3.0
+- v29.4.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/azure/releases.json
+++ b/azure/releases.json
@@ -55,6 +55,13 @@
       "releaseTimestamp": "2024-11-13 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v29.3.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.4.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2024-12-12 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v29.4.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/azure/v29.4.0/README.md
+++ b/azure/v29.4.0/README.md
@@ -1,0 +1,60 @@
+# :zap: Giant Swarm Release v29.4.0 for Azure :zap:
+
+## Changes compared to v29.3.0
+
+### Components
+
+- cluster-azure from v1.4.0 to v1.5.0
+- Kubernetes from v1.29.10 to [v1.29.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#changelog-since-v12910)
+
+### cluster-azure [v1.4.0...v1.5.0](https://github.com/giantswarm/cluster-azure/compare/v1.4.0...v1.5.0)
+
+#### Changed
+
+- Chart: Update `cluster` to [v1.7.0](https://github.com/giantswarm/cluster/releases/tag/v1.7.0).
+  - Add `teleport-init` systemd unit to handle initial token setup before `teleport` service starts
+  - Improve `teleport` service reliability by adding proper file and service dependencies and pre-start checks
+
+### Apps
+
+- cert-manager from v3.8.1 to v3.8.2
+- coredns from v1.22.0 to v1.23.0
+- observability-bundle from v1.8.0 to v1.9.0
+
+### cert-manager [v3.8.1...v3.8.2](https://github.com/giantswarm/cert-manager-app/compare/v3.8.1...v3.8.2)
+
+#### Changed
+
+- Changed ownership to team Shield
+
+#### Removed
+
+- Get rid of label `giantswarm.io/monitoring_basic_sli` as this slo generation label is not used anymore.
+
+### coredns [v1.22.0...v1.23.0](https://github.com/giantswarm/coredns-app/compare/v1.22.0...v1.23.0)
+
+#### Changed
+
+- Update `coredns` image to [1.11.4](https://github.com/coredns/coredns/releases/tag/v1.11.4).
+- Explicitly expose liveness and readiness probe ports in deployments.
+
+#### Removed
+
+- Remove PodSecurityPolicy and associated Resources and values.
+
+### observability-bundle [v1.8.0...v1.9.0](https://github.com/giantswarm/observability-bundle/compare/v1.8.0...v1.9.0)
+
+#### Added
+
+- Add `alloy` v0.7.0 as `alloyEvents`.
+
+#### Changed
+
+- Upgrade `alloy-logs` and `alloy-metrics` to chart 0.7.0.
+  - Bumps `alloy` from 1.4.2 to 1.5.0
+- upgrade `kube-prometheus-stack` from 65.1.1 to 66.2.1
+  - prometheus-operator CRDs from 0.75.0 to 0.78.1
+  - prometheus-operator from 0.77.1 to 0.78.1
+  - prometheus from 2.54.1 to 2.55.1
+  - kube-state-metrics from 2.13.0 to 2.14.0
+  - grafana from 8.5.0 to 8.6.0

--- a/azure/v29.4.0/announcement.md
+++ b/azure/v29.4.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.4.0 for Azure is available**. This release updates Kubernetes to v1.29.12 and several apps and components to their latest minor releases.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-azure/releases/azure-29.4.0).

--- a/azure/v29.4.0/kustomization.yaml
+++ b/azure/v29.4.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v29.4.0/release.diff
+++ b/azure/v29.4.0/release.diff
@@ -1,0 +1,118 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: azure-29.3.0						|         name: azure-29.4.0
+spec:									spec:
+  apps:									  apps:
+  - name: azure-cloud-controller-manager				  - name: azure-cloud-controller-manager
+    version: 1.29.8-gs1							    version: 1.29.8-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager					  - name: azure-cloud-node-manager
+    version: 1.29.8-gs1							    version: 1.29.8-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver						  - name: azuredisk-csi-driver
+    version: 1.30.2-gs2							    version: 1.30.2-gs2
+    dependsOn:								    dependsOn:
+    - azure-cloud-controller-manager					    - azure-cloud-controller-manager
+    - azure-cloud-node-manager						    - azure-cloud-node-manager
+  - name: azurefile-csi-driver						  - name: azurefile-csi-driver
+    version: 1.30.2-gs1							    version: 1.30.2-gs1
+    dependsOn:								    dependsOn:
+    - azure-cloud-controller-manager					    - azure-cloud-controller-manager
+    - azure-cloud-node-manager						    - azure-cloud-node-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.3							    version: 2.9.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.1						|           version: 3.8.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: coredns							  - name: coredns
+    version: 1.22.0						|           version: 1.23.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.0							    version: 1.20.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.8.0						|           version: 1.9.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2							    version: 0.4.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.8.2							    version: 1.8.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.3							    version: 0.10.3
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.3.0							    version: 5.3.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1							    version: 3.1.1
+  components:								  components:
+  - name: cluster-azure							  - name: cluster-azure
+    catalog: cluster							    catalog: cluster
+    version: 1.4.0						|           version: 1.5.0
+  - name: flatcar							  - name: flatcar
+    version: 3975.2.2							    version: 3975.2.2
+  - name: kubernetes							  - name: kubernetes
+    version: 1.29.10						|           version: 1.29.12
+  - name: os-tooling							  - name: os-tooling
+    version: 1.20.1						|           version: 1.21.1
+  date: "2024-11-13T12:00:00Z"					|         date: "2024-12-12T12:00:00Z"
+  state: active								  state: active

--- a/azure/v29.4.0/release.yaml
+++ b/azure/v29.4.0/release.yaml
@@ -1,0 +1,118 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: azure-29.4.0
+spec:
+  apps:
+  - name: azure-cloud-controller-manager
+    version: 1.29.8-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager
+    version: 1.29.8-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver
+    version: 1.30.2-gs2
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: azurefile-csi-driver
+    version: 1.30.2-gs1
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.3
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: coredns
+    version: 1.23.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.9.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.4.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1
+  components:
+  - name: cluster-azure
+    catalog: cluster
+    version: 1.5.0
+  - name: flatcar
+    version: 3975.2.2
+  - name: kubernetes
+    version: 1.29.12
+  - name: os-tooling
+    version: 1.21.1
+  date: "2024-12-12T12:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
