### PR TITLE
CAPA: Re-release

### DIFF
--- a/capa/releases.json
+++ b/capa/releases.json
@@ -2,7 +2,7 @@
   "releases": [
     {
       "version": "25.5.4",
-      "isDeprecated": true,
+      "isDeprecated": false,
       "releaseTimestamp": "2025-04-07 12:00:00 +0000 UTC",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v25.5.4/README.md",
       "isStable": true
@@ -23,7 +23,7 @@
     },
     {
       "version": "26.4.4",
-      "isDeprecated": true,
+      "isDeprecated": false,
       "releaseTimestamp": "2025-06-25T10:26:34+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v26.4.4/README.md",
       "isStable": true
@@ -37,7 +37,7 @@
     },
     {
       "version": "27.5.4",
-      "isDeprecated": true,
+      "isDeprecated": false,
       "releaseTimestamp": "2025-06-25T10:36:51+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v27.5.4/README.md",
       "isStable": true
@@ -51,7 +51,7 @@
     },
     {
       "version": "28.5.5",
-      "isDeprecated": true,
+      "isDeprecated": false,
       "releaseTimestamp": "2025-06-27T09:08:48+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v28.5.5/README.md",
       "isStable": true

--- a/capa/v25.5.4/release.yaml
+++ b/capa/v25.5.4/release.yaml
@@ -121,4 +121,4 @@ spec:
   - name: os-tooling
     version: 1.19.1
   date: "2025-04-07T12:00:00Z"
-  state: deprecated
+  state: active

--- a/capa/v26.4.4/release.yaml
+++ b/capa/v26.4.4/release.yaml
@@ -121,4 +121,4 @@ spec:
   - name: os-tooling
     version: 1.20.1
   date: "2025-06-25T10:26:34Z"
-  state: deprecated
+  state: active

--- a/capa/v27.5.4/release.yaml
+++ b/capa/v27.5.4/release.yaml
@@ -121,4 +121,4 @@ spec:
   - name: os-tooling
     version: 1.20.1
   date: "2025-06-25T10:36:51Z"
-  state: deprecated
+  state: active

--- a/capa/v28.5.5/release.yaml
+++ b/capa/v28.5.5/release.yaml
@@ -121,4 +121,4 @@ spec:
   - name: os-tooling
     version: 1.20.1
   date: "2025-06-27T09:08:48Z"
-  state: deprecated
+  state: active


### PR DESCRIPTION
This was due to a bug in deprecate release workflow https://github.com/giantswarm/releases/pull/1763