### PR TITLE
CAPV: Release v29.3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ to all Giant Swarm installations.
 ## vSphere
 
 - v29
+  - v29.3
+    - [v29.3.0](https://github.com/giantswarm/releases/tree/master/vsphere/v29.3.0)
   - v29.2
     - [v29.2.0](https://github.com/giantswarm/releases/tree/master/vsphere/v29.2.0)
   - v29.1

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - v29.0.0
 - v29.1.0
 - v29.2.0
+- v29.3.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -48,6 +48,13 @@
       "releaseTimestamp": "2024-12-12 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.2.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.3.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-01-27 18:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v29.3.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v29.3.0/README.md
+++ b/vsphere/v29.3.0/README.md
@@ -1,0 +1,84 @@
+# :zap: Giant Swarm Release v29.3.0 for vSphere :zap:
+
+## Changes compared to v29.2.0
+
+### Components
+
+- cluster-vsphere from v0.68.0 to v0.68.1
+- Flatcar from v3975.2.2 to [v4081.2.1](https://www.flatcar.org/releases#release-4081.2.1)
+- Kubernetes from v1.29.12 to [v1.29.13](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#changelog-since-v12912)
+
+### cluster-vsphere [v0.68.0...v0.68.1](https://github.com/giantswarm/cluster-vsphere/compare/v0.68.0...v0.68.1)
+
+#### Added
+
+- Add `components.containerd` to the schema and values.
+
+#### Changed
+
+- Update example manifest.
+- Make cloud-provider-vsphere HelmRelease catalog configurable.
+- Update `kube-vip` to `0.8.9`.
+- Update `kube-vip` static pod manifest with CIDR.
+
+### Apps
+
+- cilium from v0.25.1 to v0.25.2
+- cloud-provider-vsphere from v1.11.0 to v1.12.0
+- prometheus-blackbox-exporter from v0.4.2 to v0.5.0
+- security-bundle from v1.8.2 to v1.9.1
+- vertical-pod-autoscaler from v5.3.0 to v5.3.1
+- vertical-pod-autoscaler-crd from v3.1.1 to v3.1.2
+
+### cilium [v0.25.1...v0.25.2](https://github.com/giantswarm/cilium-app/compare/v0.25.1...v0.25.2)
+
+#### Changed
+
+- Upgrade cilium to [v1.15.13](https://github.com/cilium/cilium/releases/tag/v1.15.13).
+
+### cloud-provider-vsphere [v1.11.0...v1.12.0](https://github.com/giantswarm/cloud-provider-vsphere-app/compare/v1.11.0...v1.12.0)
+
+#### Added
+
+- Add Renovate to track new tags.
+- Update `kube-vip` helm chart to `0.6.2`.
+- Update `kube-vip` to `0.8.4`.
+- Add initContainer to CSI node registrar container to wait for CRD to be registered.
+
+### prometheus-blackbox-exporter [v0.4.2...v0.5.0](https://github.com/giantswarm/prometheus-blackbox-exporter-app/compare/v0.4.2...v0.5.0)
+
+#### Changed
+
+- Harden security context to pass PSS compliance.
+
+#### Removed
+
+- Remove PSP resources.
+
+### security-bundle [v1.8.2...v1.9.1](https://github.com/giantswarm/security-bundle/compare/v1.8.2...v1.9.1)
+
+#### Breaking changes
+
+**Note:** When upgrading to this security-bundle version with Falco enabled, the Falco App will fail to upgrade due to a breaking change in the upstream chart. To finish the upgrade, disable, then re-enable the Falco App by setting `apps.falco.enabled=[false|true]` [in the security-bundle user values Config Map](https://github.com/giantswarm/security-bundle/tree/main?tab=readme-ov-file#configuring).
+
+#### Changed
+
+- Update `trivy-operator` (app) to v0.10.3.
+- Update `trivy` (app) to v0.13.1.
+- Update `kyverno` (app) to v0.18.1.
+- Update `kyverno-crds` (app) to v1.12.0.
+- Update `kyverno-policies` (app) to v0.21.0.
+- Update `starboard-exporter` (app) to v0.8.0.
+- Update `falco` (app) to v0.9.1.
+
+### vertical-pod-autoscaler [v5.3.0...v5.3.1](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.3.0...v5.3.1)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v9.9.1. ([#333](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/333))
+
+### vertical-pod-autoscaler-crd [v3.1.1...v3.1.2](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.1.1...v3.1.2)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#124](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/124))

--- a/vsphere/v29.3.0/announcement.md
+++ b/vsphere/v29.3.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.3.0 for vSphere is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-29.3.0).

--- a/vsphere/v29.3.0/kustomization.yaml
+++ b/vsphere/v29.3.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v29.3.0/release.diff
+++ b/vsphere/v29.3.0/release.diff
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: vsphere-29.2.0						|         name: vsphere-29.3.0
+spec:									spec:
+  apps:									  apps:
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0							    version: 0.5.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.3							    version: 2.9.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.2							    version: 3.8.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.1						|           version: 0.25.2
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-vsphere					  - name: cloud-provider-vsphere
+    version: 1.11.0						|           version: 1.12.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns							  - name: coredns
+    version: 1.23.0							    version: 1.23.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0							    version: 1.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0							    version: 0.10.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2							    version: 2.4.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.0							    version: 1.20.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.9.0							    version: 1.9.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.4.2						|           version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.8.2						|           version: 1.9.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.3							    version: 0.10.3
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.3.0						|           version: 5.3.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.1						|           version: 3.1.2
+  components:								  components:
+  - name: cluster-vsphere						  - name: cluster-vsphere
+    catalog: cluster							    catalog: cluster
+    version: 0.68.0						|           version: 0.68.1
+  - name: flatcar							  - name: flatcar
+    version: 3975.2.2						|           version: 4081.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.29.12						|           version: 1.29.13
+  - name: os-tooling							  - name: os-tooling
+    version: 1.21.1						|           version: 1.22.1
+  date: "2024-12-12T12:00:00Z"					|         date: "2025-01-27T18:00:00Z"
+  state: active								  state: active

--- a/vsphere/v29.3.0/release.yaml
+++ b/vsphere/v29.3.0/release.yaml
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-29.3.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.3
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.2
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 1.12.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.23.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.9.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.2
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 0.68.1
+  - name: flatcar
+    version: 4081.2.1
+  - name: kubernetes
+    version: 1.29.13
+  - name: os-tooling
+    version: 1.22.1
+  date: "2025-01-27T18:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
