### PR TITLE
CAPI: v31 Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ to all Giant Swarm installations.
 
 ## AWS
 
+- v31
+  - v31.0
+    - [v31.0.0](https://github.com/giantswarm/releases/tree/master/capa/v31.0.0)
+
 - v30
   - v30.1
     - [v30.1.3](https://github.com/giantswarm/releases/tree/master/capa/v30.1.3)
@@ -584,6 +588,10 @@ to all Giant Swarm installations.
 
 ## vSphere
 
+- v31
+  - v31.0
+    - [v31.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v31.0.0)
+
 - v30
   - v30.1
     - [v30.1.3](https://github.com/giantswarm/releases/tree/master/vsphere/v30.1.3)
@@ -614,6 +622,10 @@ to all Giant Swarm installations.
     - [v27.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/archived/v27.0.0)
 
 ## VMware Cloud Director
+
+- v31
+  - v31.0
+    - [v31.0.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v31.0.0)
 
 - v30
   - v30.1

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -1,3 +1,5 @@
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v25.5.4
 - v26.4.2
@@ -12,10 +14,7 @@ resources:
 - v30.1.1
 - v30.1.2
 - v30.1.3
-
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-
+- v31.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -90,6 +90,13 @@
       "releaseTimestamp": "2025-05-27 09:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v30.1.3/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-05-30T11:14:06+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aws/v31.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v31.0.0/README.md
+++ b/capa/v31.0.0/README.md
@@ -1,0 +1,107 @@
+# :zap: Giant Swarm Release v31.0.0 for CAPA :zap:
+
+<< Add description here >>
+
+## Changes compared to v30.1.3
+
+### Components
+
+- Flatcar from 4152.2.1 to [4152.2.3](https://www.flatcar-linux.org/releases/#release-4152.2.3)
+- Kubernetes from v1.30.11 to [v1.31.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.9)
+
+### Apps
+
+- vertical-pod-autoscaler from 5.4.0 to 5.5.0
+- cert-manager from 3.9.0 to 3.9.1
+- cilium-crossplane-resources from 0.2.0 to 0.2.1
+- coredns from 1.24.0 to 1.25.0
+- observability-bundle from 1.11.0 to 1.14.1
+- security-bundle from 1.10.1 to 1.11.0
+- vertical-pod-autoscaler-crd from 3.2.0 to 3.3.0
+- cluster-autoscaler from 1.30.4-gs1 to 1.31.2-gs1
+- etcd-defrag from 1.0.2 to 1.0.4
+- observability-policies from 0.0.1 to 0.0.2
+- teleport-kube-agent from 0.10.4 to 0.10.5
+
+
+### vertical-pod-autoscaler [v5.4.0...v5.5.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.4.0...v5.5.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v10.1.0. ([#350](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/350))
+- Chart: Update Helm release vertical-pod-autoscaler to v10.2.0. ([#351](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/351))
+
+### cert-manager [v3.9.0...v3.9.1](https://github.com/giantswarm/cert-manager-app/compare/v3.9.0...v3.9.1)
+
+#### Added
+
+- Added Vertical Pod Autoscaler support for `controller` pods.
+- Added renovate configutarion
+
+### cilium-crossplane-resources [v0.2.0...v0.2.1](https://github.com/giantswarm/cilium-crossplane-resources/compare/v0.2.0...v0.2.1)
+
+#### Added
+
+- Included the `giantswarm.io/cluster` label
+
+### coredns [v1.24.0...v1.25.0](https://github.com/giantswarm/coredns-app/compare/v1.24.0...v1.25.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1).
+
+### observability-bundle [v1.11.0...v1.14.1](https://github.com/giantswarm/observability-bundle/compare/v1.11.0...v1.14.1)
+
+#### Changed
+
+- Reconfigure Flux-related part of the KSM to use wildcards instead of hardcoded versions.
+- Rename Flux-related metrics produced by the KSM.
+
+### security-bundle [v1.10.1...v1.11.0](https://github.com/giantswarm/security-bundle/compare/v1.10.1...v1.11.0)
+
+#### Added
+
+- Add `policy-api-crds` app to manage Policy API CRDs.
+
+#### Changed
+
+- Update `trivy` (app) to v0.13.4.
+- Update `cloudnative-pg` (app) to v0.0.7.
+- Update `starboard-exporter` (app) to v0.8.1.
+- Update `kyverno-policy-operator` (app) to v0.0.11.
+- Update `cloudnative-pg` (app) to v0.0.9.
+
+### vertical-pod-autoscaler-crd [v3.2.0...v3.3.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.2.0...v3.3.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#140](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/140))
+
+### cluster-autoscaler [v1.30.4-gs1...v1.31.2-gs1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.30.4-gs1...v1.31.2-gs1)
+
+#### Added
+
+- Add additional labels to ignore during ASG balancing check
+
+#### Changed
+
+- Chart: Update to upstream v1.31.2. ([#325](https://github.com/giantswarm/cluster-autoscaler-app/pull/325))
+
+### etcd-defrag [v1.0.2...v1.0.4](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.2...v1.0.4)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.27.0. ([#29](https://github.com/giantswarm/etcd-defrag-app/pull/29))
+
+### observability-policies [v0.0.1...v0.0.2](https://github.com/giantswarm/observability-policies-app/compare/v0.0.1...v0.0.2)
+
+#### Changed
+
+- Add Cluster Role to allow latest Kyverno versions to work (https://github.com/giantswarm/giantswarm/issues/33416)
+- Switch `.Values.disabled` to `.Values.enabled` to follow best practices.
+
+### teleport-kube-agent [v0.10.4...v0.10.5](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.4...v0.10.5)
+
+#### Added
+
+- Set Home URL in chart metadata.

--- a/capa/v31.0.0/announcement.md
+++ b/capa/v31.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.0.0 for CAPA is available**. << Add description here >> 
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.0.0).

--- a/capa/v31.0.0/kustomization.yaml
+++ b/capa/v31.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v31.0.0/release.diff
+++ b/capa/v31.0.0/release.diff
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-30.1.3                                              |    name: aws-31.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 3.0.5                                                     version: 3.0.5
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.2.1                                                     version: 1.2.1
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 1.19.1                                                    version: 1.19.1
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.0.2                                                     version: 1.0.2
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.5                                                     version: 2.9.5
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.0                                              |      version: 3.9.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 0.31.5                                                    version: 0.31.5
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.0                                              |      version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 1.30.8-gs1                                                version: 1.30.8-gs1
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.30.4-gs1                                         |      version: 1.31.2-gs1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.24.0                                             |      version: 1.25.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.0.2                                              |      version: 1.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.3                                                    version: 1.10.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.2                                                    version: 0.10.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.8.1                                                     version: 2.8.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.22.0                                                    version: 1.22.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.2                                                    version: 1.20.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 1.11.0                                             |      version: 1.14.1
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.1                                              |      version: 0.0.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.10.1                                             |      version: 1.11.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.4                                             |      version: 0.10.5
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 5.4.0                                              |      version: 5.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.2.0                                              |      version: 3.3.0
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 3.2.2                                                     version: 3.2.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.1                                           |      version: 4152.2.3
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.30.11                                            |      version: 1.31.9
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.24.0                                             |      version: 1.26.1
+  date: "2025-05-27T09:00:00Z"                                  |    date: "2025-05-30T11:14:06Z"
+  state: active                                                      state: active

--- a/capa/v31.0.0/release.yaml
+++ b/capa/v31.0.0/release.yaml
@@ -1,0 +1,137 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-31.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.5
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.1
+  - name: aws-pod-identity-webhook
+    version: 1.19.1
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.0.2
+  - name: cert-exporter
+    version: 2.9.5
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.5
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.30.8-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.31.2-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.25.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.14.1
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.11.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.5
+  - name: vertical-pod-autoscaler
+    version: 5.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.3.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 3.2.2
+  - name: flatcar
+    version: 4152.2.3
+  - name: kubernetes
+    version: 1.31.9
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-05-30T11:14:06Z"
+  state: active

--- a/cloud-director/kustomization.yaml
+++ b/cloud-director/kustomization.yaml
@@ -1,11 +1,10 @@
+commonAnnotations:
+  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
 resources:
 - v29.3.2
 - v30.1.0
 - v30.1.3
-
-commonAnnotations:
-  giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-
+- v31.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/cloud-director/releases.json
+++ b/cloud-director/releases.json
@@ -20,6 +20,13 @@
       "releaseTimestamp": "2025-05-27 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v30.1.3/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-05-30T11:11:50+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v31.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/cloud-director/v31.0.0/README.md
+++ b/cloud-director/v31.0.0/README.md
@@ -1,0 +1,89 @@
+# :zap: Giant Swarm Release v31.0.0 for VMWare Cloud Director :zap:
+
+<< Add description here >>
+
+## Changes compared to v30.1.3
+
+### Components
+
+- Flatcar from 4152.2.1 to [4152.2.3](https://www.flatcar-linux.org/releases/#release-4152.2.3)
+- Kubernetes from v1.30.11 to [v1.31.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.9)
+
+### Apps
+
+- vertical-pod-autoscaler-crd from 3.2.0 to 3.3.0
+- cert-manager from 3.9.0 to 3.9.1
+- coredns from 1.24.0 to 1.25.0
+- etcd-defrag from 1.0.2 to 1.0.4
+- observability-bundle from 1.11.0 to 1.14.1
+- vertical-pod-autoscaler from 5.4.0 to 5.5.0
+- observability-policies from 0.0.1 to 0.0.2
+- security-bundle from 1.10.1 to 1.11.0
+- teleport-kube-agent from 0.10.4 to 0.10.5
+
+
+### vertical-pod-autoscaler-crd [v3.2.0...v3.3.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.2.0...v3.3.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#140](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/140))
+
+### cert-manager [v3.9.0...v3.9.1](https://github.com/giantswarm/cert-manager-app/compare/v3.9.0...v3.9.1)
+
+#### Added
+
+- Added Vertical Pod Autoscaler support for `controller` pods.
+- Added renovate configutarion
+
+### coredns [v1.24.0...v1.25.0](https://github.com/giantswarm/coredns-app/compare/v1.24.0...v1.25.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1).
+
+### etcd-defrag [v1.0.2...v1.0.4](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.2...v1.0.4)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.27.0. ([#29](https://github.com/giantswarm/etcd-defrag-app/pull/29))
+
+### observability-bundle [v1.11.0...v1.14.1](https://github.com/giantswarm/observability-bundle/compare/v1.11.0...v1.14.1)
+
+#### Changed
+
+- Reconfigure Flux-related part of the KSM to use wildcards instead of hardcoded versions.
+- Rename Flux-related metrics produced by the KSM.
+
+### vertical-pod-autoscaler [v5.4.0...v5.5.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.4.0...v5.5.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v10.1.0. ([#350](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/350))
+- Chart: Update Helm release vertical-pod-autoscaler to v10.2.0. ([#351](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/351))
+
+### observability-policies [v0.0.1...v0.0.2](https://github.com/giantswarm/observability-policies-app/compare/v0.0.1...v0.0.2)
+
+#### Changed
+
+- Add Cluster Role to allow latest Kyverno versions to work (https://github.com/giantswarm/giantswarm/issues/33416)
+- Switch `.Values.disabled` to `.Values.enabled` to follow best practices.
+
+### security-bundle [v1.10.1...v1.11.0](https://github.com/giantswarm/security-bundle/compare/v1.10.1...v1.11.0)
+
+#### Added
+
+- Add `policy-api-crds` app to manage Policy API CRDs.
+
+#### Changed
+
+- Update `trivy` (app) to v0.13.4.
+- Update `cloudnative-pg` (app) to v0.0.7.
+- Update `starboard-exporter` (app) to v0.8.1.
+- Update `kyverno-policy-operator` (app) to v0.0.11.
+- Update `cloudnative-pg` (app) to v0.0.9.
+
+### teleport-kube-agent [v0.10.4...v0.10.5](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.4...v0.10.5)
+
+### Added
+
+- Set Home URL in chart metadata.

--- a/cloud-director/v31.0.0/announcement.md
+++ b/cloud-director/v31.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.0.0 for VMWare Cloud Director is available**. << Add description here >> 
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-31.0.0).

--- a/cloud-director/v31.0.0/kustomization.yaml
+++ b/cloud-director/v31.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 2
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/cloud-director/v31.0.0/release.diff
+++ b/cloud-director/v31.0.0/release.diff
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: cloud-director-30.1.3                                   |    name: cloud-director-31.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.0.2                                                     version: 1.0.2
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.5                                                     version: 2.9.5
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.0                                              |      version: 3.9.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 0.31.5                                                    version: 0.31.5
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-cloud-director                              - name: cloud-provider-cloud-director
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.24.0                                             |      version: 1.25.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.0.2                                              |      version: 1.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.3                                                    version: 1.10.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.2                                                    version: 0.10.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.8.1                                                     version: 2.8.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.22.0                                                    version: 1.22.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.2                                                    version: 1.20.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 1.11.0                                             |      version: 1.14.1
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.1                                              |      version: 0.0.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.10.1                                             |      version: 1.11.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.4                                             |      version: 0.10.5
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 5.4.0                                              |      version: 5.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.2.0                                              |      version: 3.3.0
+  components:                                                        components:
+  - name: cluster-cloud-director                                     - name: cluster-cloud-director
+    catalog: cluster                                                   catalog: cluster
+    version: 0.66.1                                                    version: 0.66.1
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.1                                           |      version: 4152.2.3
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.30.11                                            |      version: 1.31.9
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.24.0                                             |      version: 1.26.1
+  date: "2025-05-27T12:00:00Z"                                  |    date: "2025-05-30T11:11:50Z"
+  state: active                                                      state: active

--- a/cloud-director/v31.0.0/release.yaml
+++ b/cloud-director/v31.0.0/release.yaml
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: cloud-director-31.0.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 1.0.2
+  - name: cert-exporter
+    version: 2.9.5
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.5
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director
+    version: 0.5.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.25.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.14.1
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.11.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.5
+  - name: vertical-pod-autoscaler
+    version: 5.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.3.0
+  components:
+  - name: cluster-cloud-director
+    catalog: cluster
+    version: 0.66.1
+  - name: flatcar
+    version: 4152.2.3
+  - name: kubernetes
+    version: 1.31.9
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-05-30T11:11:50Z"
+  state: active

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -1,9 +1,8 @@
-resources:
-- v30.1.3
-
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-
+resources:
+- v30.1.3
+- v31.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -6,6 +6,13 @@
       "releaseTimestamp": "2025-05-27 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v30.1.3/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-05-30T11:08:17+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v31.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v31.0.0/README.md
+++ b/vsphere/v31.0.0/README.md
@@ -1,0 +1,98 @@
+# :zap: Giant Swarm Release v31.0.0 for vSphere :zap:
+
+<< Add description here >>
+
+## Changes compared to v30.1.3
+
+### Components
+
+- cluster-vsphere from v1.1.1 to v1.3.0
+- Flatcar from 4152.2.1 to [4152.2.3](https://www.flatcar-linux.org/releases/#release-4152.2.3)
+- Kubernetes from v1.30.11 to [v1.31.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.9)
+
+### cluster-vsphere [v1.1.1...v1.3.0](https://github.com/giantswarm/cluster-vsphere/compare/v1.1.1...v1.3.0)
+
+#### Changed
+
+- Chart: Update `cluster` to v2.3.0.
+- Update `kube-vip` to `0.9.1`.
+- Update `kube-vip` to `0.9.0`.
+
+### Apps
+
+- vertical-pod-autoscaler from 5.4.0 to 5.5.0
+- cert-manager from 3.9.0 to 3.9.1
+- etcd-defrag from 1.0.2 to 1.0.4
+- observability-bundle from 1.11.0 to 1.14.1
+- security-bundle from 1.10.1 to 1.11.0
+- vertical-pod-autoscaler-crd from 3.2.0 to 3.3.0
+- coredns from 1.24.0 to 1.25.0
+- observability-policies from 0.0.1 to 0.0.2
+- teleport-kube-agent from 0.10.4 to 0.10.5
+
+
+### vertical-pod-autoscaler [v5.4.0...v5.5.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.4.0...v5.5.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v10.1.0. ([#350](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/350))
+- Chart: Update Helm release vertical-pod-autoscaler to v10.2.0. ([#351](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/351))
+
+### cert-manager [v3.9.0...v3.9.1](https://github.com/giantswarm/cert-manager-app/compare/v3.9.0...v3.9.1)
+
+#### Added
+
+- Added Vertical Pod Autoscaler support for `controller` pods.
+- Added renovate configutarion
+
+### etcd-defrag [v1.0.2...v1.0.4](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.2...v1.0.4)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.27.0. ([#29](https://github.com/giantswarm/etcd-defrag-app/pull/29))
+
+### observability-bundle [v1.11.0...v1.14.1](https://github.com/giantswarm/observability-bundle/compare/v1.11.0...v1.14.1)
+
+#### Changed
+
+- Reconfigure Flux-related part of the KSM to use wildcards instead of hardcoded versions.
+- Rename Flux-related metrics produced by the KSM.
+
+### security-bundle [v1.10.1...v1.11.0](https://github.com/giantswarm/security-bundle/compare/v1.10.1...v1.11.0)
+
+#### Added
+
+- Add `policy-api-crds` app to manage Policy API CRDs.
+
+#### Changed
+
+- Update `trivy` (app) to v0.13.4.
+- Update `cloudnative-pg` (app) to v0.0.7.
+- Update `starboard-exporter` (app) to v0.8.1.
+- Update `kyverno-policy-operator` (app) to v0.0.11.
+- Update `cloudnative-pg` (app) to v0.0.9.
+
+### vertical-pod-autoscaler-crd [v3.2.0...v3.3.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.2.0...v3.3.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#140](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/140))
+
+### coredns [v1.24.0...v1.25.0](https://github.com/giantswarm/coredns-app/compare/v1.24.0...v1.25.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1).
+
+### observability-policies [v0.0.1...v0.0.2](https://github.com/giantswarm/observability-policies-app/compare/v0.0.1...v0.0.2)
+
+#### Changed
+
+- Add Cluster Role to allow latest Kyverno versions to work (https://github.com/giantswarm/giantswarm/issues/33416)
+- Switch `.Values.disabled` to `.Values.enabled` to follow best practices.
+
+### teleport-kube-agent [v0.10.4...v0.10.5](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.4...v0.10.5)
+
+#### Added
+
+- Set Home URL in chart metadata.

--- a/vsphere/v31.0.0/announcement.md
+++ b/vsphere/v31.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.0.0 for vSphere is available**. << Add description here >> 
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-31.0.0).

--- a/vsphere/v31.0.0/kustomization.yaml
+++ b/vsphere/v31.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v31.0.0/release.diff
+++ b/vsphere/v31.0.0/release.diff
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: vsphere-30.1.3                                          |    name: vsphere-31.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.0.2                                                     version: 1.0.2
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.5                                                     version: 2.9.5
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.0                                              |      version: 3.9.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 0.31.5                                                    version: 0.31.5
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-vsphere                                     - name: cloud-provider-vsphere
+    version: 2.0.1                                                     version: 2.0.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.24.0                                             |      version: 1.25.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.0.2                                              |      version: 1.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.3                                                    version: 1.10.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.2                                                    version: 0.10.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.8.1                                                     version: 2.8.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: kube-vip                                                   - name: kube-vip
+    version: 0.2.0                                                     version: 0.2.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: kube-vip-cloud-provider                                    - name: kube-vip-cloud-provider
+    version: 0.3.0                                                     version: 0.3.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.22.0                                                    version: 1.22.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.2                                                    version: 1.20.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 1.11.0                                             |      version: 1.14.1
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.1                                              |      version: 0.0.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.10.1                                             |      version: 1.11.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.4                                             |      version: 0.10.5
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 5.4.0                                              |      version: 5.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.2.0                                              |      version: 3.3.0
+  - name: vsphere-csi-driver                                         - name: vsphere-csi-driver
+    version: 3.4.2                                                     version: 3.4.2
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  components:                                                        components:
+  - name: cluster-vsphere                                            - name: cluster-vsphere
+    catalog: cluster                                                   catalog: cluster
+    version: 1.1.1                                              |      version: 1.3.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.1                                           |      version: 4152.2.3
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.30.11                                            |      version: 1.31.9
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.24.0                                             |      version: 1.26.1
+  date: "2025-05-27T12:00:00Z"                                  |    date: "2025-05-30T11:08:17Z"
+  state: active                                                      state: active

--- a/vsphere/v31.0.0/release.yaml
+++ b/vsphere/v31.0.0/release.yaml
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-31.0.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 1.0.2
+  - name: cert-exporter
+    version: 2.9.5
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 0.31.5
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.0.1
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.25.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.3
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.2
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.8.1
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.2.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.22.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.2
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 1.14.1
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.11.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.5
+  - name: vertical-pod-autoscaler
+    version: 5.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.3.0
+  - name: vsphere-csi-driver
+    version: 3.4.2
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 1.3.0
+  - name: flatcar
+    version: 4152.2.3
+  - name: kubernetes
+    version: 1.31.9
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-05-30T11:08:17Z"
+  state: active


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3978

<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
- [ ] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).