### PR TITLE
CAPI: Request Flatcar < v4230.2.0.

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "< 32.0.0"
+  requests:
+  - name: flatcar
+    version: "< 4230.2.0"
 - name: ">= 31.0.0"
   requests:
   - name: cilium

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "< 32.0.0"
+  requests:
+  - name: flatcar
+    version: "< 4230.2.0"
 - name: ">= 31.1.0"
   requests:
   - name: coredns

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "< 32.0.0"
+  requests:
+  - name: flatcar
+    version: "< 4230.2.0"
 - name: ">= 31.1.0"
   requests:
   - name: coredns

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,4 +1,8 @@
 releases:
+- name: "< 32.0.0"
+  requests:
+  - name: flatcar
+    version: "< 4230.2.0"
 - name: ">= 31.1.0"
   requests:
   - name: coredns


### PR DESCRIPTION
We'd like to prevent Flatcar from being bumped to v4230.2.0 and beyond in any release before v32.0.0 because it deprecates cgroups v1 and one of our customers is still using them. This change in requests makes sure they can still use v31.0.0 and have enough time to migrate.

We can still adjust these requests and the used Flatcar version in case there are some security issues only being fixed in v4230.2.0 or later, but let's start from here so nobody accidentally puts in an "incompatible" version. 🙂