### PR TITLE
Request nvidia_runtime be included from release v30.1 onwards

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 30.1.0"
+  requests:
+  - name: os-tooling
+    version: ">= 1.24.0"
 - name: ">= 30.0.0"
   requests:
   - name: cilium

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 30.1.0"
+  requests:
+  - name: os-tooling
+    version: ">= 1.24.0"
 - name: ">= 30.0.0"
   requests:
   - name: aws-ebs-csi-driver

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 30.1.0"
+  requests:
+  - name: os-tooling
+    version: ">= 1.24.0"
 - name: ">= 30.0.0"
   requests:
   - name: cilium

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: ">= 30.1.0"
+  requests:
+  - name: os-tooling
+    version: ">= 1.24.0"
 - name: ">= 30.0.0"
   requests:
   - name: cilium


### PR DESCRIPTION
Requesting that the os-tooling be updated to at least v1.24.0 starting from release v30.1 onwards which will include the nvidia_runtime binaries and config on the node image.

Closes: https://github.com/giantswarm/roadmap/issues/3886