### PR TITLE
CAPA: Release v30.1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ to all Giant Swarm installations.
 
 - v30
   - v30.1
+    - [v30.1.1](https://github.com/giantswarm/releases/tree/master/capa/v30.1.1)
     - [v30.1.0](https://github.com/giantswarm/releases/tree/master/capa/v30.1.0)
   - v30.0
     - [v30.0.0](https://github.com/giantswarm/releases/tree/master/capa/v30.0.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,5 +1,3 @@
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v25.0.0
 - v25.1.0
@@ -54,6 +52,10 @@ resources:
 - v30.0.0
 - v30.1.0
 - v30.1.1
+
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
+
 transformers:
 - |
   apiVersion: builtin

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,3 +1,5 @@
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v25.0.0
 - v25.1.0
@@ -51,10 +53,7 @@ resources:
 - v29.6.3
 - v30.0.0
 - v30.1.0
-
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-
+- v30.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -367,8 +367,8 @@
     {
       "version": "30.1.1",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-04-29T16:50:46-04:00",
-      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v30.1.1/README.md",
+      "releaseTimestamp": "2025-04-29 18:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.1.1/README.md",
       "isStable": true
     }
   ],

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -363,6 +363,13 @@
       "releaseTimestamp": "2025-03-18 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "30.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-04-29T16:50:46-04:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v30.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v30.1.1/README.md
+++ b/capa/v30.1.1/README.md
@@ -6,26 +6,16 @@
 
 ### Components
 
-
-
-
-
 ### Apps
-
-
 
 * security-bundle from 1.10.0 to [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
 
-
-
-
-
 ### security-bundle [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+
+#### Important
+
+**Note:** Kyverno `PolicyExceptions` (API group `kyverno.io`) versions `v2alpha1` and `v2beta1` are deprecated and will be removed in the next Kyverno minor release (v1.14). Please update all Kyverno PolicyExceptions to `v2`. No action is required for Giant Swarm Policy API `PolicyExceptions` (API group `policy.giantswarm.io`), which are handled automatically.
 
 #### Changed
 
 - Update `kyverno-crds` (app) to v1.13.1.
-
-
-
-

--- a/capa/v30.1.1/README.md
+++ b/capa/v30.1.1/README.md
@@ -1,16 +1,12 @@
 # :zap: Giant Swarm Release v30.1.1 for CAPA :zap:
 
-<< Add description here >>
-
 ## Changes compared to v30.1.0
-
-### Components
 
 ### Apps
 
-* security-bundle from 1.10.0 to [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+- security-bundle from v1.10.0 to v1.10.1
 
-### security-bundle [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+### security-bundle [v1.10.0...v1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
 
 #### Important
 

--- a/capa/v30.1.1/README.md
+++ b/capa/v30.1.1/README.md
@@ -1,0 +1,31 @@
+# :zap: Giant Swarm Release v30.1.1 for CAPA :zap:
+
+<< Add description here >>
+
+## Changes compared to v30.1.0
+
+### Components
+
+
+
+
+
+### Apps
+
+
+
+* security-bundle from 1.10.0 to [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+
+
+
+
+
+### security-bundle [1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+
+#### Changed
+
+- Update `kyverno-crds` (app) to v1.13.1.
+
+
+
+

--- a/capa/v30.1.1/README.md
+++ b/capa/v30.1.1/README.md
@@ -1,5 +1,7 @@
 # :zap: Giant Swarm Release v30.1.1 for CAPA :zap:
 
+This release reverts removal of `PolicyExceptions` v2alpha1 API version for smoother transition for any customer and GS workloads. The deprecated API version of `v2alpha1` will be fully removed in next major release.
+
 ## Changes compared to v30.1.0
 
 ### Apps

--- a/capa/v30.1.1/announcement.md
+++ b/capa/v30.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v30.1.1 for CAPA is available**. << Add description here >> 
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-30.1.1).

--- a/capa/v30.1.1/announcement.md
+++ b/capa/v30.1.1/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v30.1.1 for CAPA is available**. << Add description here >> 
+**Workload cluster release v30.1.1 for CAPA is available**.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-30.1.1).

--- a/capa/v30.1.1/announcement.md
+++ b/capa/v30.1.1/announcement.md
@@ -1,3 +1,5 @@
 **Workload cluster release v30.1.1 for CAPA is available**.
 
+This release reverts removal of `PolicyExceptions` v2alpha1 API version for smoother transition for any customer and GS workloads. The deprecated API version of `v2alpha1` will be fully removed in next major release.
+
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-30.1.1).

--- a/capa/v30.1.1/kustomization.yaml
+++ b/capa/v30.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v30.1.1/release.diff
+++ b/capa/v30.1.1/release.diff
@@ -1,0 +1,159 @@
+                                                                >  # Generated with:
+                                                                >  # devctl release create --name 30.1.1 --provider aws --base 30.
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-30.1.0                                              |    creationTimestamp: null
+                                                                >    name: aws-30.1.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                    |    - dependsOn:
+    version: 3.0.5                                              <
+    dependsOn:                                                  <
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                    |      name: aws-ebs-csi-driver
+    version: 0.1.0                                              |      version: 3.0.5
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+                                                                >      name: aws-ebs-csi-driver-servicemonitors
+                                                                >      version: 0.1.0
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.2.1                                                     version: 1.2.1
+  - name: aws-pod-identity-webhook                              |    - dependsOn:
+    version: 1.19.1                                             <
+    dependsOn:                                                  <
+    - cert-manager                                                     - cert-manager
+                                                                >      name: aws-pod-identity-webhook
+                                                                >      version: 1.19.1
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.0.2                                                     version: 1.0.2
+  - name: cert-exporter                                         |    - dependsOn:
+    version: 2.9.5                                              <
+    dependsOn:                                                  <
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                          |      name: cert-exporter
+                                                                >      version: 2.9.5
+                                                                >    - dependsOn:
+                                                                >      - prometheus-operator-crd
+                                                                >      name: cert-manager
+    version: 3.9.0                                                     version: 3.9.0
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                             |      name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                   <
+  - name: cilium                                                     - name: cilium
+    version: 0.31.1                                                    version: 0.31.1
+  - name: cilium-crossplane-resources                           |    - catalog: cluster
+    catalog: cluster                                            |      name: cilium-crossplane-resources
+    version: 0.2.0                                                     version: 0.2.0
+  - name: cilium-servicemonitors                                |    - dependsOn:
+    version: 0.1.2                                              <
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                    |      name: cilium-servicemonitors
+    version: 1.30.8-gs1                                         |      version: 0.1.2
+    dependsOn:                                                  |    - dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                    |      name: cloud-provider-aws
+    version: 1.30.4-gs1                                         |      version: 1.30.8-gs1
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                               |      name: cluster-autoscaler
+    version: 1.24.0                                             |      version: 1.30.4-gs1
+    dependsOn:                                                  |    - dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                    |      name: coredns
+    version: 0.1.2                                              |      version: 1.24.0
+    dependsOn:                                                  |    - dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                           |      name: coredns-extensions
+                                                                >      version: 0.1.2
+                                                                >    - dependsOn:
+                                                                >      - kyverno-crds
+                                                                >      name: etcd-defrag
+    version: 1.0.2                                                     version: 1.0.2
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                           |      name: etcd-k8s-res-count-exporter
+    version: 1.10.3                                                    version: 1.10.3
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                              |      - prometheus-operator-crd
+  - name: external-dns                                          |      name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                  |      name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                   |      - kyverno-crds
+  - name: k8s-audit-metrics                                     |      name: k8s-audit-metrics
+    version: 0.10.2                                                    version: 0.10.2
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                    |      name: k8s-dns-node-cache
+    version: 2.8.1                                                     version: 2.8.1
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                        |      name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                              <
+  - name: net-exporter                                          <
+    version: 1.22.0                                             <
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                      |      name: net-exporter
+    catalog: cluster                                            |      version: 1.22.0
+    version: 0.1.1                                              |    - catalog: cluster
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                         |      name: network-policies
+    version: 1.20.2                                             |      version: 0.1.1
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                  |      name: node-exporter
+    version: 1.11.0                                             |      version: 1.20.2
+    dependsOn:                                                  |    - dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                |      name: observability-bundle
+    version: 0.0.1                                              |      version: 1.11.0
+    dependsOn:                                                  |    - dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                          |      name: observability-policies
+    version: 0.5.0                                              |      version: 0.0.1
+    dependsOn:                                                  |    - dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                       |      name: prometheus-blackbox-exporter
+    catalog: giantswarm                                         |      version: 0.5.0
+    version: 1.10.0                                             |    - catalog: giantswarm
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+                                                                >      name: security-bundle
+                                                                >      version: 1.10.1
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.4                                                    version: 0.10.4
+  - name: vertical-pod-autoscaler                               |    - dependsOn:
+    version: 5.4.0                                              <
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+                                                                >      name: vertical-pod-autoscaler
+                                                                >      version: 5.4.0
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.2.0                                                     version: 3.2.0
+  components:                                                        components:
+  - name: cluster-aws                                           |    - catalog: cluster
+    catalog: cluster                                            |      name: cluster-aws
+    version: 3.2.1                                                     version: 3.2.1
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.1                                                  version: 4152.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.30.11                                                   version: 1.30.11
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.24.0                                                    version: 1.24.0
+  date: "2025-03-18T12:00:00Z"                                  |    date: "2025-04-29T20:50:46Z"
+  state: active                                                      state: active
+                                                                >  status:
+                                                                >    inUse: false
+                                                                >    ready: false

--- a/capa/v30.1.1/release.diff
+++ b/capa/v30.1.1/release.diff
@@ -1,159 +1,137 @@
-                                                                >  # Generated with:
-                                                                >  # devctl release create --name 30.1.1 --provider aws --base 30.
-apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
-kind: Release                                                      kind: Release
-metadata:                                                          metadata:
-  name: aws-30.1.0                                              |    creationTimestamp: null
-                                                                >    name: aws-30.1.1
-spec:                                                              spec:
-  apps:                                                              apps:
-  - name: aws-ebs-csi-driver                                    |    - dependsOn:
-    version: 3.0.5                                              <
-    dependsOn:                                                  <
-    - cloud-provider-aws                                               - cloud-provider-aws
-  - name: aws-ebs-csi-driver-servicemonitors                    |      name: aws-ebs-csi-driver
-    version: 0.1.0                                              |      version: 3.0.5
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-                                                                >      name: aws-ebs-csi-driver-servicemonitors
-                                                                >      version: 0.1.0
-  - name: aws-nth-bundle                                             - name: aws-nth-bundle
-    version: 1.2.1                                                     version: 1.2.1
-  - name: aws-pod-identity-webhook                              |    - dependsOn:
-    version: 1.19.1                                             <
-    dependsOn:                                                  <
-    - cert-manager                                                     - cert-manager
-                                                                >      name: aws-pod-identity-webhook
-                                                                >      version: 1.19.1
-  - name: capi-node-labeler                                          - name: capi-node-labeler
-    version: 1.0.2                                                     version: 1.0.2
-  - name: cert-exporter                                         |    - dependsOn:
-    version: 2.9.5                                              <
-    dependsOn:                                                  <
-    - kyverno-crds                                                     - kyverno-crds
-  - name: cert-manager                                          |      name: cert-exporter
-                                                                >      version: 2.9.5
-                                                                >    - dependsOn:
-                                                                >      - prometheus-operator-crd
-                                                                >      name: cert-manager
-    version: 3.9.0                                                     version: 3.9.0
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: chart-operator-extensions                             |      name: chart-operator-extensions
-    version: 1.1.2                                                     version: 1.1.2
-    dependsOn:                                                  <
-    - prometheus-operator-crd                                   <
-  - name: cilium                                                     - name: cilium
-    version: 0.31.1                                                    version: 0.31.1
-  - name: cilium-crossplane-resources                           |    - catalog: cluster
-    catalog: cluster                                            |      name: cilium-crossplane-resources
-    version: 0.2.0                                                     version: 0.2.0
-  - name: cilium-servicemonitors                                |    - dependsOn:
-    version: 0.1.2                                              <
-    dependsOn:                                                  <
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: cloud-provider-aws                                    |      name: cilium-servicemonitors
-    version: 1.30.8-gs1                                         |      version: 0.1.2
-    dependsOn:                                                  |    - dependsOn:
-    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - name: cluster-autoscaler                                    |      name: cloud-provider-aws
-    version: 1.30.4-gs1                                         |      version: 1.30.8-gs1
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: coredns                                               |      name: cluster-autoscaler
-    version: 1.24.0                                             |      version: 1.30.4-gs1
-    dependsOn:                                                  |    - dependsOn:
-    - cilium                                                           - cilium
-  - name: coredns-extensions                                    |      name: coredns
-    version: 0.1.2                                              |      version: 1.24.0
-    dependsOn:                                                  |    - dependsOn:
-    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
-  - name: etcd-defrag                                           |      name: coredns-extensions
-                                                                >      version: 0.1.2
-                                                                >    - dependsOn:
-                                                                >      - kyverno-crds
-                                                                >      name: etcd-defrag
-    version: 1.0.2                                                     version: 1.0.2
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: etcd-k8s-res-count-exporter                           |      name: etcd-k8s-res-count-exporter
-    version: 1.10.3                                                    version: 1.10.3
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                              |      - prometheus-operator-crd
-  - name: external-dns                                          |      name: external-dns
-    version: 3.2.0                                                     version: 3.2.0
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: irsa-servicemonitors                                  |      name: irsa-servicemonitors
-    version: 0.1.0                                                     version: 0.1.0
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                   |      - kyverno-crds
-  - name: k8s-audit-metrics                                     |      name: k8s-audit-metrics
-    version: 0.10.2                                                    version: 0.10.2
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: k8s-dns-node-cache                                    |      name: k8s-dns-node-cache
-    version: 2.8.1                                                     version: 2.8.1
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: metrics-server                                        |      name: metrics-server
-    version: 2.6.0                                                     version: 2.6.0
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                              <
-  - name: net-exporter                                          <
-    version: 1.22.0                                             <
-    dependsOn:                                                  <
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: network-policies                                      |      name: net-exporter
-    catalog: cluster                                            |      version: 1.22.0
-    version: 0.1.1                                              |    - catalog: cluster
-    dependsOn:                                                         dependsOn:
-    - cilium                                                           - cilium
-  - name: node-exporter                                         |      name: network-policies
-    version: 1.20.2                                             |      version: 0.1.1
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: observability-bundle                                  |      name: node-exporter
-    version: 1.11.0                                             |      version: 1.20.2
-    dependsOn:                                                  |    - dependsOn:
-    - coredns                                                          - coredns
-  - name: observability-policies                                |      name: observability-bundle
-    version: 0.0.1                                              |      version: 1.11.0
-    dependsOn:                                                  |    - dependsOn:
-    - kyverno-crds                                                     - kyverno-crds
-  - name: prometheus-blackbox-exporter                          |      name: observability-policies
-    version: 0.5.0                                              |      version: 0.0.1
-    dependsOn:                                                  |    - dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-  - name: security-bundle                                       |      name: prometheus-blackbox-exporter
-    catalog: giantswarm                                         |      version: 0.5.0
-    version: 1.10.0                                             |    - catalog: giantswarm
-    dependsOn:                                                         dependsOn:
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-                                                                >      name: security-bundle
-                                                                >      version: 1.10.1
-  - name: teleport-kube-agent                                        - name: teleport-kube-agent
-    version: 0.10.4                                                    version: 0.10.4
-  - name: vertical-pod-autoscaler                               |    - dependsOn:
-    version: 5.4.0                                              <
-    dependsOn:                                                  <
-    - prometheus-operator-crd                                          - prometheus-operator-crd
-                                                                >      name: vertical-pod-autoscaler
-                                                                >      version: 5.4.0
-  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
-    version: 3.2.0                                                     version: 3.2.0
-  components:                                                        components:
-  - name: cluster-aws                                           |    - catalog: cluster
-    catalog: cluster                                            |      name: cluster-aws
-    version: 3.2.1                                                     version: 3.2.1
-  - name: flatcar                                                    - name: flatcar
-    version: 4152.2.1                                                  version: 4152.2.1
-  - name: kubernetes                                                 - name: kubernetes
-    version: 1.30.11                                                   version: 1.30.11
-  - name: os-tooling                                                 - name: os-tooling
-    version: 1.24.0                                                    version: 1.24.0
-  date: "2025-03-18T12:00:00Z"                                  |    date: "2025-04-29T20:50:46Z"
-  state: active                                                      state: active
-                                                                >  status:
-                                                                >    inUse: false
-                                                                >    ready: false
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: aws-30.1.0						|         name: aws-30.1.1
+spec:									spec:
+  apps:									  apps:
+  - name: aws-ebs-csi-driver						  - name: aws-ebs-csi-driver
+    version: 3.0.5							    version: 3.0.5
+    dependsOn:								    dependsOn:
+    - cloud-provider-aws						    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors				  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: aws-nth-bundle						  - name: aws-nth-bundle
+    version: 1.2.1							    version: 1.2.1
+  - name: aws-pod-identity-webhook					  - name: aws-pod-identity-webhook
+    version: 1.19.1							    version: 1.19.1
+    dependsOn:								    dependsOn:
+    - cert-manager							    - cert-manager
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 1.0.2							    version: 1.0.2
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.5							    version: 2.9.5
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.9.0							    version: 3.9.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.31.1							    version: 0.31.1
+  - name: cilium-crossplane-resources					  - name: cilium-crossplane-resources
+    catalog: cluster							    catalog: cluster
+    version: 0.2.0							    version: 0.2.0
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-aws						  - name: cloud-provider-aws
+    version: 1.30.8-gs1							    version: 1.30.8-gs1
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler						  - name: cluster-autoscaler
+    version: 1.30.4-gs1							    version: 1.30.4-gs1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: coredns							  - name: coredns
+    version: 1.24.0							    version: 1.24.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns-extensions						  - name: coredns-extensions
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag							  - name: etcd-defrag
+    version: 1.0.2							    version: 1.0.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3							    version: 1.10.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.2.0							    version: 3.2.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: irsa-servicemonitors						  - name: irsa-servicemonitors
+    version: 0.1.0							    version: 0.1.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.2							    version: 0.10.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: metrics-server						  - name: metrics-server
+    version: 2.6.0							    version: 2.6.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.22.0							    version: 1.22.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.2							    version: 1.20.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.11.0							    version: 1.11.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.5.0							    version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.10.0						|           version: 1.10.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.4							    version: 0.10.4
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.4.0							    version: 5.4.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0							    version: 3.2.0
+  components:								  components:
+  - name: cluster-aws							  - name: cluster-aws
+    catalog: cluster							    catalog: cluster
+    version: 3.2.1							    version: 3.2.1
+  - name: flatcar							  - name: flatcar
+    version: 4152.2.1							    version: 4152.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.30.11							    version: 1.30.11
+  - name: os-tooling							  - name: os-tooling
+    version: 1.24.0							    version: 1.24.0
+  date: "2025-03-18T12:00:00Z"					|         date: "2025-04-29T18:00:00Z"
+  state: active								  state: active

--- a/capa/v30.1.1/release.yaml
+++ b/capa/v30.1.1/release.yaml
@@ -1,0 +1,147 @@
+# Generated with:
+# devctl release create --name 30.1.1 --provider aws --base 30.1.0 --app security-bundle@1.10.1
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  creationTimestamp: null
+  name: aws-30.1.1
+spec:
+  apps:
+  - dependsOn:
+    - cloud-provider-aws
+    name: aws-ebs-csi-driver
+    version: 3.0.5
+  - dependsOn:
+    - prometheus-operator-crd
+    name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+  - name: aws-nth-bundle
+    version: 1.2.1
+  - dependsOn:
+    - cert-manager
+    name: aws-pod-identity-webhook
+    version: 1.19.1
+  - name: capi-node-labeler
+    version: 1.0.2
+  - dependsOn:
+    - kyverno-crds
+    name: cert-exporter
+    version: 2.9.5
+  - dependsOn:
+    - prometheus-operator-crd
+    name: cert-manager
+    version: 3.9.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: chart-operator-extensions
+    version: 1.1.2
+  - name: cilium
+    version: 0.31.1
+  - catalog: cluster
+    name: cilium-crossplane-resources
+    version: 0.2.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: cilium-servicemonitors
+    version: 0.1.2
+  - dependsOn:
+    - vertical-pod-autoscaler-crd
+    name: cloud-provider-aws
+    version: 1.30.8-gs1
+  - dependsOn:
+    - kyverno-crds
+    name: cluster-autoscaler
+    version: 1.30.4-gs1
+  - dependsOn:
+    - cilium
+    name: coredns
+    version: 1.24.0
+  - dependsOn:
+    - vertical-pod-autoscaler-crd
+    name: coredns-extensions
+    version: 0.1.2
+  - dependsOn:
+    - kyverno-crds
+    name: etcd-defrag
+    version: 1.0.2
+  - dependsOn:
+    - kyverno-crds
+    name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+  - dependsOn:
+    - prometheus-operator-crd
+    name: external-dns
+    version: 3.2.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: irsa-servicemonitors
+    version: 0.1.0
+  - dependsOn:
+    - kyverno-crds
+    name: k8s-audit-metrics
+    version: 0.10.2
+  - dependsOn:
+    - kyverno-crds
+    name: k8s-dns-node-cache
+    version: 2.8.1
+  - dependsOn:
+    - kyverno-crds
+    name: metrics-server
+    version: 2.6.0
+  - dependsOn:
+    - prometheus-operator-crd
+    name: net-exporter
+    version: 1.22.0
+  - catalog: cluster
+    dependsOn:
+    - cilium
+    name: network-policies
+    version: 0.1.1
+  - dependsOn:
+    - kyverno-crds
+    name: node-exporter
+    version: 1.20.2
+  - dependsOn:
+    - coredns
+    name: observability-bundle
+    version: 1.11.0
+  - dependsOn:
+    - kyverno-crds
+    name: observability-policies
+    version: 0.0.1
+  - dependsOn:
+    - prometheus-operator-crd
+    name: prometheus-blackbox-exporter
+    version: 0.5.0
+  - catalog: giantswarm
+    dependsOn:
+    - prometheus-operator-crd
+    name: security-bundle
+    version: 1.10.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.4
+  - dependsOn:
+    - prometheus-operator-crd
+    name: vertical-pod-autoscaler
+    version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0
+  components:
+  - catalog: cluster
+    name: cluster-aws
+    version: 3.2.1
+  - name: flatcar
+    version: 4152.2.1
+  - name: kubernetes
+    version: 1.30.11
+  - name: os-tooling
+    version: 1.24.0
+  date: "2025-04-29T20:50:46Z"
+  state: active
+status:
+  inUse: false
+  ready: false

--- a/capa/v30.1.1/release.yaml
+++ b/capa/v30.1.1/release.yaml
@@ -118,16 +118,12 @@ spec:
     - prometheus-operator-crd
     name: security-bundle
     version: 1.10.1
-    dependsOn:
-    - prometheus-operator-crd
   - name: teleport-kube-agent
     version: 0.10.4
   - dependsOn:
     - prometheus-operator-crd
     name: vertical-pod-autoscaler
     version: 5.4.0
-    dependsOn:
-    - prometheus-operator-crd
   - name: vertical-pod-autoscaler-crd
     version: 3.2.0
   components:

--- a/capa/v30.1.1/release.yaml
+++ b/capa/v30.1.1/release.yaml
@@ -1,134 +1,131 @@
-# Generated with:
-# devctl release create --name 30.1.1 --provider aws --base 30.1.0 --app security-bundle@1.10.1
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  creationTimestamp: null
   name: aws-30.1.1
 spec:
   apps:
-  - dependsOn:
-    - cloud-provider-aws
-    name: aws-ebs-csi-driver
+  - name: aws-ebs-csi-driver
     version: 3.0.5
-  - dependsOn:
-    - prometheus-operator-crd
-    name: aws-ebs-csi-driver-servicemonitors
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
     version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
   - name: aws-nth-bundle
     version: 1.2.1
-  - dependsOn:
-    - cert-manager
-    name: aws-pod-identity-webhook
+  - name: aws-pod-identity-webhook
     version: 1.19.1
+    dependsOn:
+    - cert-manager
   - name: capi-node-labeler
     version: 1.0.2
-  - dependsOn:
-    - kyverno-crds
-    name: cert-exporter
+  - name: cert-exporter
     version: 2.9.5
-  - dependsOn:
-    - prometheus-operator-crd
-    name: cert-manager
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
     version: 3.9.0
-  - dependsOn:
+    dependsOn:
     - prometheus-operator-crd
-    name: chart-operator-extensions
+  - name: chart-operator-extensions
     version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
   - name: cilium
     version: 0.31.1
-  - catalog: cluster
-    name: cilium-crossplane-resources
+  - name: cilium-crossplane-resources
+    catalog: cluster
     version: 0.2.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: cilium-servicemonitors
+  - name: cilium-servicemonitors
     version: 0.1.2
-  - dependsOn:
-    - vertical-pod-autoscaler-crd
-    name: cloud-provider-aws
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
     version: 1.30.8-gs1
-  - dependsOn:
-    - kyverno-crds
-    name: cluster-autoscaler
-    version: 1.30.4-gs1
-  - dependsOn:
-    - cilium
-    name: coredns
-    version: 1.24.0
-  - dependsOn:
+    dependsOn:
     - vertical-pod-autoscaler-crd
-    name: coredns-extensions
-    version: 0.1.2
-  - dependsOn:
+  - name: cluster-autoscaler
+    version: 1.30.4-gs1
+    dependsOn:
     - kyverno-crds
-    name: etcd-defrag
-    version: 1.0.2
-  - dependsOn:
-    - kyverno-crds
-    name: etcd-k8s-res-count-exporter
-    version: 1.10.3
-  - dependsOn:
-    - prometheus-operator-crd
-    name: external-dns
-    version: 3.2.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: irsa-servicemonitors
-    version: 0.1.0
-  - dependsOn:
-    - kyverno-crds
-    name: k8s-audit-metrics
-    version: 0.10.2
-  - dependsOn:
-    - kyverno-crds
-    name: k8s-dns-node-cache
-    version: 2.8.1
-  - dependsOn:
-    - kyverno-crds
-    name: metrics-server
-    version: 2.6.0
-  - dependsOn:
-    - prometheus-operator-crd
-    name: net-exporter
-    version: 1.22.0
-  - catalog: cluster
+  - name: coredns
+    version: 1.24.0
     dependsOn:
     - cilium
-    name: network-policies
-    version: 0.1.1
-  - dependsOn:
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.2
+    dependsOn:
     - kyverno-crds
-    name: node-exporter
-    version: 1.20.2
-  - dependsOn:
-    - coredns
-    name: observability-bundle
-    version: 1.11.0
-  - dependsOn:
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
     - kyverno-crds
-    name: observability-policies
-    version: 0.0.1
-  - dependsOn:
-    - prometheus-operator-crd
-    name: prometheus-blackbox-exporter
-    version: 0.5.0
-  - catalog: giantswarm
+  - name: external-dns
+    version: 3.2.0
     dependsOn:
     - prometheus-operator-crd
-    name: security-bundle
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.11.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
     version: 1.10.1
+    dependsOn:
+    - prometheus-operator-crd
   - name: teleport-kube-agent
     version: 0.10.4
-  - dependsOn:
-    - prometheus-operator-crd
-    name: vertical-pod-autoscaler
+  - name: vertical-pod-autoscaler
     version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
   - name: vertical-pod-autoscaler-crd
     version: 3.2.0
   components:
-  - catalog: cluster
-    name: cluster-aws
+  - name: cluster-aws
+    catalog: cluster
     version: 3.2.1
   - name: flatcar
     version: 4152.2.1
@@ -136,8 +133,5 @@ spec:
     version: 1.30.11
   - name: os-tooling
     version: 1.24.0
-  date: "2025-04-29T20:50:46Z"
+  date: "2025-04-29T18:00:00Z"
   state: active
-status:
-  inUse: false
-  ready: false


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->
Adding release v30.1.1 to re-introduce the Kyverno PolicyException `v2alpha1` API.

Opening this so that tests can start and run overnight, but gladly take it over in the morning.

As a no-longer-frequent user of this repo, I encountered some friction:
- `devctl` (v7.2.0) generated file headers, CR status, and diffs that are different than in other releases. The diff in particular isn't very helpful
- all existing documentation about creating releases explicitly targets vintage. I don't think it changed, so I followed it anyway
- the changelog-->readme automation ignored some content from the security-bundle changelog. If that happens often, it might mean important announcements don't make it to customers. (see the [bundle release](https://github.com/giantswarm/security-bundle/releases/tag/v1.10.1) vs the [generated changelog](https://github.com/giantswarm/releases/commit/037cc6ae58531e8d4c6f9a1b0dd2b8b5f8ffb166#diff-0fd12a2a65b1dae23978574eb10b30c28deb97193e4121e2f540688a71dfc0f3R23))


### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
