### PR TITLE
Add release notes and announcements for v31

### DIFF
--- a/capa/v31.0.0/README.md
+++ b/capa/v31.0.0/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v31.0.0 for CAPA :zap:
 
-This release contains initial support for karpenter node pools. This support is still under development, and there is a known issue when deleting clusters. During cluster deletion, there is a race condition, and there may be EC2 instances left behind, blocking the cluster deletion. If that's the case, these instances need to be terminated manually. These instances are tagged with karpenter.sh/nodepool: $nodePoolName
+This release contains initial support for Karpenter node pools. This support is still under development, and there is a known issue when deleting clusters. During cluster deletion, there is a race condition, and there may be EC2 instances left behind, blocking the cluster deletion. If that's the case, these instances need to be terminated manually. These instances are tagged with `karpenter.sh/nodepool: $nodePoolName`.
 
 ## Changes compared to v30.1.3
 

--- a/capa/v31.0.0/README.md
+++ b/capa/v31.0.0/README.md
@@ -1,6 +1,6 @@
 # :zap: Giant Swarm Release v31.0.0 for CAPA :zap:
 
-<< Add description here >>
+This release contains initial support for karpenter node pools. This support is still under development, and there is a known issue when deleting clusters. During cluster deletion, there is a race condition, and there may be EC2 instances left behind, blocking the cluster deletion. If that's the case, these instances need to be terminated manually. These instances are tagged with karpenter.sh/nodepool: $nodePoolName
 
 ## Changes compared to v30.1.3
 

--- a/capa/v31.0.0/README.md
+++ b/capa/v31.0.0/README.md
@@ -1,6 +1,10 @@
 # :zap: Giant Swarm Release v31.0.0 for CAPA :zap:
 
-This release contains initial support for Karpenter node pools. This support is still under development, and there is a known issue when deleting clusters. During cluster deletion, there is a race condition, and there may be EC2 instances left behind, blocking the cluster deletion. If that's the case, these instances need to be terminated manually. These instances are tagged with `karpenter.sh/nodepool: $nodePoolName`.
+This release along with k8s and application upgrades also brings several new features for the product. Node Pools have been extended with [new Karpenter type](https://github.com/giantswarm/cluster-aws/blob/main/helm/cluster-aws/values.schema.json#L151), integrating the solution fully with the Giant Swarm cluster lifecycle instead of a Managed Applications. Karpenter application will now be deployed as a part of the Giant Swarm clusters ouf of the box if configured. 
+Additionally, we have extended the Cluster configuration with supporting multiple VPC CIDRs under `global.connectivity.network.vpcCidr`, please read the [schema documentation](https://github.com/giantswarm/cluster-aws/blob/main/helm/cluster-aws/README.md) for more details. 
+Finally we are slowly indroducing changes to `IAM roles for service accounts` (IRSA) management on GS side, where the infrastructure required will be fully managed by Crossplane instead of `irsa-operator` and `capa-iam-operator`. There is no impact for customers, but the change will allow Giant Swarm to pair the IAM permissions for required applications with their actual releases and deployments, moving away from single operators implementing all the roles. Karpenter application will be the first one to use it.
+
+For any questions regarding new features or their usage, please reach out to Giant Swarm.
 
 ## Changes compared to v30.1.3
 

--- a/capa/v31.0.0/announcement.md
+++ b/capa/v31.0.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v31.0.0 for CAPA is available**. << Add description here >>
+**Workload cluster release v31.0.0 for CAPA is available**. This release updates Kubernetes to v1.31.9, introduces Karpenter support, enhances IRSA and private cluster DNS configurations, and upgrades numerous apps including Cilium, cert-manager, and observability tools for improved scalability, automation, and performance.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.0.0).

--- a/capa/v31.0.0/announcement.md
+++ b/capa/v31.0.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v31.0.0 for CAPA is available**. This release updates Kubernetes to v1.31.9, introduces Karpenter support, enhances IRSA and private cluster DNS configurations, and upgrades numerous apps including Cilium, cert-manager, and observability tools for improved scalability, automation, and performance.
+**Workload cluster release v31.0.0 for CAPA is available**. This release updates Kubernetes to v1.31.9, introduces Karpenter type support for Node Pools, brings feature to extend cluster's CIDRs, enhances IRSA and private cluster DNS configurations, and upgrades numerous apps including Cilium, cert-manager, and observability tools for improved scalability, automation, and performance.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.0.0).

--- a/cloud-director/v31.0.0/README.md
+++ b/cloud-director/v31.0.0/README.md
@@ -1,7 +1,5 @@
 # :zap: Giant Swarm Release v31.0.0 for VMware Cloud Director :zap:
 
-<< Add description here >>
-
 ## Changes compared to v30.1.3
 
 ### Components

--- a/cloud-director/v31.0.0/announcement.md
+++ b/cloud-director/v31.0.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v31.0.0 for VMware Cloud Director is available**. << Add description here >>
+**Workload cluster release v31.0.0 for VMware Cloud Director is available**. This release updates Kubernetes to v1.31.9 and upgrades numerous apps including Cilium, cert-manager, and observability tools for improved scalability, automation, and performance.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-31.0.0).

--- a/vsphere/v31.0.0/README.md
+++ b/vsphere/v31.0.0/README.md
@@ -1,7 +1,5 @@
 # :zap: Giant Swarm Release v31.0.0 for vSphere :zap:
 
-<< Add description here >>
-
 ## Changes compared to v30.1.3
 
 ### Components

--- a/vsphere/v31.0.0/announcement.md
+++ b/vsphere/v31.0.0/announcement.md
@@ -1,3 +1,3 @@
-**Workload cluster release v31.0.0 for vSphere is available**. << Add description here >>
+**Workload cluster release v31.0.0 for vSphere is available**. This release updates Kubernetes to v1.31.9 and upgrades numerous apps including Cilium, cert-manager, and observability tools for improved scalability, automation, and performance.
 
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-31.0.0).


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
- [ ] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
