### PR TITLE
CAPV: Release v30.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ to all Giant Swarm installations.
 - v30
   - v30.0
     - [v30.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.0.0)
+    - [v30.1.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.0)
 
 - v29
   - v29.3

--- a/README.md
+++ b/README.md
@@ -574,9 +574,10 @@ to all Giant Swarm installations.
 ## vSphere
 
 - v30
+  - v30.1
+    - [v30.1.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.0)
   - v30.0
     - [v30.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.0.0)
-    - [v30.1.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.0)
 
 - v29
   - v29.3

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - v29.2.0
 - v29.3.0
 - v30.0.0
+- v30.1.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "30.1.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-03-17 12:00:00 +0000 UTC",
+      "releaseTimestamp": "2025-03-18 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.1.0/README.md",
       "isStable": true
     }

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -62,6 +62,13 @@
       "releaseTimestamp": "2025-03-03 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "30.1.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-03-17 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.1.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v30.1.0/README.md
+++ b/vsphere/v30.1.0/README.md
@@ -8,26 +8,26 @@
 
 ### cluster-vsphere [v0.69.0...v1.0.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.69.0...v1.0.0)
 
-#### Changed
-
-- Split cloud provider app into separate HelmReleases.
-
 #### Added
 
 - Add `global.providerSpecific.templateSuffix` to set a suffix on the VM template to use.
 
+#### Changed
+
+- Split cloud provider app into separate HelmReleases.
+
 ### Apps
 
-- cloud-provider-vsphere from `v1.12.0` to `v2.0.1`
-- kube-vip added at `v0.2.0`
-- kube-vip-cloud-provider added at `v0.3.0`
-- vsphere-csi-driver added at `v3.4.2`
+- cloud-provider-vsphere from v1.12.0 to v2.0.1
+- kube-vip added at v0.2.0
+- kube-vip-cloud-provider added at v0.3.0
+- vsphere-csi-driver added at v3.4.2
 
 ### cloud-provider-vsphere [v1.12.0...v2.0.1](https://github.com/giantswarm/cloud-provider-vsphere-app/compare/v1.12.0...v2.0.1)
 
 #### Changed
 
