### PR TITLE
Dummy test please ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ to all Giant Swarm installations.
 
 ## AWS
 
+- v32
+  - v32.0
+    - [v32.0.0](https://github.com/giantswarm/releases/tree/master/capa/v32.0.0)
+
 - v31
   - v31.1
     - [v31.1.0](https://github.com/giantswarm/releases/tree/master/capa/v31.1.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - v30.1.4
 - v31.0.0
 - v31.1.0
+- v32.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -69,6 +69,13 @@
       "releaseTimestamp": "2025-07-31T20:10:32+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "32.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-08-19T18:14:42+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v32.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v32.0.0/README.md
+++ b/capa/v32.0.0/README.md
@@ -1,0 +1,43 @@
+# :zap: Giant Swarm Release v32.0.0 for CAPA :zap:
+
+<< Add description here >>
+
+## Changes compared to v31.1.0
+
+### Components
+
+- Flatcar from v4152.2.3 to [v4230.2.1](https://www.flatcar-linux.org/releases/#release-4230.2.1)
+- Kubernetes from v1.31.11 to [v1.32.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1.32.8)
+
+### Apps
+
+- coredns from v1.26.0 to v1.27.0
+- etcd-defrag from v1.0.6 to v1.0.7
+- vertical-pod-autoscaler from v5.5.1 to v6.0.0
+- vertical-pod-autoscaler-crd from v3.3.1 to v4.0.0
+
+
+### coredns [v1.26.0...v1.27.0](https://github.com/giantswarm/coredns-app/compare/v1.26.0...v1.27.0)
+
+#### Changed
+
+- Updated E2E tests to use apptest-framework v1.14.0
+- Update `coredns` image to [1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3).
+
+### etcd-defrag [v1.0.6...v1.0.7](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.6...v1.0.7)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.30.0. ([#46](https://github.com/giantswarm/etcd-defrag-app/pull/46))
+
+### vertical-pod-autoscaler [v5.5.1...v6.0.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.5.1...v6.0.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v11.0.0. ([#362](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/362))
+
+### vertical-pod-autoscaler-crd [v3.3.1...v4.0.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.3.1...v4.0.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#154](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/154))

--- a/capa/v32.0.0/announcement.md
+++ b/capa/v32.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v32.0.0 for CAPA is available**. << Add description here >>
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-32.0.0).

--- a/capa/v32.0.0/kustomization.yaml
+++ b/capa/v32.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v32.0.0/release.diff
+++ b/capa/v32.0.0/release.diff
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-31.1.0                                              |    name: aws-32.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 3.0.5                                                     version: 3.0.5
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.2.2                                                     version: 1.2.2
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 1.19.1                                                    version: 1.19.1
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.1.2                                                     version: 1.1.2
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.8                                                     version: 2.9.8
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.1                                                     version: 3.9.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.0                                                     version: 0.1.0
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.2.2                                                     version: 1.2.2
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.1                                                     version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 1.31.5-gs1                                                version: 1.31.5-gs1
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.31.3-gs1                                                version: 1.31.3-gs1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.26.0                                             |      version: 1.27.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.0.6                                              |      version: 1.0.7
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.6                                                    version: 1.10.6
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.5                                                    version: 0.10.5
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.0                                                     version: 2.9.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter-bundle                                           - name: karpenter-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter-nodepools                                        - name: karpenter-nodepools
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 0.2.0                                                     version: 0.2.0
+    dependsOn:                                                         dependsOn:
+    - karpenter                                                        - karpenter
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.4                                                    version: 1.20.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.0.0                                                     version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.2                                                     version: 0.0.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.12.0                                                    version: 1.12.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.6                                                    version: 0.10.6
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 5.5.1                                              |      version: 6.0.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.3.1                                              |      version: 4.0.0
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 3.6.0                                                     version: 3.6.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.3                                           |      version: 4230.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.31.11                                            |      version: 1.32.8
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.1                                                    version: 1.26.1
+  date: "2025-07-31T20:10:32Z"                                  |    date: "2025-08-19T18:14:42Z"
+  state: active                                                      state: active

--- a/capa/v32.0.0/release.yaml
+++ b/capa/v32.0.0/release.yaml
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-32.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.5
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.2
+  - name: aws-pod-identity-webhook
+    version: 1.19.1
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.1.2
+  - name: cert-exporter
+    version: 2.9.8
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.2.2
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.31.5-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.31.3-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.27.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.7
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.6
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.5
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-bundle
+    catalog: giantswarm
+    version: 2.1.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-nodepools
+    catalog: giantswarm
+    version: 0.2.0
+    dependsOn:
+    - karpenter
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.4
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.0.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.12.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.6
+  - name: vertical-pod-autoscaler
+    version: 6.0.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.0.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 3.6.0
+  - name: flatcar
+    version: 4230.2.1
+  - name: kubernetes
+    version: 1.32.8
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-08-19T18:14:42Z"
+  state: active


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
- [ ] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).