### PR TITLE
CAPVCD: Release v31.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,8 @@ to all Giant Swarm installations.
 ## VMware Cloud Director
 
 - v31
+  - v31.1
+    - [v31.1.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v31.1.0)
   - v31.0
     - [v31.0.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v31.0.0)
 

--- a/cloud-director/kustomization.yaml
+++ b/cloud-director/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - v30.1.0
 - v30.1.3
 - v31.0.0
+- v31.1.0
 transformers:
 - |
   apiVersion: builtin

--- a/cloud-director/releases.json
+++ b/cloud-director/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2025-06-12T15:04:32+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v31.0.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.1.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-08-02T13:38:41+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v31.1.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/cloud-director/v31.1.0/README.md
+++ b/cloud-director/v31.1.0/README.md
@@ -1,0 +1,108 @@
+# :zap: Giant Swarm Release v31.1.0 for VMware Cloud Director :zap:
+
+## Changes compared to v31.0.0
+
+### Components
+
+- cluster-cloud-director from v0.67.0 to v0.68.0
+- Kubernetes from v1.31.9 to [v1.31.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.11)
+
+### cluster-cloud-director [v0.67.0...v0.68.0](https://github.com/giantswarm/cluster-cloud-director/compare/v0.67.0...v0.68.0)
+
+#### Changed
+
+- Chart: Update `cluster` to v2.5.0.
+
+### Apps
+
+- capi-node-labeler from v1.1.1 to v1.1.2
+- cert-exporter from v2.9.7 to v2.9.8
+- cilium from v1.2.1 to v1.2.2
+- coredns from v1.25.0 to v1.26.0
+- etcd-defrag from v1.0.5 to v1.0.6
+- etcd-k8s-res-count-exporter from v1.10.5 to v1.10.6
+- k8s-audit-metrics from v0.10.4 to v0.10.5
+- k8s-dns-node-cache from v2.8.1 to v2.9.0
+- node-exporter from v1.20.3 to v1.20.4
+- security-bundle from v1.11.0 to v1.12.0
+- teleport-kube-agent from v0.10.5 to v0.10.6
+
+
+### capi-node-labeler [v1.1.1...v1.1.2](https://github.com/giantswarm/capi-node-labeler-app/compare/v1.1.1...v1.1.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cert-exporter [v2.9.7...v2.9.8](https://github.com/giantswarm/cert-exporter/compare/v2.9.7...v2.9.8)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.2.1...v1.2.2](https://github.com/giantswarm/cilium-app/compare/v1.2.1...v1.2.2)
+
+#### Changed
+
+- Upgrade Cilium to [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6).
+- Updated E2E tests to use apptest-framework v1.14.0
+- Increase Cilium operator resource limits.
+
+#### Removed
+
+- Remove deprecated "partial" mode from Kube Proxy Replacement options.
+
+### coredns [v1.25.0...v1.26.0](https://github.com/giantswarm/coredns-app/compare/v1.25.0...v1.26.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2).
+
+### etcd-defrag [v1.0.5...v1.0.6](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.5...v1.0.6)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.29.0. ([#43](https://github.com/giantswarm/etcd-defrag-app/pull/43))
+
+### etcd-k8s-res-count-exporter [v1.10.5...v1.10.6](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.5...v1.10.6)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-audit-metrics [v0.10.4...v0.10.5](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.4...v0.10.5)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-dns-node-cache [v2.8.1...v2.9.0](https://github.com/giantswarm/k8s-dns-node-cache-app/compare/v2.8.1...v2.9.0)
+
+#### Changed
+
+- Upgrade application to version 1.26.4 (includes coredns 1.11.3)
+- Increase ServiceMonitor's scrapping interval to 1m.
+- Remove obsolete PSPs
+
+### node-exporter [v1.20.3...v1.20.4](https://github.com/giantswarm/node-exporter-app/compare/v1.20.3...v1.20.4)
+
+#### Changed
+
+- Go: Update to v1.24.5.
+
+### security-bundle [v1.11.0...v1.12.0](https://github.com/giantswarm/security-bundle/compare/v1.11.0...v1.12.0)
+
+#### Changed
+
+- Update `trivy-operator` (app) to v0.11.1.
+- Update `trivy` (app) to v0.14.0.
+- Update `falco` (app) to v0.10.1.
+- Update `cloudnative-pg` (app) to v0.0.10.
+- Update `starboard-exporter` (app) to v0.8.2.
+- Updated E2E tests to use apptest-framework v1.14.0
+
+### teleport-kube-agent [v0.10.5...v0.10.6](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.5...v0.10.6)
+
+#### Changed
+
+- AppVersion upgrade to 17.5.4

--- a/cloud-director/v31.1.0/announcement.md
+++ b/cloud-director/v31.1.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.1.0 for VMware Cloud Director is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-31.1.0).