-- Remove subcharts in order to deploy only the vSphere CPI (at upstream version v1.30.0). ([#217](https://github.com/giantswarm/cloud-provider-vsphere-app/pull/217))
+- Remove subcharts in order to deploy only the vSphere CPI (at upstream version `v1.30.0`).
 
 ### kube-vip [v0.2.0](https://github.com/giantswarm/kube-vip-app/blob/main/CHANGELOG.md#020---2025-02-25)
 
@@ -43,10 +43,18 @@
 
 #### Changed
 
-- Run container with a read-only filesystem. ([#17](https://github.com/giantswarm/kube-vip-cloud-provider-app/pull/17))
+- Run container with a read-only filesystem.
 
 ### vsphere-csi-driver [v3.4.2](https://github.com/giantswarm/vsphere-csi-driver-app/blob/main/CHANGELOG.md#342---2025-03-17)
 
 #### Added
 
 - Add upstream chart at `v3.3.0`.
+
+#### Changed
+
+- Correct kubectl image tag.
+
+#### Removed
+
+- Remove superfluous update script.

--- a/vsphere/v30.1.0/README.md
+++ b/vsphere/v30.1.0/README.md
@@ -42,6 +42,12 @@
 - teleport-kube-agent from v0.10.3 to v0.10.4
 - vsphere-csi-driver added at v3.4.2
 
+### capi-node-labeler [v1.0.1...v1.0.2](https://github.com/giantswarm/capi-node-labeler-app/compare/v1.0.1...v1.0.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
 ### cert-exporter [v2.9.4...v2.9.5](https://github.com/giantswarm/cert-exporter/compare/v2.9.4...v2.9.5)
 
 #### Changed

--- a/vsphere/v30.1.0/README.md
+++ b/vsphere/v30.1.0/README.md
@@ -4,11 +4,11 @@
 
 ### Components
 
-- cluster-vsphere from v0.69.0 to v1.0.0
+- cluster-vsphere from v0.69.0 to v1.1.0
 - Kubernetes from v1.30.10 to [v1.30.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md)
 - os-tooling from v1.23.1 to v1.24.0
 
-### cluster-vsphere [v0.69.0...v1.0.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.69.0...v1.0.0)
+### cluster-vsphere [v0.69.0...v1.1.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.69.0...v1.1.0)
 
 #### Added
 
@@ -16,6 +16,7 @@
 
 #### Changed
 
+- Chart: Update `cluster` to v2.2.0.
 - Split cloud provider app into separate HelmReleases.
 
 ### os-tooling [v1.23.1...v1.24.0](https://github.com/giantswarm/capi-image-builder/compare/v1.23.1...v1.24.0)

--- a/vsphere/v30.1.0/README.md
+++ b/vsphere/v30.1.0/README.md
@@ -1,0 +1,52 @@
+# :zap: Giant Swarm Release v30.1.0 for vSphere :zap:
+
+## Changes compared to v30.0.0
+
+### Components
+
+- cluster-vsphere from v0.69.0 to v1.0.0
+
+### cluster-vsphere [v0.69.0...v1.0.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.69.0...v1.0.0)
+
+#### Changed
+
+- Split cloud provider app into separate HelmReleases.
+
+#### Added
+
+- Add `global.providerSpecific.templateSuffix` to set a suffix on the VM template to use.
+
+### Apps
+
+- cloud-provider-vsphere from `v1.12.0` to `v2.0.1`
+- kube-vip added at `v0.2.0`
+- kube-vip-cloud-provider added at `v0.3.0`
+- vsphere-csi-driver added at `v3.4.2`
+
+### cloud-provider-vsphere [v1.12.0...v2.0.1](https://github.com/giantswarm/cloud-provider-vsphere-app/compare/v1.12.0...v2.0.1)
+
+#### Changed
+
+- Remove subcharts in order to deploy only the vSphere CPI (at upstream version v1.30.0). ([#217](https://github.com/giantswarm/cloud-provider-vsphere-app/pull/217))
+
+### kube-vip [v0.2.0](https://github.com/giantswarm/kube-vip-app/blob/main/CHANGELOG.md#020---2025-02-25)
+
+#### Added
+
+- Initial release which tracks upstream version `0.8.4`.
+
+### kube-vip-cloud-provider [v0.3.0](https://github.com/giantswarm/kube-vip-cloud-provider-app/blob/main/CHANGELOG.md#030---2025-03-14)
+
+#### Added
+
+- Initial release which tracks upstream version `0.0.10`.
+
+#### Changed
+
+- Run container with a read-only filesystem. ([#17](https://github.com/giantswarm/kube-vip-cloud-provider-app/pull/17))
+
+### vsphere-csi-driver [v3.4.2](https://github.com/giantswarm/vsphere-csi-driver-app/blob/main/CHANGELOG.md#342---2025-03-17)
+
+#### Added
+
+- Add upstream chart at `v3.3.0`.

--- a/vsphere/v30.1.0/README.md
+++ b/vsphere/v30.1.0/README.md
@@ -5,6 +5,8 @@
 ### Components
 
 - cluster-vsphere from v0.69.0 to v1.0.0
+- Kubernetes from v1.30.10 to [v1.30.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md)
+- os-tooling from v1.23.1 to v1.24.0
 
 ### cluster-vsphere [v0.69.0...v1.0.0](https://github.com/giantswarm/cluster-vsphere/compare/v0.69.0...v1.0.0)
 
@@ -16,18 +18,65 @@
 
 - Split cloud provider app into separate HelmReleases.
 
+### os-tooling [v1.23.1...v1.24.0](https://github.com/giantswarm/capi-image-builder/compare/v1.23.1...v1.24.0)
+
+#### Added
+
+- Added nvidia_runtime to allow running of GPU workloads
+
 ### Apps
 
+- capi-node-labeler from v1.0.1 to v1.0.2
+- cert-exporter from v2.9.4 to v2.9.5
+- cilium from v0.31.0 to v0.31.1
 - cloud-provider-vsphere from v1.12.0 to v2.0.1
+- etcd-defrag from v1.0.1 to v1.0.2
+- etcd-kubernetes-resources-count-exporter from v1.10.1 to v1.10.3
+- k8s-audit-metrics from v0.10.1 to v0.10.2
 - kube-vip added at v0.2.0
 - kube-vip-cloud-provider added at v0.3.0
+- net-exporter from v1.21.0 to v1.22.0
+- node-exporter from v1.20.1 to v1.20.2
+- observability-bundle from v1.9.0 to v1.11.0
+- security-bundle from v1.9.1 to v1.10.0
+- teleport-kube-agent from v0.10.3 to v0.10.4
 - vsphere-csi-driver added at v3.4.2
+
+### cert-exporter [v2.9.4...v2.9.5](https://github.com/giantswarm/cert-exporter/compare/v2.9.4...v2.9.5)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v0.31.0...v0.31.1](https://github.com/giantswarm/cilium-app/compare/v0.31.0...v0.31.1)
+
+#### Changed
+
+- Upgrade Cilium to [v1.16.7](https://github.com/cilium/cilium/releases/tag/v1.16.7).
 
 ### cloud-provider-vsphere [v1.12.0...v2.0.1](https://github.com/giantswarm/cloud-provider-vsphere-app/compare/v1.12.0...v2.0.1)
 
 #### Changed
 
 - Remove subcharts in order to deploy only the vSphere CPI (at upstream version `v1.30.0`).
+
+### etcd-defrag [v1.0.1...v1.0.2](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.1...v1.0.2)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.25.0. ([#17](https://github.com/giantswarm/etcd-defrag-app/pull/17))
+
+### etcd-kubernetes-resources-count-exporter [v1.10.1...v1.10.3](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.1...v1.10.3)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-audit-metrics [v0.10.1...v0.10.2](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.1...v0.10.2)
+
+#### Changed
+
+- Go: Update dependencies.
 
 ### kube-vip [v0.2.0](https://github.com/giantswarm/kube-vip-app/blob/main/CHANGELOG.md#020---2025-02-25)
 
@@ -44,6 +93,58 @@
 #### Changed
 
 - Run container with a read-only filesystem.
+
+### net-exporter [v1.21.0...v1.22.0](https://github.com/giantswarm/net-exporter/compare/v1.21.0...v1.22.0)
+
+#### Changed
+
+- Narrow down CiliumNetworkPolicy to allow desired traffic only.
+
+#### Removed
+
+- Remove NetworkPolicy resource and rely on CiliumNetworkPolicy only.
+
+### node-exporter [v1.20.1...v1.20.2](https://github.com/giantswarm/node-exporter-app/compare/v1.20.1...v1.20.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### observability-bundle [v1.9.0...v1.11.0](https://github.com/giantswarm/observability-bundle/compare/v1.9.0...v1.11.0)
+
+#### Changed
+
+- prometheus-operator will not check promql syntax for prometheusRules that are labelled `observability.giantswarm.io/rule-type: logs`
+- Upgrade `alloy` to chart 0.9.0.
+  - Bumps `alloy` from to 1.5.1 to 1.7.1
+- Upgrade `kube-prometheus-stack` from 66.2.1 to 69.5.1
+  - Bumps prometheus-operator to 0.80.1
+  - Bumps prometheus to 3.0.1
+
+### security-bundle [v1.9.1...v1.10.0](https://github.com/giantswarm/security-bundle/compare/v1.9.1...v1.10.0)
+
+#### Added
+
+- Add e2e tests for the `security-bundle` and all is components
+
+#### Changed
+
+- Update `kyverno` (app) to v0.19.0.
+- Update `kyverno-crds` (app) to v1.13.0.
+- Update `kyverno-policies` (app) to v0.23.0.
+- Update `edgedb` (app) to v0.1.0.
+- Update `falco` (app) to v0.10.0.
+- Update `trivy` (app) to v0.13.2.
+
+### teleport-kube-agent [v0.10.3...v0.10.4](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.3...v0.10.4)
+
+#### Added
+
+- Add headless service on `diag` port 3000.
+
+#### Changed
+
+- Migrated to ABS
 
 ### vsphere-csi-driver [v3.4.2](https://github.com/giantswarm/vsphere-csi-driver-app/blob/main/CHANGELOG.md#342---2025-03-17)
 

--- a/vsphere/v30.1.0/announcement.md
+++ b/vsphere/v30.1.0/announcement.md
@@ -1,3 +1,3 @@
 **Workload cluster release v30.1.0 for vSphere is available**. This release splits the `cloud-provider-vsphere` chart out into 4 separate charts. The change is transparent to users and does not require any configuration changes.
 
-Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-30.0.0).
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-30.1.0).

--- a/vsphere/v30.1.0/announcement.md
+++ b/vsphere/v30.1.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v30.1.0 for vSphere is available**. This release splits the `cloud-provider-vsphere` chart out into 4 separate charts. The change is transparent to users and does not require any configuration changes.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-30.0.0).

--- a/vsphere/v30.1.0/kustomization.yaml
+++ b/vsphere/v30.1.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v30.1.0/release.diff
+++ b/vsphere/v30.1.0/release.diff
@@ -1,124 +1,124 @@
-apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
-kind: Release							kind: Release
-metadata:							metadata:
-  name: vsphere-30.0.0					      |	  name: vsphere-30.1.0
-spec:								spec:
-  apps:								  apps:
-  - name: capi-node-labeler					  - name: capi-node-labeler
-    version: 1.0.1						    version: 1.0.1
-  - name: cert-exporter						  - name: cert-exporter
-    version: 2.9.4						    version: 2.9.4
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: cert-manager						  - name: cert-manager
-    version: 3.9.0						    version: 3.9.0
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: chart-operator-extensions				  - name: chart-operator-extensions
-    version: 1.1.2						    version: 1.1.2
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: cilium						  - name: cilium
-    version: 0.31.0						    version: 0.31.0
-  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
-    version: 0.1.2						    version: 0.1.2
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: cloud-provider-vsphere				  - name: cloud-provider-vsphere
-    version: 1.12.0					      |	    version: 2.0.1
-    dependsOn:							    dependsOn:
-    - cilium							    - cilium
-  - name: coredns						  - name: coredns
-    version: 1.24.0						    version: 1.24.0
-    dependsOn:							    dependsOn:
-    - cilium							    - cilium
-  - name: coredns-extensions					  - name: coredns-extensions
-    version: 0.1.2						    version: 0.1.2
-    dependsOn:							    dependsOn:
-    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
-  - name: etcd-defrag						  - name: etcd-defrag
-    version: 1.0.1						    version: 1.0.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
-    version: 1.10.1						    version: 1.10.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: external-dns						  - name: external-dns
-    version: 3.2.0						    version: 3.2.0
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
-    version: 0.10.1						    version: 0.10.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
-    version: 2.8.1						    version: 2.8.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-							      >	  - name: kube-vip
-							      >	    version: 0.2.0
-							      >	    dependsOn:
-							      >	    - cilium
-							      >	  - name: kube-vip-cloud-provider
-							      >	    version: 0.3.0
-							      >	    dependsOn:
-							      >	    - cilium
-  - name: metrics-server					  - name: metrics-server
-    version: 2.6.0						    version: 2.6.0
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: net-exporter						  - name: net-exporter
-    version: 1.21.0						    version: 1.21.0
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: network-policies					  - name: network-policies
-    catalog: cluster						    catalog: cluster
-    version: 0.1.1						    version: 0.1.1
-    dependsOn:							    dependsOn:
-    - cilium							    - cilium
-  - name: node-exporter						  - name: node-exporter
-    version: 1.20.1						    version: 1.20.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: observability-bundle					  - name: observability-bundle
-    version: 1.9.0						    version: 1.9.0
-    dependsOn:							    dependsOn:
-    - coredns							    - coredns
-  - name: observability-policies				  - name: observability-policies
-    version: 0.0.1						    version: 0.0.1
-    dependsOn:							    dependsOn:
-    - kyverno-crds						    - kyverno-crds
-  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
-    version: 0.5.0						    version: 0.5.0
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: security-bundle					  - name: security-bundle
-    catalog: giantswarm						    catalog: giantswarm
-    version: 1.9.1						    version: 1.9.1
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: teleport-kube-agent					  - name: teleport-kube-agent
-    version: 0.10.3						    version: 0.10.3
-  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
-    version: 5.4.0						    version: 5.4.0
-    dependsOn:							    dependsOn:
-    - prometheus-operator-crd					    - prometheus-operator-crd
-  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
-    version: 3.2.0						    version: 3.2.0
-							      >	  - name: vsphere-csi-driver
-							      >	    version: 3.4.2
-							      >	    dependsOn:
-							      >	    - cilium
-  components:							  components:
-  - name: cluster-vsphere					  - name: cluster-vsphere
-    catalog: cluster						    catalog: cluster
-    version: 0.69.0					      |	    version: 1.0.0
-  - name: flatcar						  - name: flatcar
-    version: 4152.2.1						    version: 4152.2.1
-  - name: kubernetes						  - name: kubernetes
-    version: 1.30.10						    version: 1.30.10
-  - name: os-tooling						  - name: os-tooling
-    version: 1.23.1						    version: 1.23.1
-  date: "2025-03-03T12:00:00Z"				      |	  date: "2025-03-17T12:00:00Z"
-  state: active							  state: active
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: vsphere-30.0.0						|         name: vsphere-30.1.0
+spec:									spec:
+  apps:									  apps:
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 1.0.1						|           version: 1.0.2
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.4						|           version: 2.9.5
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.9.0							    version: 3.9.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.31.0						|           version: 0.31.1
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-vsphere					  - name: cloud-provider-vsphere
+    version: 1.12.0						|           version: 2.0.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns							  - name: coredns
+    version: 1.24.0							    version: 1.24.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns-extensions						  - name: coredns-extensions
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag							  - name: etcd-defrag
+    version: 1.0.1						|           version: 1.0.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.1						|           version: 1.10.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.2.0							    version: 3.2.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.1						|           version: 0.10.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+								>         - name: kube-vip
+								>           version: 0.2.0
+								>           dependsOn:
+								>           - cilium
+								>         - name: kube-vip-cloud-provider
+								>           version: 0.3.0
+								>           dependsOn:
+								>           - cilium
+  - name: metrics-server						  - name: metrics-server
+    version: 2.6.0							    version: 2.6.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0						|           version: 1.22.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.1						|           version: 1.20.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.9.0						|           version: 1.11.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.5.0							    version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.9.1						|           version: 1.10.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.3						|           version: 0.10.4
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.4.0							    version: 5.4.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0							    version: 3.2.0
+								>         - name: vsphere-csi-driver
+								>           version: 3.4.2
+								>           dependsOn:
+								>           - cilium
+  components:								  components:
+  - name: cluster-vsphere						  - name: cluster-vsphere
+    catalog: cluster							    catalog: cluster
+    version: 0.69.0						|           version: 1.0.0
+  - name: flatcar							  - name: flatcar
+    version: 4152.2.1							    version: 4152.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.30.10						|           version: 1.30.11
+  - name: os-tooling							  - name: os-tooling
+    version: 1.23.1						|           version: 1.24.0
+  date: "2025-03-03T12:00:00Z"					|         date: "2025-03-18T12:00:00Z"
+  state: active								  state: active

--- a/vsphere/v30.1.0/release.diff
+++ b/vsphere/v30.1.0/release.diff
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
+kind: Release							kind: Release
+metadata:							metadata:
+  name: vsphere-30.0.0					      |	  name: vsphere-30.1.0
+spec:								spec:
+  apps:								  apps:
+  - name: capi-node-labeler					  - name: capi-node-labeler
+    version: 1.0.1						    version: 1.0.1
+  - name: cert-exporter						  - name: cert-exporter
+    version: 2.9.4						    version: 2.9.4
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: cert-manager						  - name: cert-manager
+    version: 3.9.0						    version: 3.9.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: chart-operator-extensions				  - name: chart-operator-extensions
+    version: 1.1.2						    version: 1.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cilium						  - name: cilium
+    version: 0.31.0						    version: 0.31.0
+  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cloud-provider-vsphere				  - name: cloud-provider-vsphere
+    version: 1.12.0					      |	    version: 2.0.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns						  - name: coredns
+    version: 1.24.0						    version: 1.24.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns-extensions					  - name: coredns-extensions
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag						  - name: etcd-defrag
+    version: 1.0.1						    version: 1.0.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
+    version: 1.10.1						    version: 1.10.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: external-dns						  - name: external-dns
+    version: 3.2.0						    version: 3.2.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
+    version: 0.10.1						    version: 0.10.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
+    version: 2.8.1						    version: 2.8.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+							      >	  - name: kube-vip
+							      >	    version: 0.2.0
+							      >	    dependsOn:
+							      >	    - cilium
+							      >	  - name: kube-vip-cloud-provider
+							      >	    version: 0.3.0
+							      >	    dependsOn:
+							      >	    - cilium
+  - name: metrics-server					  - name: metrics-server
+    version: 2.6.0						    version: 2.6.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: net-exporter						  - name: net-exporter
+    version: 1.21.0						    version: 1.21.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: network-policies					  - name: network-policies
+    catalog: cluster						    catalog: cluster
+    version: 0.1.1						    version: 0.1.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: node-exporter						  - name: node-exporter
+    version: 1.20.1						    version: 1.20.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: observability-bundle					  - name: observability-bundle
+    version: 1.9.0						    version: 1.9.0
+    dependsOn:							    dependsOn:
+    - coredns							    - coredns
+  - name: observability-policies				  - name: observability-policies
+    version: 0.0.1						    version: 0.0.1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
+    version: 0.5.0						    version: 0.5.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: security-bundle					  - name: security-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 1.9.1						    version: 1.9.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: teleport-kube-agent					  - name: teleport-kube-agent
+    version: 0.10.3						    version: 0.10.3
+  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
+    version: 5.4.0						    version: 5.4.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0						    version: 3.2.0
+							      >	  - name: vsphere-csi-driver
+							      >	    version: 3.4.2
+							      >	    dependsOn:
+							      >	    - cilium
+  components:							  components:
+  - name: cluster-vsphere					  - name: cluster-vsphere
+    catalog: cluster						    catalog: cluster
+    version: 0.69.0					      |	    version: 1.0.0
+  - name: flatcar						  - name: flatcar
+    version: 4152.2.1						    version: 4152.2.1
+  - name: kubernetes						  - name: kubernetes
+    version: 1.30.10						    version: 1.30.10
+  - name: os-tooling						  - name: os-tooling
+    version: 1.23.1						    version: 1.23.1
+  date: "2025-03-03T12:00:00Z"				      |	  date: "2025-03-17T12:00:00Z"
+  state: active							  state: active

--- a/vsphere/v30.1.0/release.diff
+++ b/vsphere/v30.1.0/release.diff
@@ -113,7 +113,7 @@ spec:									spec:
   components:								  components:
   - name: cluster-vsphere						  - name: cluster-vsphere
     catalog: cluster							    catalog: cluster
-    version: 0.69.0						|           version: 1.0.0
+    version: 0.69.0						|           version: 1.1.0
   - name: flatcar							  - name: flatcar
     version: 4152.2.1							    version: 4152.2.1
   - name: kubernetes							  - name: kubernetes

--- a/vsphere/v30.1.0/release.yaml
+++ b/vsphere/v30.1.0/release.yaml
@@ -112,8 +112,8 @@ spec:
     - cilium
   components:
   - name: cluster-vsphere
-    catalog: cluster
-    version: 1.0.0
+    catalog: cluster-test
+    version: 1.0.0-5fa2e52498eaede78e5c3977cd6c339ba92ec176
   - name: flatcar
     version: 4152.2.1
   - name: kubernetes

--- a/vsphere/v30.1.0/release.yaml
+++ b/vsphere/v30.1.0/release.yaml
@@ -113,7 +113,7 @@ spec:
   components:
   - name: cluster-vsphere
     catalog: cluster-test
-    version: 1.0.0-5fa2e52498eaede78e5c3977cd6c339ba92ec176
+    version: 1.0.0-be7bf400e85db8b9db216a3f6deac529f5a17d20
   - name: flatcar
     version: 4152.2.1
   - name: kubernetes

--- a/vsphere/v30.1.0/release.yaml
+++ b/vsphere/v30.1.0/release.yaml
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-30.1.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 1.0.1
+  - name: cert-exporter
+    version: 2.9.4
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.0.1
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.24.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.2.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.21.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.1
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.9.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.3
+  - name: vertical-pod-autoscaler
+    version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0
+  - name: vsphere-csi-driver
+    version: 3.4.2
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 1.0.0
+  - name: flatcar
+    version: 4152.2.1
+  - name: kubernetes
+    version: 1.30.10
+  - name: os-tooling
+    version: 1.23.1
+  date: "2025-03-17T12:00:00Z"
+  state: active

--- a/vsphere/v30.1.0/release.yaml
+++ b/vsphere/v30.1.0/release.yaml
@@ -112,8 +112,8 @@ spec:
     - cilium
   components:
   - name: cluster-vsphere
-    catalog: cluster-test
-    version: 1.0.0-be7bf400e85db8b9db216a3f6deac529f5a17d20
+    catalog: cluster
+    version: 1.1.0
   - name: flatcar
     version: 4152.2.1
   - name: kubernetes

--- a/vsphere/v30.1.0/release.yaml
+++ b/vsphere/v30.1.0/release.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   apps:
   - name: capi-node-labeler
-    version: 1.0.1
+    version: 1.0.2
   - name: cert-exporter
-    version: 2.9.4
+    version: 2.9.5
     dependsOn:
     - kyverno-crds
   - name: cert-manager
@@ -19,7 +19,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cilium
-    version: 0.31.0
+    version: 0.31.1
   - name: cilium-servicemonitors
     version: 0.1.2
     dependsOn:
@@ -37,11 +37,11 @@ spec:
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: etcd-defrag
-    version: 1.0.1
+    version: 1.0.2
     dependsOn:
     - kyverno-crds
   - name: etcd-k8s-res-count-exporter
-    version: 1.10.1
+    version: 1.10.3
     dependsOn:
     - kyverno-crds
   - name: external-dns
@@ -49,7 +49,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: k8s-audit-metrics
-    version: 0.10.1
+    version: 0.10.2
     dependsOn:
     - kyverno-crds
   - name: k8s-dns-node-cache
@@ -69,7 +69,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: net-exporter
-    version: 1.21.0
+    version: 1.22.0
     dependsOn:
     - prometheus-operator-crd
   - name: network-policies
@@ -78,11 +78,11 @@ spec:
     dependsOn:
     - cilium
   - name: node-exporter
-    version: 1.20.1
+    version: 1.20.2
     dependsOn:
     - kyverno-crds
   - name: observability-bundle
-    version: 1.9.0
+    version: 1.11.0
     dependsOn:
     - coredns
   - name: observability-policies
@@ -95,11 +95,11 @@ spec:
     - prometheus-operator-crd
   - name: security-bundle
     catalog: giantswarm
-    version: 1.9.1
+    version: 1.10.0
     dependsOn:
     - prometheus-operator-crd
   - name: teleport-kube-agent
-    version: 0.10.3
+    version: 0.10.4
   - name: vertical-pod-autoscaler
     version: 5.4.0
     dependsOn:
@@ -117,8 +117,8 @@ spec:
   - name: flatcar
     version: 4152.2.1
   - name: kubernetes
-    version: 1.30.10
+    version: 1.30.11
   - name: os-tooling
-    version: 1.23.1
-  date: "2025-03-17T12:00:00Z"
+    version: 1.24.0
+  date: "2025-03-18T12:00:00Z"
   state: active


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/32808

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
