### PR TITLE
CAPA: Release v30.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to all Giant Swarm installations.
 ## AWS
 
 - v30
+  - v30.1
+    - [v30.1.0](https://github.com/giantswarm/releases/tree/master/capa/v30.1.0)
   - v30.0
     - [v30.0.0](https://github.com/giantswarm/releases/tree/master/capa/v30.0.0)
 

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -49,6 +49,7 @@ resources:
 - v29.6.2
 - v29.6.3
 - v30.0.0
+- v30.1.0
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -349,6 +349,13 @@
       "releaseTimestamp": "2025-02-20 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "30.1.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-03-18 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.1.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v30.1.0/README.md
+++ b/capa/v30.1.0/README.md
@@ -1,0 +1,158 @@
+# :zap: Giant Swarm Release v30.1.0 for CAPA :zap:
+
+## Changes compared to v30.0.0
+
+### Components
+
+- cluster-aws from v3.0.0 to v3.2.1
+- Kubernetes from v1.30.10 to [v1.30.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md)
+- os-tooling from v1.23.1 to v1.24.0
+
+### cluster-aws [v3.0.0...v3.2.1](https://github.com/giantswarm/cluster-aws/compare/v3.0.0...v3.2.1)
+
+#### Added
+
+- Add ingress rule in nodes Security Group to allow access for monitoring Chart Operator, EBS CSI Controller, Cilium Operator and Node Exporter.
+- Add ingress rule in nodes Security Group to allow access to the Cilium Relay when using ENI mode.
+- Add option `global.providerSpecific.nodeTerminationHandlerEnabled` to disable the AWS Node Termination Handler (NTH).
+
+#### Changed
+
+- Chart: Update `cluster` to v2.2.0.
+
+### os-tooling [v1.23.1...v1.24.0](https://github.com/giantswarm/capi-image-builder/compare/v1.23.1...v1.24.0)
+
+#### Added
+
+- Added nvidia_runtime to allow running of GPU workloads
+
+### Apps
+
+- aws-ebs-csi-driver from v3.0.3 to v3.0.5
+- aws-pod-identity-webhook from v1.19.0 to v1.19.1
+- capi-node-labeler from v1.0.1 to v1.0.2
+- cert-exporter from v2.9.4 to v2.9.5
+- cilium from v0.31.0 to v0.31.1
+- cloud-provider-aws from v1.30.7-gs3 to v1.30.8-gs1
+- cluster-autoscaler from v1.30.3-gs2 to v1.30.4-gs1
+- etcd-defrag from v1.0.1 to v1.0.2
+- etcd-kubernetes-resources-count-exporter from v1.10.1 to v1.10.3
+- k8s-audit-metrics from v0.10.1 to v0.10.2
+- net-exporter from v1.21.0 to v1.22.0
+- node-exporter from v1.20.1 to v1.20.2
+- observability-bundle from v1.9.0 to v1.11.0
+- security-bundle from v1.9.1 to v1.10.0
+- teleport-kube-agent from v0.10.3 to v0.10.4
+
+### aws-ebs-csi-driver [v3.0.3...v3.0.5](https://github.com/giantswarm/aws-ebs-csi-driver-app/compare/v3.0.3...v3.0.5)
+
+#### Changed
+
+- Chart: Update `snapshot-controller` to v8.2.1. ([#283](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/283))
+- Chart: Sync to upstream. ([#264](https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/264))
+
+### aws-pod-identity-webhook [v1.19.0...v1.19.1](https://github.com/giantswarm/aws-pod-identity-webhook/compare/v1.19.0...v1.19.1)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### capi-node-labeler [v1.0.1...v1.0.2](https://github.com/giantswarm/capi-node-labeler-app/compare/v1.0.1...v1.0.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cert-exporter [v2.9.4...v2.9.5](https://github.com/giantswarm/cert-exporter/compare/v2.9.4...v2.9.5)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v0.31.0...v0.31.1](https://github.com/giantswarm/cilium-app/compare/v0.31.0...v0.31.1)
+
+#### Changed
+
+- Upgrade Cilium to [v1.16.7](https://github.com/cilium/cilium/releases/tag/v1.16.7).
+
+### cloud-provider-aws [v1.30.7-gs3...v1.30.8-gs1](https://github.com/giantswarm/aws-cloud-controller-manager-app/compare/v1.30.7-gs3...v1.30.8-gs1)
+
+#### Changed
+
+- Chart: Update to upstream v1.30.8.
+
+### cluster-autoscaler [v1.30.3-gs2...v1.30.4-gs1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.30.3-gs2...v1.30.4-gs1)
+
+#### Changed
+
+- Chart: Update to upstream v1.30.4. ([#308](https://github.com/giantswarm/cluster-autoscaler-app/pull/308))
+
+### etcd-defrag [v1.0.1...v1.0.2](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.1...v1.0.2)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.25.0. ([#17](https://github.com/giantswarm/etcd-defrag-app/pull/17))
+
+### etcd-kubernetes-resources-count-exporter [v1.10.1...v1.10.3](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.1...v1.10.3)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-audit-metrics [v0.10.1...v0.10.2](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.1...v0.10.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### net-exporter [v1.21.0...v1.22.0](https://github.com/giantswarm/net-exporter/compare/v1.21.0...v1.22.0)
+
+#### Changed
+
+- Narrow down CiliumNetworkPolicy to allow desired traffic only.
+
+#### Removed
+
+- Remove NetworkPolicy resource and rely on CiliumNetworkPolicy only.
+
+### node-exporter [v1.20.1...v1.20.2](https://github.com/giantswarm/node-exporter-app/compare/v1.20.1...v1.20.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### observability-bundle [v1.9.0...v1.11.0](https://github.com/giantswarm/observability-bundle/compare/v1.9.0...v1.11.0)
+
+#### Changed
+
+- prometheus-operator will not check promql syntax for prometheusRules that are labelled `observability.giantswarm.io/rule-type: logs`
+- Upgrade `alloy` to chart 0.9.0.
+  - Bumps `alloy` from to 1.5.1 to 1.7.1
+- Upgrade `kube-prometheus-stack` from 66.2.1 to 69.5.1
+  - Bumps prometheus-operator to 0.80.1
+  - Bumps prometheus to 3.0.1
+
+### security-bundle [v1.9.1...v1.10.0](https://github.com/giantswarm/security-bundle/compare/v1.9.1...v1.10.0)
+
+#### Added
+
+- Add e2e tests for the `security-bundle` and all is components
+
+#### Changed
+
+- Update `kyverno` (app) to v0.19.0.
+- Update `kyverno-crds` (app) to v1.13.0.
+- Update `kyverno-policies` (app) to v0.23.0.
+- Update `edgedb` (app) to v0.1.0.
+- Update `falco` (app) to v0.10.0.
+- Update `trivy` (app) to v0.13.2.
+
+### teleport-kube-agent [v0.10.3...v0.10.4](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.3...v0.10.4)
+
+#### Added
+
+- Add headless service on `diag` port 3000.
+
+#### Changed
+
+- Migrated to ABS

--- a/capa/v30.1.0/announcement.md
+++ b/capa/v30.1.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v30.1.0 for CAPA is available**. This release updates Kubernetes to v1.30.11 and introduces various enhancements and fixes to our apps and components.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-30.1.0).

--- a/capa/v30.1.0/kustomization.yaml
+++ b/capa/v30.1.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v30.1.0/release.diff
+++ b/capa/v30.1.0/release.diff
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-30.0.0						|         name: aws-30.1.0
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 3.0.3						|           version: 3.0.5
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: aws-nth-bundle						  - name: aws-nth-bundle
+    version: 1.2.1							    version: 1.2.1
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.19.0						|           version: 1.19.1
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 1.0.1						|           version: 1.0.2
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.4						|           version: 2.9.5
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.9.0							    version: 3.9.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.31.0						|           version: 0.31.1
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    catalog: cluster							    catalog: cluster
+    version: 0.2.0							    version: 0.2.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.30.7-gs3						|           version: 1.30.8-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.30.3-gs2						|           version: 1.30.4-gs1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: coredns							  - name: coredns
+    version: 1.24.0							    version: 1.24.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns-extensions						  - name: coredns-extensions
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag							  - name: etcd-defrag
+    version: 1.0.1						|           version: 1.0.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.1						|           version: 1.10.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.2.0							    version: 3.2.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.1						|           version: 0.10.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.6.0							    version: 2.6.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.21.0						|           version: 1.22.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.1						|           version: 1.20.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.9.0						|           version: 1.11.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.5.0							    version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.9.1						|           version: 1.10.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.3						|           version: 0.10.4
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.4.0							    version: 5.4.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0							    version: 3.2.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 3.0.0						|           version: 3.2.1
+  - name: flatcar							  - name: flatcar
+    version: 4152.2.1							    version: 4152.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.30.10						|           version: 1.30.11
+  - name: os-tooling							  - name: os-tooling
+    version: 1.23.1						|           version: 1.24.0
+  date: "2025-02-20T12:00:00Z"					|         date: "2025-03-18T12:00:00Z"
+  state: active								  state: active

--- a/capa/v30.1.0/release.yaml
+++ b/capa/v30.1.0/release.yaml
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-30.1.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.5
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.1
+  - name: aws-pod-identity-webhook
+    version: 1.19.1
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.0.2
+  - name: cert-exporter
+    version: 2.9.5
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.1
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.0
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.30.8-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.30.4-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.24.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.11.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.10.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.4
+  - name: vertical-pod-autoscaler
+    version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 3.2.1
+  - name: flatcar
+    version: 4152.2.1
+  - name: kubernetes
+    version: 1.30.11
+  - name: os-tooling
+    version: 1.24.0
+  date: "2025-03-18T12:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
