### PR TITLE
CAPVCD: Release v29.3.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ to all Giant Swarm installations.
 
 - v29
   - v29.3
+    - [v29.3.2](https://github.com/giantswarm/releases/tree/master/cloud-director/v29.3.2)
     - [v29.3.1](https://github.com/giantswarm/releases/tree/master/cloud-director/v29.3.1)
     - [v29.3.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v29.3.0)
   - v29.2

--- a/cloud-director/kustomization.yaml
+++ b/cloud-director/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - v29.2.1
 - v29.3.0
 - v29.3.1
+- v29.3.2
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/cloud-director/releases.json
+++ b/cloud-director/releases.json
@@ -76,6 +76,13 @@
       "releaseTimestamp": "2025-02-06 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v29.3.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "29.3.2",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-02-10 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v29.3.2/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/cloud-director/v29.3.2/README.md
+++ b/cloud-director/v29.3.2/README.md
@@ -1,0 +1,14 @@
+# :zap: Giant Swarm Release v29.3.2 for VMware Cloud Director :zap:
+
+## Changes compared to v29.3.1
+
+### Apps
+
+- cloud-provider-cloud-director from v0.4.0 to v0.5.0
+
+### cloud-provider-cloud-director [v0.4.0...v0.5.0](https://github.com/giantswarm/cloud-provider-cloud-director-app/compare/v0.4.0...v0.5.0)
+
+#### Changed
+
+- Update to `1.6.1-gs` of CPI. (Upstream version `1.6.1` plus unreleased patch to address LB health monitor upgrade issue).
+- Update to `1.6.0` of CSI. This also removes `--v=5` from the CSI plugin as this flag is no longer supported in this version.

--- a/cloud-director/v29.3.2/announcement.md
+++ b/cloud-director/v29.3.2/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v29.3.2 for VMware Cloud Director is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-29.3.1).

--- a/cloud-director/v29.3.2/announcement.md
+++ b/cloud-director/v29.3.2/announcement.md
@@ -1,3 +1,3 @@
 **Workload cluster release v29.3.2 for VMware Cloud Director is available**.
 
-Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-29.3.1).
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-29.3.2).

--- a/cloud-director/v29.3.2/kustomization.yaml
+++ b/cloud-director/v29.3.2/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      # Need to target index 2 here as `cloud-director` itself already contains a hyphen.
+      index: 2
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/cloud-director/v29.3.2/release.diff
+++ b/cloud-director/v29.3.2/release.diff
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
+kind: Release							kind: Release
+metadata:							metadata:
+  name: cloud-director-29.3.1				      |	  name: cloud-director-29.3.2
+spec:								spec:
+  apps:								  apps:
+  - name: capi-node-labeler					  - name: capi-node-labeler
+    version: 0.5.0						    version: 0.5.0
+  - name: cert-exporter						  - name: cert-exporter
+    version: 2.9.3						    version: 2.9.3
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: cert-manager						  - name: cert-manager
+    version: 3.8.2						    version: 3.8.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: chart-operator-extensions				  - name: chart-operator-extensions
+    version: 1.1.2						    version: 1.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cilium						  - name: cilium
+    version: 0.25.2						    version: 0.25.2
+  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director				  - name: cloud-provider-cloud-director
+    version: 0.4.0					      |	    version: 0.5.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns						  - name: coredns
+    version: 1.23.0						    version: 1.23.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0						    version: 1.10.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: external-dns						  - name: external-dns
+    version: 3.1.0						    version: 3.1.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
+    version: 0.10.0						    version: 0.10.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
+    version: 2.8.1						    version: 2.8.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: metrics-server					  - name: metrics-server
+    version: 2.4.2						    version: 2.4.2
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: net-exporter						  - name: net-exporter
+    version: 1.21.0						    version: 1.21.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: network-policies					  - name: network-policies
+    catalog: cluster						    catalog: cluster
+    version: 0.1.1						    version: 0.1.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: node-exporter						  - name: node-exporter
+    version: 1.20.0						    version: 1.20.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: observability-bundle					  - name: observability-bundle
+    version: 1.9.0						    version: 1.9.0
+    dependsOn:							    dependsOn:
+    - coredns							    - coredns
+  - name: observability-policies				  - name: observability-policies
+    version: 0.0.1						    version: 0.0.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
+    version: 0.5.0						    version: 0.5.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: security-bundle					  - name: security-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 1.9.1						    version: 1.9.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: teleport-kube-agent					  - name: teleport-kube-agent
+    version: 0.10.3						    version: 0.10.3
+  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
+    version: 5.3.1						    version: 5.3.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
+    version: 3.1.2						    version: 3.1.2
+  components:							  components:
+  - name: cluster-cloud-director				  - name: cluster-cloud-director
+    catalog: cluster						    catalog: cluster
+    version: 0.64.2						    version: 0.64.2
+  - name: flatcar						  - name: flatcar
+    version: 4081.2.1						    version: 4081.2.1
+  - name: kubernetes						  - name: kubernetes
+    version: 1.29.13						    version: 1.29.13
+  - name: os-tooling						  - name: os-tooling
+    version: 1.22.1						    version: 1.22.1
+  date: "2025-02-06T12:00:00Z"				      |	  date: "2025-02-10T12:00:00Z"
+  state: active							  state: active

--- a/cloud-director/v29.3.2/release.yaml
+++ b/cloud-director/v29.3.2/release.yaml
@@ -1,0 +1,104 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: cloud-director-29.3.2
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 0.5.0
+  - name: cert-exporter
+    version: 2.9.3
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.8.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.25.2
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director
+    version: 0.5.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.23.0
+    dependsOn:
+    - cilium
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.0
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.4.2
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.0
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.9.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.3.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.1.2
+  components:
+  - name: cluster-cloud-director
+    catalog: cluster
+    version: 0.64.2
+  - name: flatcar
+    version: 4081.2.1
+  - name: kubernetes
+    version: 1.29.13
+  - name: os-tooling
+    version: 1.22.1
+  date: "2025-02-10T12:00:00Z"
+  state: active


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/32585 and https://github.com/giantswarm/giantswarm/issues/32599

<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
