### PR TITLE
CAPA: Release v28.5.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ to all Giant Swarm installations.
     - [v29.0.0](https://github.com/giantswarm/releases/tree/master/capa/archived/v29.0.0)
 
 - v28
+  - v28.5
+    - [v28.5.0](https://github.com/giantswarm/releases/tree/master/capa/v28.5.0)
   - v28.4
     - [v28.4.0](https://github.com/giantswarm/releases/tree/master/capa/v28.4.0)
   - v28.3

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,3 +1,5 @@
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v25.0.0
 - v25.1.0
@@ -22,15 +24,12 @@ resources:
 - v28.2.0
 - v28.3.0
 - v28.4.0
+- v28.5.0
 - v29.1.0
 - v29.2.0
 - v29.3.0
 - v29.4.0
 - v29.5.0
-
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-
 transformers:
 - |
   apiVersion: builtin

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,5 +1,3 @@
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v25.0.0
 - v25.1.0
@@ -30,6 +28,10 @@ resources:
 - v29.3.0
 - v29.4.0
 - v29.5.0
+
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
+
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -164,7 +164,7 @@
     {
       "version": "28.5.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-01-23T17:35:31+01:00",
+      "releaseTimestamp": "2025-01-27T17:14:16+01:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v28.5.0/README.md",
       "isStable": true
     },

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -162,6 +162,13 @@
       "isStable": true
     },
     {
+      "version": "28.5.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-01-23T17:35:31+01:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v28.5.0/README.md",
+      "isStable": true
+    },
+    {
       "version": "29.1.0",
       "isDeprecated": true,
       "releaseTimestamp": "2024-08-26 12:00:00 +0000 UTC",

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -164,8 +164,8 @@
     {
       "version": "28.5.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-01-27T17:14:16+01:00",
-      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v28.5.0/README.md",
+      "releaseTimestamp": "2025-01-27 18:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.5.0/README.md",
       "isStable": true
     },
     {

--- a/capa/v28.5.0/README.md
+++ b/capa/v28.5.0/README.md
@@ -8,6 +8,27 @@
 
 
 
+* cluster-aws from 1.3.5 to [1.3.6](https://github.com/giantswarm/cluster-aws/compare/v1.3.5...v1.3.6)
+
+
+
+
+
+
+### cluster-aws [1.3.6](https://github.com/giantswarm/cluster-aws/compare/v1.3.5...v1.3.6)
+
+#### Changed
+
+- Chart: Reduce default etcd volume size to 50 GB.
+- Explicitly set Ignition user data storage type to S3 bucket objects for machine pools
+- Use reduced IAM permissions on worker nodes instance profile. This can be toggled back with `global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers`.
+
+#### Fixed
+
+- Explicitly set aws-node-termination-handler queue region so crash-loops are avoided, allowing faster startup
+
+
+
 
 
 ### Apps

--- a/capa/v28.5.0/README.md
+++ b/capa/v28.5.0/README.md
@@ -1,5 +1,7 @@
 # :zap: Giant Swarm Release v28.5.0 for CAPA :zap:
 
+Most notable change in this release is the reduction of IAM permissions on the worker nodes instance profile, aiming at improving the general security of the clusters. Additional changes include reducing the size of the ETCD volume to 50GB targetting costs saving initiatives, as well as improvements for the `node-termination-handler` application for smoother upgrades and operations.
+
 ## Changes compared to v28.4.0
 
 ### Components

--- a/capa/v28.5.0/README.md
+++ b/capa/v28.5.0/README.md
@@ -1,21 +1,12 @@
 # :zap: Giant Swarm Release v28.5.0 for CAPA :zap:
 
-<< Add description here >>
-
 ## Changes compared to v28.4.0
 
 ### Components
 
+- cluster-aws from v1.3.5 to v1.3.6
 
-
-* cluster-aws from 1.3.5 to [1.3.6](https://github.com/giantswarm/cluster-aws/compare/v1.3.5...v1.3.6)
-
-
-
-
-
-
-### cluster-aws [1.3.6](https://github.com/giantswarm/cluster-aws/compare/v1.3.5...v1.3.6)
+### cluster-aws [v1.3.5...v1.3.6](https://github.com/giantswarm/cluster-aws/compare/v1.3.5...v1.3.6)
 
 #### Changed
 
@@ -27,26 +18,12 @@
 
 - Explicitly set aws-node-termination-handler queue region so crash-loops are avoided, allowing faster startup
 
-
-
-
-
 ### Apps
 
+- aws-nth-bundle from v1.2.0 to v1.2.1
 
-
-* aws-nth-bundle from 1.2.0 to [1.2.1](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.0...v1.2.1)
-
-
-
-
-
-### aws-nth-bundle [1.2.1](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.0...v1.2.1)
+### aws-nth-bundle [v1.2.0...v1.2.1](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.0...v1.2.1)
 
 #### Added
 
 - Forward proxy settings to `aws-node-termination-handler-app` as environment variables
-
-
-
-

--- a/capa/v28.5.0/README.md
+++ b/capa/v28.5.0/README.md
@@ -1,0 +1,31 @@
+# :zap: Giant Swarm Release v28.5.0 for CAPA :zap:
+
+<< Add description here >>
+
+## Changes compared to v28.4.0
+
+### Components
+
+
+
+
+
+### Apps
+
+
+
+* aws-nth-bundle from 1.2.0 to [1.2.1](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.0...v1.2.1)
+
+
+
+
+
+### aws-nth-bundle [1.2.1](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.0...v1.2.1)
+
+#### Added
+
+- Forward proxy settings to `aws-node-termination-handler-app` as environment variables
+
+
+
+

--- a/capa/v28.5.0/announcement.md
+++ b/capa/v28.5.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v28.5.0 for CAPA is available**. << Add description here >> 
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-28.5.0).

--- a/capa/v28.5.0/announcement.md
+++ b/capa/v28.5.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v28.5.0 for CAPA is available**.
+**Workload cluster release v28.5.0 for CAPA is available**. This release reduces IAM permissions on the worker nodes instance profile, aiming at improving the general security of the clusters. Additional changes include reducing the size of the ETCD volume to 50GB targetting costs saving initiatives, as well as improvements for the `node-termination-handler` application for smoother upgrades and operations.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-28.5.0).

--- a/capa/v28.5.0/announcement.md
+++ b/capa/v28.5.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v28.5.0 for CAPA is available**. << Add description here >> 
+**Workload cluster release v28.5.0 for CAPA is available**.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-28.5.0).

--- a/capa/v28.5.0/kustomization.yaml
+++ b/capa/v28.5.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v28.5.0/release.diff
+++ b/capa/v28.5.0/release.diff
@@ -140,14 +140,14 @@ spec:                                                              spec:
   components:                                                        components:
   - name: cluster-aws                                           |    - catalog: cluster
     catalog: cluster                                            |      name: cluster-aws
-    version: 1.3.5                                                     version: 1.3.5
+    version: 1.3.5                                              |      version: 1.3.6
   - name: flatcar                                                    - name: flatcar
     version: 3815.2.5                                                  version: 3815.2.5
   - name: kubernetes                                                 - name: kubernetes
     version: 1.28.14                                                   version: 1.28.14
   - name: os-tooling                                                 - name: os-tooling
     version: 1.20.1                                                    version: 1.20.1
-  date: "2024-12-12T12:00:00Z"                                  |    date: "2025-01-23T16:35:31Z"
+  date: "2024-12-12T12:00:00Z"                                  |    date: "2025-01-27T16:14:16Z"
   state: active                                                      state: active
                                                                 >  status:
                                                                 >    inUse: false

--- a/capa/v28.5.0/release.diff
+++ b/capa/v28.5.0/release.diff
@@ -1,154 +1,124 @@
-                                                                >  # Generated with:
-                                                                >  # devctl release create --provider aws --name 28.5.0 --base 28.
-apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
-kind: Release                                                      kind: Release
-metadata:                                                          metadata:
-  name: aws-28.4.0                                              |    creationTimestamp: null
-                                                                >    name: aws-28.5.0
-spec:                                                              spec:
-  apps:                                                              apps:
-  - name: aws-ebs-csi-driver                                    |    - dependsOn:
-    version: 2.30.1                                             <  
-    dependsOn:                                                  <  
-    - cloud-provider-aws                                               - cloud-provider-aws
-  - name: aws-ebs-csi-driver-servicemonitors                    |      name: aws-ebs-csi-driver
-    version: 0.1.0                                              |      version: 2.30.1
-    dependsOn:                                                  |    - dependsOn:
-    - cert-manager                                                     - cert-manager
-                                                                >      name: aws-ebs-csi-driver-servicemonitors
-                                                                >      version: 0.1.0
-  - name: aws-nth-bundle                                             - name: aws-nth-bundle
-    version: 1.2.0                                              |      version: 1.2.1
-  - name: aws-pod-identity-webhook                              |    - dependsOn:
-    version: 1.16.0                                             <  
-    dependsOn:                                                  <  
-    - cert-manager                                                     - cert-manager
-                                                                >      name: aws-pod-identity-webhook
-                                                                >      version: 1.16.0
-  - name: capi-node-labeler                                          - name: capi-node-labeler
-    version: 0.5.0                                                     version: 0.5.0
-  - name: cert-exporter                                         |    - dependsOn:
-    version: 2.9.3                                              <  
-    dependsOn:                                                  <  
-    - kyverno                                                          - kyverno
-  - name: cert-manager                                          |      name: cert-exporter
-                                                                >      version: 2.9.3
-                                                                >    - dependsOn:
-                                                                >      - prometheus-operator-crd
-                                                                >      name: cert-manager
-    version: 3.7.9                                                     version: 3.7.9
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: chart-operator-extensions                             |      name: chart-operator-extensions
-    version: 1.1.2                                                     version: 1.1.2
-    dependsOn:                                                  <  
-    - prometheus-operator-crd                                   <  
-  - name: cilium                                                     - name: cilium
-    version: 0.25.1                                                    version: 0.25.1
-  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
-    version: 0.1.0                                                     version: 0.1.0
-  - name: cilium-servicemonitors                                |    - dependsOn:
-    version: 0.1.2                                              <  
-    dependsOn:                                                  <  
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: cloud-provider-aws                                    |      name: cilium-servicemonitors
-    version: 1.28.6-gs1                                         |      version: 0.1.2
-    dependsOn:                                                  |    - dependsOn:
-    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - name: cluster-autoscaler                                    |      name: cloud-provider-aws
-    version: 1.28.5-gs1                                         |      version: 1.28.6-gs1
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno                                                          - kyverno
-  - name: coredns                                               |      name: cluster-autoscaler
-    version: 1.21.0                                             |      version: 1.28.5-gs1
-    dependsOn:                                                  |    - dependsOn:
-    - cilium                                                           - cilium
-  - name: etcd-k8s-res-count-exporter                           |      name: coredns
-    version: 1.10.0                                             |      version: 1.21.0
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno                                                          - kyverno
-  - name: external-dns                                          |      name: etcd-k8s-res-count-exporter
-    version: 3.1.0                                              |      version: 1.10.0
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: irsa-servicemonitors                                  |      name: external-dns
-    version: 0.0.1                                              |      version: 3.1.0
-    dependsOn:                                                  |    - dependsOn:
-    - cert-manager                                                     - cert-manager
-  - name: k8s-audit-metrics                                     |      name: irsa-servicemonitors
-                                                                >      version: 0.0.1
-                                                                >    - dependsOn:
-                                                                >      - kyverno
-                                                                >      name: k8s-audit-metrics
-    version: 0.9.0                                                     version: 0.9.0
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno                                                          - kyverno
-  - name: k8s-dns-node-cache                                    |      name: k8s-dns-node-cache
-    version: 2.6.2                                                     version: 2.6.2
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno                                                          - kyverno
-  - name: metrics-server                                        |      name: metrics-server
-    version: 2.4.2                                                     version: 2.4.2
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno                                                   <  
-  - name: net-exporter                                          <  
-    version: 1.19.0                                             <  
-    dependsOn:                                                  <  
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: network-policies                                      |      name: net-exporter
-    version: 0.1.1                                              <  
-    catalog: cluster                                            <  
-    dependsOn:                                                  <  
-    - cilium                                                    <  
-  - name: node-exporter                                         <  
-    version: 1.19.0                                                    version: 1.19.0
-                                                                >    - catalog: cluster
-    dependsOn:                                                         dependsOn:
-                                                                >      - cilium
-                                                                >      name: network-policies
-                                                                >      version: 0.1.1
-                                                                >    - dependsOn:
-    - kyverno                                                          - kyverno
-  - name: observability-bundle                                  |      name: node-exporter
-    version: 1.3.4                                              |      version: 1.19.0
-    dependsOn:                                                  |    - dependsOn:
-    - coredns                                                          - coredns
-  - name: prometheus-blackbox-exporter                          |      name: observability-bundle
-                                                                >      version: 1.3.4
-                                                                >    - dependsOn:
-                                                                >      - prometheus-operator-crd
-                                                                >      name: prometheus-blackbox-exporter
-    version: 0.4.1                                                     version: 0.4.1
-                                                                >    - catalog: giantswarm
-    dependsOn:                                                         dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: security-bundle                                       |      name: security-bundle
-    version: 1.7.2                                                     version: 1.7.2
-    catalog: giantswarm                                         <  
-    dependsOn:                                                  <  
-    - prometheus-operator-crd                                   <  
-  - name: teleport-kube-agent                                        - name: teleport-kube-agent
-    version: 0.9.0                                                     version: 0.9.0
-  - name: vertical-pod-autoscaler                               |    - dependsOn:
-    version: 5.2.2                                              <  
-    dependsOn:                                                  <  
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-                                                                >      name: vertical-pod-autoscaler
-                                                                >      version: 5.2.2
-  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
-    version: 3.1.0                                                     version: 3.1.0
-  components:                                                        components:
-  - name: cluster-aws                                           |    - catalog: cluster
-    catalog: cluster                                            |      name: cluster-aws
-    version: 1.3.5                                              |      version: 1.3.6
-  - name: flatcar                                                    - name: flatcar
-    version: 3815.2.5                                                  version: 3815.2.5
-  - name: kubernetes                                                 - name: kubernetes
-    version: 1.28.14                                                   version: 1.28.14
-  - name: os-tooling                                                 - name: os-tooling
-    version: 1.20.1                                                    version: 1.20.1
-  date: "2024-12-12T12:00:00Z"                                  |    date: "2025-01-27T16:14:16Z"
-  state: active                                                      state: active
-                                                                >  status:
-                                                                >    inUse: false
-                                                                >    ready: false
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-28.4.0						|         name: aws-28.5.0
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 2.30.1							    version: 2.30.1
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: aws-nth-bundle						  - name: aws-nth-bundle
+    version: 1.2.0						|           version: 1.2.1
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.16.0							    version: 1.16.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.3							    version: 2.9.3
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: cert-manager							  - name: cert-manager
+    version: 3.7.9							    version: 3.7.9
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1							    version: 0.25.1
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    version: 0.1.0							    version: 0.1.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.28.6-gs1							    version: 1.28.6-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.28.5-gs1							    version: 1.28.5-gs1
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: coredns							  - name: coredns
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.9.0							    version: 0.9.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.6.2							    version: 2.6.2
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: net-exporter							  - name: net-exporter
+    version: 1.19.0							    version: 1.19.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    version: 0.1.1							    version: 0.1.1
+    catalog: cluster							    catalog: cluster
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.19.0							    version: 1.19.0
+    dependsOn:								    dependsOn:
+    - kyverno								    - kyverno
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.3.4							    version: 1.3.4
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.1							    version: 0.4.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    version: 1.7.2							    version: 1.7.2
+    catalog: giantswarm							    catalog: giantswarm
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.9.0							    version: 0.9.0
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.2.2							    version: 5.2.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0							    version: 3.1.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 1.3.5						|           version: 1.3.6
+  - name: flatcar							  - name: flatcar
+    version: 3815.2.5							    version: 3815.2.5
+  - name: kubernetes							  - name: kubernetes
+    version: 1.28.14							    version: 1.28.14
+  - name: os-tooling							  - name: os-tooling
+    version: 1.20.1							    version: 1.20.1
+  date: "2024-12-12T12:00:00Z"					|         date: "2025-01-27T18:00:00Z"
+  state: active								  state: active

--- a/capa/v28.5.0/release.diff
+++ b/capa/v28.5.0/release.diff
@@ -1,0 +1,154 @@
+                                                                >  # Generated with:
+                                                                >  # devctl release create --provider aws --name 28.5.0 --base 28.
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-28.4.0                                              |    creationTimestamp: null
+                                                                >    name: aws-28.5.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                    |    - dependsOn:
+    version: 2.30.1                                             <  
+    dependsOn:                                                  <  
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                    |      name: aws-ebs-csi-driver
+    version: 0.1.0                                              |      version: 2.30.1
+    dependsOn:                                                  |    - dependsOn:
+    - cert-manager                                                     - cert-manager
+                                                                >      name: aws-ebs-csi-driver-servicemonitors
+                                                                >      version: 0.1.0
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.2.0                                              |      version: 1.2.1
+  - name: aws-pod-identity-webhook                              |    - dependsOn:
+    version: 1.16.0                                             <  
+    dependsOn:                                                  <  
+    - cert-manager                                                     - cert-manager
+                                                                >      name: aws-pod-identity-webhook
+                                                                >      version: 1.16.0
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 0.5.0                                                     version: 0.5.0
+  - name: cert-exporter                                         |    - dependsOn:
+    version: 2.9.3                                              <  
+    dependsOn:                                                  <  
+    - kyverno                                                          - kyverno
+  - name: cert-manager                                          |      name: cert-exporter
+                                                                >      version: 2.9.3
+                                                                >    - dependsOn:
+                                                                >      - prometheus-operator-crd
+                                                                >      name: cert-manager
+    version: 3.7.9                                                     version: 3.7.9
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                             |      name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                  <  
+    - prometheus-operator-crd                                   <  
+  - name: cilium                                                     - name: cilium
+    version: 0.25.1                                                    version: 0.25.1
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    version: 0.1.0                                                     version: 0.1.0
+  - name: cilium-servicemonitors                                |    - dependsOn:
+    version: 0.1.2                                              <  
+    dependsOn:                                                  <  
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                    |      name: cilium-servicemonitors
+    version: 1.28.6-gs1                                         |      version: 0.1.2
+    dependsOn:                                                  |    - dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                    |      name: cloud-provider-aws
+    version: 1.28.5-gs1                                         |      version: 1.28.6-gs1
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno                                                          - kyverno
+  - name: coredns                                               |      name: cluster-autoscaler
+    version: 1.21.0                                             |      version: 1.28.5-gs1
+    dependsOn:                                                  |    - dependsOn:
+    - cilium                                                           - cilium
+  - name: etcd-k8s-res-count-exporter                           |      name: coredns
+    version: 1.10.0                                             |      version: 1.21.0
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno                                                          - kyverno
+  - name: external-dns                                          |      name: etcd-k8s-res-count-exporter
+    version: 3.1.0                                              |      version: 1.10.0
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                  |      name: external-dns
+    version: 0.0.1                                              |      version: 3.1.0
+    dependsOn:                                                  |    - dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: k8s-audit-metrics                                     |      name: irsa-servicemonitors
+                                                                >      version: 0.0.1
+                                                                >    - dependsOn:
+                                                                >      - kyverno
+                                                                >      name: k8s-audit-metrics
+    version: 0.9.0                                                     version: 0.9.0
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno                                                          - kyverno
+  - name: k8s-dns-node-cache                                    |      name: k8s-dns-node-cache
+    version: 2.6.2                                                     version: 2.6.2
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno                                                          - kyverno
+  - name: metrics-server                                        |      name: metrics-server
+    version: 2.4.2                                                     version: 2.4.2
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno                                                   <  
+  - name: net-exporter                                          <  
+    version: 1.19.0                                             <  
+    dependsOn:                                                  <  
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                      |      name: net-exporter
+    version: 0.1.1                                              <  
+    catalog: cluster                                            <  
+    dependsOn:                                                  <  
+    - cilium                                                    <  
+  - name: node-exporter                                         <  
+    version: 1.19.0                                                    version: 1.19.0
+                                                                >    - catalog: cluster
+    dependsOn:                                                         dependsOn:
+                                                                >      - cilium
+                                                                >      name: network-policies
+                                                                >      version: 0.1.1
+                                                                >    - dependsOn:
+    - kyverno                                                          - kyverno
+  - name: observability-bundle                                  |      name: node-exporter
+    version: 1.3.4                                              |      version: 1.19.0
+    dependsOn:                                                  |    - dependsOn:
+    - coredns                                                          - coredns
+  - name: prometheus-blackbox-exporter                          |      name: observability-bundle
+                                                                >      version: 1.3.4
+                                                                >    - dependsOn:
+                                                                >      - prometheus-operator-crd
+                                                                >      name: prometheus-blackbox-exporter
+    version: 0.4.1                                                     version: 0.4.1
+                                                                >    - catalog: giantswarm
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                       |      name: security-bundle
+    version: 1.7.2                                                     version: 1.7.2
+    catalog: giantswarm                                         <  
+    dependsOn:                                                  <  
+    - prometheus-operator-crd                                   <  
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.9.0                                                     version: 0.9.0
+  - name: vertical-pod-autoscaler                               |    - dependsOn:
+    version: 5.2.2                                              <  
+    dependsOn:                                                  <  
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+                                                                >      name: vertical-pod-autoscaler
+                                                                >      version: 5.2.2
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.1.0                                                     version: 3.1.0
+  components:                                                        components:
+  - name: cluster-aws                                           |    - catalog: cluster
+    catalog: cluster                                            |      name: cluster-aws
+    version: 1.3.5                                                     version: 1.3.5
+  - name: flatcar                                                    - name: flatcar
+    version: 3815.2.5                                                  version: 3815.2.5
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.28.14                                                   version: 1.28.14
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.20.1                                                    version: 1.20.1
+  date: "2024-12-12T12:00:00Z"                                  |    date: "2025-01-23T16:35:31Z"
+  state: active                                                      state: active
+                                                                >  status:
+                                                                >    inUse: false
+                                                                >    ready: false

--- a/capa/v28.5.0/release.yaml
+++ b/capa/v28.5.0/release.yaml
@@ -1,121 +1,118 @@
-# Generated with:
-# devctl release create --provider aws --name 28.5.0 --base 28.4.0 --component cluster-aws@1.3.6 --app aws-nth-bundle@1.2.1 --app cert-exporter@2.9.3
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  creationTimestamp: null
   name: aws-28.5.0
 spec:
   apps:
-  - dependsOn:
-    - cloud-provider-aws
-    name: aws-ebs-csi-driver
+  - name: aws-ebs-csi-driver
     version: 2.30.1
-  - dependsOn:
-    - cert-manager
-    name: aws-ebs-csi-driver-servicemonitors
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
     version: 0.1.0
+    dependsOn:
+    - cert-manager
   - name: aws-nth-bundle
     version: 1.2.1
-  - dependsOn:
-    - cert-manager
-    name: aws-pod-identity-webhook
+  - name: aws-pod-identity-webhook
     version: 1.16.0
+    dependsOn:
+    - cert-manager
   - name: capi-node-labeler
     version: 0.5.0
-  - dependsOn:
-    - kyverno
-    name: cert-exporter
+  - name: cert-exporter
     version: 2.9.3
-  - dependsOn:
-    - prometheus-operator-crd
-    name: cert-manager
+    dependsOn:
+    - kyverno
+  - name: cert-manager
     version: 3.7.9
-  - dependsOn:
+    dependsOn:
     - prometheus-operator-crd
-    name: chart-operator-extensions
+  - name: chart-operator-extensions
     version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
   - name: cilium
     version: 0.25.1
   - name: cilium-crossplane-resources
     version: 0.1.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: cilium-servicemonitors
+  - name: cilium-servicemonitors
     version: 0.1.2
-  - dependsOn:
-    - vertical-pod-autoscaler-crd
-    name: cloud-provider-aws
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
     version: 1.28.6-gs1
-  - dependsOn:
-    - kyverno
-    name: cluster-autoscaler
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
     version: 1.28.5-gs1
-  - dependsOn:
-    - cilium
-    name: coredns
+    dependsOn:
+    - kyverno
+  - name: coredns
     version: 1.21.0
-  - dependsOn:
-    - kyverno
-    name: etcd-k8s-res-count-exporter
-    version: 1.10.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: external-dns
-    version: 3.1.0
-  - dependsOn:
-    - cert-manager
-    name: irsa-servicemonitors
-    version: 0.0.1
-  - dependsOn:
-    - kyverno
-    name: k8s-audit-metrics
-    version: 0.9.0
-  - dependsOn:
-    - kyverno
-    name: k8s-dns-node-cache
-    version: 2.6.2
-  - dependsOn:
-    - kyverno
-    name: metrics-server
-    version: 2.4.2
-  - dependsOn:
-    - prometheus-operator-crd
-    name: net-exporter
-    version: 1.19.0
-  - catalog: cluster
     dependsOn:
     - cilium
-    name: network-policies
-    version: 0.1.1
-  - dependsOn:
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
     - kyverno
-    name: node-exporter
-    version: 1.19.0
-  - dependsOn:
-    - coredns
-    name: observability-bundle
-    version: 1.3.4
-  - dependsOn:
-    - prometheus-operator-crd
-    name: prometheus-blackbox-exporter
-    version: 0.4.1
-  - catalog: giantswarm
+  - name: external-dns
+    version: 3.1.0
     dependsOn:
     - prometheus-operator-crd
-    name: security-bundle
+  - name: irsa-servicemonitors
+    version: 0.0.1
+    dependsOn:
+    - cert-manager
+  - name: k8s-audit-metrics
+    version: 0.9.0
+    dependsOn:
+    - kyverno
+  - name: k8s-dns-node-cache
+    version: 2.6.2
+    dependsOn:
+    - kyverno
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno
+  - name: net-exporter
+    version: 1.19.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    version: 0.1.1
+    catalog: cluster
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.19.0
+    dependsOn:
+    - kyverno
+  - name: observability-bundle
+    version: 1.3.4
+    dependsOn:
+    - coredns
+  - name: prometheus-blackbox-exporter
+    version: 0.4.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
     version: 1.7.2
+    catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
   - name: teleport-kube-agent
     version: 0.9.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: vertical-pod-autoscaler
+  - name: vertical-pod-autoscaler
     version: 5.2.2
+    dependsOn:
+    - prometheus-operator-crd
   - name: vertical-pod-autoscaler-crd
     version: 3.1.0
   components:
-  - catalog: cluster
-    name: cluster-aws
+  - name: cluster-aws
+    catalog: cluster
     version: 1.3.6
   - name: flatcar
     version: 3815.2.5
@@ -123,8 +120,5 @@ spec:
     version: 1.28.14
   - name: os-tooling
     version: 1.20.1
-  date: "2025-01-27T16:14:16Z"
+  date: "2025-01-27T18:00:00Z"
   state: active
-status:
-  inUse: false
-  ready: false

--- a/capa/v28.5.0/release.yaml
+++ b/capa/v28.5.0/release.yaml
@@ -1,0 +1,130 @@
+# Generated with:
+# devctl release create --provider aws --name 28.5.0 --base 28.4.0 --component cluster-aws@1.3.5 --app aws-nth-bundle@1.2.1 --app cert-exporter@2.9.3 # TODO fill in cluster-aws bumped version
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  creationTimestamp: null
+  name: aws-28.5.0
+spec:
+  apps:
+  - dependsOn:
+    - cloud-provider-aws
+    name: aws-ebs-csi-driver
+    version: 2.30.1
+  - dependsOn:
+    - cert-manager
+    name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+  - name: aws-nth-bundle
+    version: 1.2.1
+  - dependsOn:
+    - cert-manager
+    name: aws-pod-identity-webhook
+    version: 1.16.0
+  - name: capi-node-labeler
+    version: 0.5.0
+  - dependsOn:
+    - kyverno
+    name: cert-exporter
+    version: 2.9.3
+  - dependsOn:
+    - prometheus-operator-crd
+    name: cert-manager
+    version: 3.7.9
+  - dependsOn:
+    - prometheus-operator-crd
+    name: chart-operator-extensions
+    version: 1.1.2
+  - name: cilium
+    version: 0.25.1
+  - name: cilium-crossplane-resources
+    version: 0.1.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: cilium-servicemonitors
+    version: 0.1.2
+  - dependsOn:
+    - vertical-pod-autoscaler-crd
+    name: cloud-provider-aws
+    version: 1.28.6-gs1
+  - dependsOn:
+    - kyverno
+    name: cluster-autoscaler
+    version: 1.28.5-gs1
+  - dependsOn:
+    - cilium
+    name: coredns
+    version: 1.21.0
+  - dependsOn:
+    - kyverno
+    name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: external-dns
+    version: 3.1.0
+  - dependsOn:
+    - cert-manager
+    name: irsa-servicemonitors
+    version: 0.0.1
+  - dependsOn:
+    - kyverno
+    name: k8s-audit-metrics
+    version: 0.9.0
+  - dependsOn:
+    - kyverno
+    name: k8s-dns-node-cache
+    version: 2.6.2
+  - dependsOn:
+    - kyverno
+    name: metrics-server
+    version: 2.4.2
+  - dependsOn:
+    - prometheus-operator-crd
+    name: net-exporter
+    version: 1.19.0
+  - catalog: cluster
+    dependsOn:
+    - cilium
+    name: network-policies
+    version: 0.1.1
+  - dependsOn:
+    - kyverno
+    name: node-exporter
+    version: 1.19.0
+  - dependsOn:
+    - coredns
+    name: observability-bundle
+    version: 1.3.4
+  - dependsOn:
+    - prometheus-operator-crd
+    name: prometheus-blackbox-exporter
+    version: 0.4.1
+  - catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+    name: security-bundle
+    version: 1.7.2
+  - name: teleport-kube-agent
+    version: 0.9.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: vertical-pod-autoscaler
+    version: 5.2.2
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.0
+  components:
+  - catalog: cluster-test
+    name: cluster-aws
+    version: 1.3.5-29c29d6ec3aa1859114eef55e678fc884a61247e # TODO bump cluster-aws with https://github.com/giantswarm/cluster-aws/pull/1006
+  - name: flatcar
+    version: 3815.2.5
+  - name: kubernetes
+    version: 1.28.14
+  - name: os-tooling
+    version: 1.20.1
+  date: "2025-01-23T16:35:31Z"
+  state: active
+status:
+  inUse: false
+  ready: false

--- a/capa/v28.5.0/release.yaml
+++ b/capa/v28.5.0/release.yaml
@@ -1,5 +1,5 @@
 # Generated with:
-# devctl release create --provider aws --name 28.5.0 --base 28.4.0 --component cluster-aws@1.3.5 --app aws-nth-bundle@1.2.1 --app cert-exporter@2.9.3 # TODO fill in cluster-aws bumped version
+# devctl release create --provider aws --name 28.5.0 --base 28.4.0 --component cluster-aws@1.3.6 --app aws-nth-bundle@1.2.1 --app cert-exporter@2.9.3
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
@@ -114,16 +114,16 @@ spec:
   - name: vertical-pod-autoscaler-crd
     version: 3.1.0
   components:
-  - catalog: cluster-test
+  - catalog: cluster
     name: cluster-aws
-    version: 1.3.5-29c29d6ec3aa1859114eef55e678fc884a61247e # TODO bump cluster-aws with https://github.com/giantswarm/cluster-aws/pull/1006
+    version: 1.3.6
   - name: flatcar
     version: 3815.2.5
   - name: kubernetes
     version: 1.28.14
   - name: os-tooling
     version: 1.20.1
-  date: "2025-01-23T16:35:31Z"
+  date: "2025-01-27T16:14:16Z"
   state: active
 status:
   inUse: false


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

This brings backports as added to [CAPA v29.6.0](https://github.com/giantswarm/releases/pull/1550).

Towards https://github.com/giantswarm/roadmap/issues/3795, https://github.com/giantswarm/giantswarm/issues/32487, https://github.com/giantswarm/giantswarm/issues/32045

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version