### PR TITLE
Update cilium requests

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "31.x.x"
+  requests:
+  - name: cilium
+    version: ">= 0.32.0"
 - name: ">= 30.1.0"
   requests:
   - name: os-tooling

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -3,10 +3,10 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
-    version: ">= 0.26.0"
+    version: "0.31.x"
 - name: ">= 29.5.0"
   requests:
   - name: cilium

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "31.x.x"
+- name: ">= 31.0.0"
   requests:
   - name: cilium
     version: ">= 0.32.0"
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0 < 31.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "31.x.x"
+  requests:
+  - name: cilium
+    version: ">= 0.32.0"
 - name: ">= 30.1.0"
   requests:
   - name: os-tooling

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -7,12 +7,14 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
+- name: "30.x.x"
+  requests:
+  - name: cilium
+    version: "0.31.x"
 - name: ">= 30.0.0"
   requests:
   - name: aws-ebs-csi-driver
     version: ">= 3.0.0"
-  - name: cilium
-    version: "0.31.x"
 - name: ">= 29.6.0"
   requests:
   - name: aws-pod-identity-webhook

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -3,12 +3,14 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
+- name: "30.x.x"
+  requests:
+  - name: cilium
+    version: "0.31.x"
 - name: ">= 30.0.0"
   requests:
   - name: aws-ebs-csi-driver
     version: ">= 3.0.0"
-  - name: cilium
-    version: ">= 0.26.0"
 - name: ">= 29.6.0"
   requests:
   - name: aws-pod-identity-webhook

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0 < 31.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "31.x.x"
+- name: ">= 31.0.0"
   requests:
   - name: cilium
     version: ">= 0.32.0"
@@ -7,14 +7,12 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
-  requests:
-  - name: cilium
-    version: "0.31.x"
 - name: ">= 30.0.0"
   requests:
   - name: aws-ebs-csi-driver
     version: ">= 3.0.0"
+  - name: cilium
+    version: "0.31.x"
 - name: ">= 29.6.0"
   requests:
   - name: aws-pod-identity-webhook

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "31.x.x"
+  requests:
+  - name: cilium
+    version: ">= 0.32.0"
 - name: ">= 30.1.0"
   requests:
   - name: os-tooling

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "31.x.x"
+- name: ">= 31.0.0"
   requests:
   - name: cilium
     version: ">= 0.32.0"
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0 < 31.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -3,10 +3,10 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
-    version: ">= 0.26.0"
+    version: "0.31.x"
 - name: ">= 29.3.0"
   requests:
   - name: cilium

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "31.x.x"
+  requests:
+  - name: cilium
+    version: ">= 0.32.0"
 - name: ">= 30.1.0"
   requests:
   - name: os-tooling

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,5 +1,5 @@
 releases:
-- name: "31.x.x"
+- name: ">= 31.0.0"
   requests:
   - name: cilium
     version: ">= 0.32.0"
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -7,7 +7,7 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: "30.x.x"
+- name: ">= 30.0.0 < 31.0.0"
   requests:
   - name: cilium
     version: "0.31.x"

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -3,10 +3,10 @@ releases:
   requests:
   - name: os-tooling
     version: ">= 1.24.0"
-- name: ">= 30.0.0"
+- name: "30.x.x"
   requests:
   - name: cilium
-    version: ">= 0.26.0"
+    version: "0.31.x"
 - name: ">= 29.3.0"
   requests:
   - name: cilium


### PR DESCRIPTION
- **Update requested version for cilium-app**
- **Add requested version for future releases**

<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
