### PR TITLE
CAPI: Fix Cilium requests.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.5.0"
   requests:
   - name: cilium
-    version: ">= 0.25.2 < 0.26.0"
+    version: ">= 0.25.2"
   - name: os-tooling
     version: ">= 1.22.1"
   - name: security-bundle

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -10,7 +10,7 @@ releases:
   - name: aws-pod-identity-webhook
     version: ">= 1.18.0"
   - name: cilium
-    version: ">= 0.25.2 < 0.26.0"
+    version: ">= 0.25.2"
   - name: os-tooling
     version: ">= 1.22.1"
   - name: security-bundle

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.3.0"
   requests:
   - name: cilium
-    version: ">= 0.25.2 < 0.26.0"
+    version: ">= 0.25.2"
   - name: os-tooling
     version: ">= 1.22.1"
   - name: security-bundle

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -6,7 +6,7 @@ releases:
 - name: ">= 29.3.0"
   requests:
   - name: cilium
-    version: ">= 0.25.2 < 0.26.0"
+    version: ">= 0.25.2"
   - name: os-tooling
     version: ">= 1.22.1"
   - name: security-bundle


### PR DESCRIPTION
v30.0.0 matches `>= 29.5.0`, but requests Cilium `>= 0.26.0`. This clashes and as we already fulfill the old request, I'm going to remove the upper bound.