### PR TITLE
Request CoreDNS app 1.26.0 in v31.1.0

### DIFF
--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,6 +1,8 @@
 releases:
 - name: ">= 31.1.0"
   requests:
+  - name: coredns
+    version: ">= 1.26.0"
   - name: k8s-dns-node-cache
     version: ">= 2.9.0"
 - name: ">= 31.0.0"

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -1,6 +1,8 @@
 releases:
 - name: ">= 31.1.0"
   requests:
+  - name: coredns
+    version: ">= 1.26.0"
   - name: k8s-dns-node-cache
     version: ">= 2.9.0"
 - name: ">= 31.0.0"

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,6 +1,8 @@
 releases:
 - name: ">= 31.1.0"
   requests:
+  - name: coredns
+    version: ">= 1.26.0"
   - name: k8s-dns-node-cache
     version: ">= 2.9.0"
 - name: ">= 31.0.0"


### PR DESCRIPTION
This PR adds requests for coredns-app 1.26.0 in v31.1.0