### PR TITLE
Request k8s-dns-node-cache v2.9.0

### DIFF
--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -5,6 +5,8 @@ releases:
     version: ">= 0.1.0"
   - name: cilium
     version: ">= 1.1.1"
+  - name: k8s-dns-node-cache-app
+    version: ">= 2.9.0"
 - name: ">= 30.1.2 < 31.0.0"
   requests:
   - name: cilium

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.1.1"
+  - name: k8s-dns-node-cache-app
+    version: ">= 2.9.0"
 - name: ">= 30.1.2 < 31.0.0"
   requests:
   - name: cilium

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -3,6 +3,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.1.1"
+  - name: k8s-dns-node-cache-app
+    version: ">= 2.9.0"
 - name: ">= 30.1.2 < 31.0.0"
   requests:
   - name: cilium


### PR DESCRIPTION
This PR requests a new version of k8s-dns-node-cache for v31