### PR TITLE
CAPA: Release v30.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ to all Giant Swarm installations.
 
 ## AWS
 
+- v30
+  - v30.0
+    - [v30.0.0](https://github.com/giantswarm/releases/tree/master/capa/v30.0.0)
+
 - v29
   - v29.6
     - [v29.6.1](https://github.com/giantswarm/releases/tree/master/capa/v29.6.1)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
 - v29.5.0
 - v29.6.0
 - v29.6.1
+- v30.0.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -272,6 +272,13 @@
       "releaseTimestamp": "2025-02-05 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v29.6.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "30.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-02-19 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v30.0.0/README.md
+++ b/capa/v30.0.0/README.md
@@ -1,0 +1,229 @@
+# :zap: Giant Swarm Release v30.0.0 for CAPA :zap:
+
+## Changes compared to v29.6.1
+
+### Components
+
+- cluster-aws from v2.6.1 to v3.0.0
+- Flatcar from v4081.2.1 to [v4152.2.1](https://www.flatcar.org/releases#release-4152.2.1)
+- Kubernetes from v1.29.13 to [v1.30.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md)
+
+### cluster-aws [v2.6.1...v3.0.0](https://github.com/giantswarm/cluster-aws/compare/v2.6.1...v3.0.0)
+
+#### Added
+
+- Values: Add schema for `cilium-crossplane-resources`.
+
+#### Changed
+
+- Scale down cilium-operator before deleting a cluster (only in eni mode)
+- Chart: Update `cluster` to v2.0.1.
+- Chart: Enable `coredns-extensions` and `etcd-defrag`.
+
+### Apps
+
+- aws-ebs-csi-driver from v2.30.1 to v3.0.1
+- aws-pod-identity-webhook from v1.18.0 to v1.19.0
+- capi-node-labeler from v0.5.0 to v1.0.0
+- cert-exporter from v2.9.3 to v2.9.4
+- cert-manager from v3.8.2 to v3.9.0
+- cilium from v0.25.2 to v0.31.0
+- cloud-provider-aws from v1.29.3-gs1 to v1.30.7-gs2
+- cluster-autoscaler from v1.29.3-gs1 to v1.30.3-gs2
+- coredns from v1.23.0 to v1.24.0
+- coredns-extensions v0.1.2
+- etcd-defrag v1.0.0
+- etcd-k8s-res-count-exporter from v1.10.0 to v1.10.1
+- k8s-audit-metrics from v0.10.0 to v0.10.1
+- metrics-server from v2.4.2 to v2.6.0
+- node-exporter from v1.20.0 to v1.20.1
+- vertical-pod-autoscaler from v5.3.1 to v5.4.0
+- vertical-pod-autoscaler-crd from v3.1.2 to v3.2.0
+
+### aws-ebs-csi-driver [v2.30.1...v3.0.1](https://github.com/giantswarm/aws-ebs-csi-driver-app/compare/v2.30.1...v3.0.1)
+
+#### Added
+
+- Repository: Some chores. ([#235](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/235))
+  - Repository: Add `Makefile.custom.mk`.
+- Chart: Add `snapshot-controller` NetworkPolicy. ([#246](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/246))
+  - Kustomization: Add `snapshot-controller` NetworkPolicy.
+
+#### Changed
+
+- Harden security context for controller and node.
+- Repository: Some chores. ([#235](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/235))
+  - ABS: Rework `main.yaml`.
+  - CircleCI: Rework `config.yml`.
+  - Repository: Rework `README.md`.
+  - Repository: Move `.gitignore` & `kustomization-snapshotter.yaml` to `vendor/external-snapshotter/`.
+  - Chart: Rework `.kube-linter.yaml`.
+  - Vendir: Rework `vendir.yml`.
+  - Chart: Rework `Chart.yaml`.
+  - Chart: Revert image to v1.37.0.
+  - Renovate: Ignore `values.yaml`.
+- Chart: Sync to upstream. ([#243](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/243))
+  - Chart: Reorder labels.
+  - Chart: Fix network policies.
+- Chart: Add `snapshot-controller` NetworkPolicy. ([#246](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/246))
+  - Vendir: Sync to `vendor/external-snapshotter/upstream`.
+  - Kustomization: Set namespace.
+  - Kustomization: Extend common labels.
+  - Kustomization: Extract CRD patches.
+  - Kustomization: Extract service account patches.
+  - Kustomization: Extract deployment patches.
+- Change to use ImagePullPolicy as specified via values.
+- Upgrade to release v1.37.0
+- Enable Volume Snapshotter by default
+- Switch to Helm managed CRDs
+
+#### Removed
+
+- Repository: Some chores. ([#235](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/235))
+  - Repository: Remove `.nancy-ignore`.
+  - Chart: Remove pod `securityContext` from `external-snapshotter`.
+  - Chart: Remove `.helmignore`.
+  - Chart: Remove `CHANGELOG.md`.
+
+### aws-pod-identity-webhook [v1.18.0...v1.19.0](https://github.com/giantswarm/aws-pod-identity-webhook/compare/v1.18.0...v1.19.0)
+
+#### Changed
+
+- Add support for rolling `Deployments` owned by unknown CRs, like the case of Crossplane providers.
+
+### capi-node-labeler [v0.5.0...v1.0.0](https://github.com/giantswarm/capi-node-labeler-app/compare/v0.5.0...v1.0.0)
+
+#### Changed
+
+- Go: Update `go.mod` and `.nancy-ignore`. ([#123](https://github.com/giantswarm/capi-node-labeler-app/pull/123))
+
+### cert-exporter [v2.9.3...v2.9.4](https://github.com/giantswarm/cert-exporter/compare/v2.9.3...v2.9.4)
+
+#### Changed
+
+- Repository: Some chores. ([#418](https://github.com/giantswarm/cert-exporter/pull/418))
+- Go: Update `go.mod` and `.nancy-ignore`. ([#437](https://github.com/giantswarm/cert-exporter/pull/437))
+
+### cert-manager [v3.8.2...v3.9.0](https://github.com/giantswarm/cert-manager-app/compare/v3.8.2...v3.9.0)
+
+#### Added
+
+- Adds new sync method based on Vendir to sync from upstream
+
+#### Changed
+
+- Updates Cert-manager Chart to Upstream 1.16.2
+
+### cilium [v0.25.2...v0.31.0](https://github.com/giantswarm/cilium-app/compare/v0.25.2...v0.31.0)
+
+#### Changed
+
+- Upgrade Cilium to [v1.16.6](https://github.com/cilium/cilium/releases/tag/v1.16.6).
+- Move provider specific custom CNI configuration to subchart.
+- Improve security defaults for:
+  - Hubble UI
+  - Hubble Relay
+  - Cilium Operator
+
+#### Removed
+
+- Delete defaultPolicies and extraPolicies templates.
+
+### cloud-provider-aws [v1.29.3-gs1...v1.30.7-gs2](https://github.com/giantswarm/aws-cloud-controller-manager-app/compare/v1.29.3-gs1...v1.30.7-gs2)
+
+#### Added
+
+- Add security context to the container for PSS.
+
+#### Changed
+
+- Chart: Remove duplicate service account. ([#87](https://github.com/giantswarm/aws-cloud-controller-manager-app/pull/87))
+- Chart: Update to upstream v1.30.7.
+
+#### Remove
+
+- Remove PSP manifest.
+
+### cluster-autoscaler [v1.29.3-gs1...v1.30.3-gs2](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.29.3-gs1...v1.30.3-gs2)
+
+#### Changed
+
+- Values: Enable Pod Security Standards. ([#296](https://github.com/giantswarm/cluster-autoscaler-app/pull/296))
+- Chart: Update to upstream v1.30.3. ([#298](https://github.com/giantswarm/cluster-autoscaler-app/pull/298))
+- Update `PolicyExceptions` apiVersion to `v2beta1`. ([#282](https://github.com/giantswarm/cluster-autoscaler-app/pull/282))
+
+### coredns [v1.23.0...v1.24.0](https://github.com/giantswarm/coredns-app/compare/v1.23.0...v1.24.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0).
+- Disable HPA Memory target.
+- Increase threshold for HPA CPU target to 80%.
+
+### coredns-extensions [v0.1.2](https://github.com/giantswarm/coredns-extensions-app/releases/v0.1.2)
+
+#### Added
+
+- Add VPA for CoreDNS deployments.
+- Add value to enable or disable VPA resources.
+
+#### Changed
+
+- Push App to the default-catalog.
+- Publish App in giantswarm-catalog.
+
+### etcd-defrag [v1.0.0](https://github.com/giantswarm/etcd-defrag-app/releases/v1.0.0)
+
+#### Added
+
+- Chart: Add `moveLeader`. ([#11](https://github.com/giantswarm/etcd-defrag-app/pull/11))
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.23.0. ([#10](https://github.com/giantswarm/etcd-defrag-app/pull/10))
+- Values: Rename `cluster` into `useClusterEndpoints`. ([#8](https://github.com/giantswarm/etcd-defrag-app/pull/8))
+
+### etcd-k8s-res-count-exporter [v1.10.0...v1.10.1](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.0...v1.10.1)
+
+#### Changed
+
+- Set `readOnlyRootFilesystem` to true in the container security context.
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
+- Go: Update `go.mod` and `.nancy-ignore`. ([#242](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/pull/242))
+
+### k8s-audit-metrics [v0.10.0...v0.10.1](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.0...v0.10.1)
+
+#### Changed
+
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
+- Go: Update `go.mod` and `.nancy-ignore`. ([#248](https://github.com/giantswarm/k8s-audit-metrics/pull/248))
+
+### metrics-server [v2.4.2...v2.6.0](https://github.com/giantswarm/metrics-server-app/compare/v2.4.2...v2.6.0)
+
+#### Added
+
+- Add VPA setting for `metrics-server`.
+
+#### Changed
+
+- Upgrade metrics-server to v0.7.2.
+- Chart: Update PolicyExceptions to v2beta1. ([#226](https://github.com/giantswarm/metrics-server-app/pull/226))
+
+### node-exporter [v1.20.0...v1.20.1](https://github.com/giantswarm/node-exporter-app/compare/v1.20.0...v1.20.1)
+
+#### Changed
+
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
+- Go: Update `go.mod`. ([#322](https://github.com/giantswarm/node-exporter-app/pull/322))
+
+### vertical-pod-autoscaler [v5.3.1...v5.4.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.3.1...v5.4.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v10.0.0 ([#335](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/335))
+
+### vertical-pod-autoscaler-crd [v3.1.2...v3.2.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.1.2...v3.2.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#126](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/126))

--- a/capa/v30.0.0/announcement.md
+++ b/capa/v30.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v30.0.0 for CAPA is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-30.0.0).

--- a/capa/v30.0.0/kustomization.yaml
+++ b/capa/v30.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v30.0.0/release.diff
+++ b/capa/v30.0.0/release.diff
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-29.6.1						|         name: aws-30.0.0
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 2.30.1						|           version: 3.0.1
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: aws-nth-bundle						  - name: aws-nth-bundle
+    version: 1.2.1							    version: 1.2.1
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.18.0						|           version: 1.19.0
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 0.5.0						|           version: 1.0.0
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.3						|           version: 2.9.4
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.8.2						|           version: 3.9.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.25.2						|           version: 0.31.0
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    catalog: cluster							    catalog: cluster
+    version: 0.2.0							    version: 0.2.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.29.3-gs1						|           version: 1.30.7-gs2
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.29.3-gs1						|           version: 1.30.3-gs2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: coredns							  - name: coredns
+    version: 1.23.0						|           version: 1.24.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+								>         - name: coredns-extensions
+								>           version: 0.1.2
+								>           dependsOn:
+								>           - vertical-pod-autoscaler-crd
+								>         - name: etcd-defrag
+								>           version: 1.0.0
+								>           dependsOn:
+								>           - kyverno-crds
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.0						|           version: 1.10.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.1.0							    version: 3.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.0						|           version: 0.10.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.4.2						|           version: 2.6.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0							    version: 1.21.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.0						|           version: 1.20.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.9.0							    version: 1.9.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.5.0							    version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.9.1							    version: 1.9.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.3							    version: 0.10.3
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.3.1						|           version: 5.4.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.1.2						|           version: 3.2.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 2.6.1						|           version: 3.0.0
+  - name: flatcar							  - name: flatcar
+    version: 4081.2.1						|           version: 4152.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.29.13						|           version: 1.30.10
+  - name: os-tooling							  - name: os-tooling
+    version: 1.22.1						|           version: 1.23.1
+  date: "2025-02-05T12:00:00Z"					|         date: "2025-02-19T12:00:00Z"
+  state: active								  state: active

--- a/capa/v30.0.0/release.yaml
+++ b/capa/v30.0.0/release.yaml
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-30.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.1
+  - name: aws-pod-identity-webhook
+    version: 1.19.0
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.0.0
+  - name: cert-exporter
+    version: 2.9.4
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.0
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.30.7-gs2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.30.3-gs2
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.24.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.0
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.1
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.9.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0
+  components:
+  - name: cluster-aws
+    catalog: cluster-test
+    version: 2.6.1-365c1144cae29109bd2ede79d3e7f87c438afa0a
+  - name: flatcar
+    version: 4152.2.1
+  - name: kubernetes
+    version: 1.30.10
+  - name: os-tooling
+    version: 1.23.1
+  date: "2025-02-19T12:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
