### PR TITLE
CAPV: Release v30.1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ to all Giant Swarm installations.
 
 - v30
   - v30.1
+    - [v30.1.1](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.1)
     - [v30.1.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.0)
   - v30.0
     - [v30.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v30.0.0)

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - v30.0.0
 - v30.1.0
+- v30.1.1
 
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -13,6 +13,13 @@
       "releaseTimestamp": "2025-03-18 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "30.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-05-01 12:00:00 +0000 UTC",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v30.1.1/README.md
+++ b/vsphere/v30.1.1/README.md
@@ -1,0 +1,19 @@
+# :zap: Giant Swarm Release v30.1.1 for vSphere :zap:
+
+This release reverts removal of `PolicyExceptions` v2alpha1 API version for smoother transition for any customer and GS workloads. The deprecated API version of `v2alpha1` will be fully removed in next major release.
+
+## Changes compared to v30.1.0
+
+### Apps
+
+- security-bundle from v1.10.0 to v1.10.1
+
+### security-bundle [v1.10.0...v1.10.1](https://github.com/giantswarm/security-bundle/compare/v1.10.0...v1.10.1)
+
+#### Important
+
+**Note:** Kyverno `PolicyExceptions` (API group `kyverno.io`) versions `v2alpha1` and `v2beta1` are deprecated and will be removed in the next Kyverno minor release (v1.14). Please update all Kyverno PolicyExceptions to `v2`. No action is required for Giant Swarm Policy API `PolicyExceptions` (API group `policy.giantswarm.io`), which are handled automatically.
+
+#### Changed
+
+- Update `kyverno-crds` (app) to v1.13.1.

--- a/vsphere/v30.1.1/announcement.md
+++ b/vsphere/v30.1.1/announcement.md
@@ -1,0 +1,5 @@
+**Workload cluster release v30.1.1 for vSphere is available**.
+
+This release reverts removal of `PolicyExceptions` v2alpha1 API version for smoother transition for any customer and GS workloads. The deprecated API version of `v2alpha1` will be fully removed in next major release.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-30.1.1).

--- a/vsphere/v30.1.1/kustomization.yaml
+++ b/vsphere/v30.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v30.1.1/release.diff
+++ b/vsphere/v30.1.1/release.diff
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1				apiVersion: release.giantswarm.io/v1alpha1
+kind: Release								kind: Release
+metadata:								metadata:
+  name: vsphere-30.1.0						|         name: vsphere-30.1.1
+spec:									spec:
+  apps:									  apps:
+  - name: capi-node-labeler						  - name: capi-node-labeler
+    version: 1.0.2							    version: 1.0.2
+  - name: cert-exporter							  - name: cert-exporter
+    version: 2.9.5							    version: 2.9.5
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: cert-manager							  - name: cert-manager
+    version: 3.9.0							    version: 3.9.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: chart-operator-extensions					  - name: chart-operator-extensions
+    version: 1.1.2							    version: 1.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cilium							  - name: cilium
+    version: 0.31.1							    version: 0.31.1
+  - name: cilium-servicemonitors					  - name: cilium-servicemonitors
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: cloud-provider-vsphere					  - name: cloud-provider-vsphere
+    version: 2.0.1							    version: 2.0.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns							  - name: coredns
+    version: 1.24.0							    version: 1.24.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: coredns-extensions						  - name: coredns-extensions
+    version: 0.1.2							    version: 0.1.2
+    dependsOn:								    dependsOn:
+    - vertical-pod-autoscaler-crd					    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag							  - name: etcd-defrag
+    version: 1.0.2							    version: 1.0.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter					  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3							    version: 1.10.3
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: external-dns							  - name: external-dns
+    version: 3.2.0							    version: 3.2.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: k8s-audit-metrics						  - name: k8s-audit-metrics
+    version: 0.10.2							    version: 0.10.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: k8s-dns-node-cache						  - name: k8s-dns-node-cache
+    version: 2.8.1							    version: 2.8.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: kube-vip							  - name: kube-vip
+    version: 0.2.0							    version: 0.2.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: kube-vip-cloud-provider					  - name: kube-vip-cloud-provider
+    version: 0.3.0							    version: 0.3.0
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: metrics-server						  - name: metrics-server
+    version: 2.6.0							    version: 2.6.0
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: net-exporter							  - name: net-exporter
+    version: 1.22.0							    version: 1.22.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: network-policies						  - name: network-policies
+    catalog: cluster							    catalog: cluster
+    version: 0.1.1							    version: 0.1.1
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  - name: node-exporter							  - name: node-exporter
+    version: 1.20.2							    version: 1.20.2
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: observability-bundle						  - name: observability-bundle
+    version: 1.11.0							    version: 1.11.0
+    dependsOn:								    dependsOn:
+    - coredns								    - coredns
+  - name: observability-policies					  - name: observability-policies
+    version: 0.0.1							    version: 0.0.1
+    dependsOn:								    dependsOn:
+    - kyverno-crds							    - kyverno-crds
+  - name: prometheus-blackbox-exporter					  - name: prometheus-blackbox-exporter
+    version: 0.5.0							    version: 0.5.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: security-bundle						  - name: security-bundle
+    catalog: giantswarm							    catalog: giantswarm
+    version: 1.10.0						|           version: 1.10.1
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: teleport-kube-agent						  - name: teleport-kube-agent
+    version: 0.10.4							    version: 0.10.4
+  - name: vertical-pod-autoscaler					  - name: vertical-pod-autoscaler
+    version: 5.4.0							    version: 5.4.0
+    dependsOn:								    dependsOn:
+    - prometheus-operator-crd						    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd					  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0							    version: 3.2.0
+  - name: vsphere-csi-driver						  - name: vsphere-csi-driver
+    version: 3.4.2							    version: 3.4.2
+    dependsOn:								    dependsOn:
+    - cilium								    - cilium
+  components:								  components:
+  - name: cluster-vsphere						  - name: cluster-vsphere
+    catalog: cluster							    catalog: cluster
+    version: 1.1.0							    version: 1.1.0
+  - name: flatcar							  - name: flatcar
+    version: 4152.2.1							    version: 4152.2.1
+  - name: kubernetes							  - name: kubernetes
+    version: 1.30.11							    version: 1.30.11
+  - name: os-tooling							  - name: os-tooling
+    version: 1.24.0							    version: 1.24.0
+  date: "2025-03-18T12:00:00Z"					|         date: "2025-05-01T12:00:00Z"
+  state: active								  state: active

--- a/vsphere/v30.1.1/release.yaml
+++ b/vsphere/v30.1.1/release.yaml
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-30.1.1
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 1.0.2
+  - name: cert-exporter
+    version: 2.9.5
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.1
+  - name: cilium-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.0.1
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.24.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.2.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.11.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.1
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.10.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.4
+  - name: vertical-pod-autoscaler
+    version: 5.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.2.0
+  - name: vsphere-csi-driver
+    version: 3.4.2
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 1.1.0
+  - name: flatcar
+    version: 4152.2.1
+  - name: kubernetes
+    version: 1.30.11
+  - name: os-tooling
+    version: 1.24.0
+  date: "2025-05-01T12:00:00Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
- [ ] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