--- a/cloud-director/v31.1.0/kustomization.yaml
+++ b/cloud-director/v31.1.0/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      # Need to target index 2 here as `cloud-director` itself already contains a hyphen.
+      delimiter: "-"
+      index: 2
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/cloud-director/v31.1.0/release.diff
+++ b/cloud-director/v31.1.0/release.diff
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1                       apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                    kind: Release
+metadata:                                                        metadata:
+  name: cloud-director-31.0.0                                  |   name: cloud-director-31.1.0
+spec:                                                            spec:
+  apps:                                                            apps:
+  - name: capi-node-labeler                                        - name: capi-node-labeler
+    version: 1.1.1                                             |     version: 1.1.2
+  - name: cert-exporter                                            - name: cert-exporter
+    version: 2.9.7                                             |     version: 2.9.8
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: cert-manager                                             - name: cert-manager
+    version: 3.9.1                                                   version: 3.9.1
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: chart-operator-extensions                                - name: chart-operator-extensions
+    version: 1.1.2                                                   version: 1.1.2
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: cilium                                                   - name: cilium
+    version: 1.2.1                                             |     version: 1.2.2
+  - name: cilium-servicemonitors                                   - name: cilium-servicemonitors
+    version: 0.1.3                                                   version: 0.1.3
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: cloud-provider-cloud-director                            - name: cloud-provider-cloud-director
+    version: 0.5.0                                                   version: 0.5.0
+    dependsOn:                                                       dependsOn:
+    - cilium                                                         - cilium
+  - name: coredns                                                  - name: coredns
+    version: 1.25.0                                            |     version: 1.26.0
+    dependsOn:                                                       dependsOn:
+    - cilium                                                         - cilium
+  - name: coredns-extensions                                       - name: coredns-extensions
+    version: 0.1.2                                                   version: 0.1.2
+    dependsOn:                                                       dependsOn:
+    - vertical-pod-autoscaler-crd                                    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                              - name: etcd-defrag
+    version: 1.0.5                                             |     version: 1.0.6
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                              - name: etcd-k8s-res-count-exporter
+    version: 1.10.5                                            |     version: 1.10.6
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: external-dns                                             - name: external-dns
+    version: 3.2.0                                                   version: 3.2.0
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: k8s-audit-metrics                                        - name: k8s-audit-metrics
+    version: 0.10.4                                            |     version: 0.10.5
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: k8s-dns-node-cache                                       - name: k8s-dns-node-cache
+    version: 2.8.1                                             |     version: 2.9.0
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: metrics-server                                           - name: metrics-server
+    version: 2.6.0                                                   version: 2.6.0
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: net-exporter                                             - name: net-exporter
+    version: 1.23.0                                                  version: 1.23.0
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: network-policies                                         - name: network-policies
+    catalog: cluster                                                 catalog: cluster
+    version: 0.1.1                                                   version: 0.1.1
+    dependsOn:                                                       dependsOn:
+    - cilium                                                         - cilium
+  - name: node-exporter                                            - name: node-exporter
+    version: 1.20.3                                            |     version: 1.20.4
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: observability-bundle                                     - name: observability-bundle
+    version: 2.0.0                                                   version: 2.0.0
+    dependsOn:                                                       dependsOn:
+    - coredns                                                        - coredns
+  - name: observability-policies                                   - name: observability-policies
+    version: 0.0.2                                                   version: 0.0.2
+    dependsOn:                                                       dependsOn:
+    - kyverno-crds                                                   - kyverno-crds
+  - name: prometheus-blackbox-exporter                             - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                   version: 0.5.0
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: security-bundle                                          - name: security-bundle
+    catalog: giantswarm                                              catalog: giantswarm
+    version: 1.11.0                                            |     version: 1.12.0
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: teleport-kube-agent                                      - name: teleport-kube-agent
+    version: 0.10.5                                            |     version: 0.10.6
+  - name: vertical-pod-autoscaler                                  - name: vertical-pod-autoscaler
+    version: 5.5.1                                                   version: 5.5.1
+    dependsOn:                                                       dependsOn:
+    - prometheus-operator-crd                                        - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                              - name: vertical-pod-autoscaler-crd
+    version: 3.3.1                                                   version: 3.3.1
+  components:                                                      components:
+  - name: cluster-cloud-director                                   - name: cluster-cloud-director
+    catalog: cluster                                                 catalog: cluster
+    version: 0.67.0                                            |     version: 0.68.0
+  - name: flatcar                                                  - name: flatcar
+    version: 4152.2.3                                                version: 4152.2.3
+  - name: kubernetes                                               - name: kubernetes
+    version: 1.31.9                                            |     version: 1.31.11
+  - name: os-tooling                                               - name: os-tooling
+    version: 1.26.1                                                  version: 1.26.1
+  date: "2025-06-12T15:04:32Z"                                 |   date: "2025-08-02T13:38:41Z"
+  state: active                                                    state: active

--- a/cloud-director/v31.1.0/release.yaml
+++ b/cloud-director/v31.1.0/release.yaml
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: cloud-director-31.1.0
+spec:
+  apps:
+  - name: capi-node-labeler
+    version: 1.1.2
+  - name: cert-exporter
+    version: 2.9.8
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.2.2
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director
+    version: 0.5.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.26.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.6
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.6
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.5
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.0
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.4
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.0.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.12.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.6
+  - name: vertical-pod-autoscaler
+    version: 5.5.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.3.1
+  components:
+  - name: cluster-cloud-director
+    catalog: cluster
+    version: 0.68.0
+  - name: flatcar
+    version: 4152.2.3
+  - name: kubernetes
+    version: 1.31.11
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-08-02T13:38:41Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [x] Roadmap issue created
- [x] Release uses latest stable Flatcar
- [x] Release uses latest Kubernetes patch version
- [x] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
