### PR TITLE
Throw-away release to test new version of cilium

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ to all Giant Swarm installations.
 
 - v31
   - v31.1
+    - [v31.1.1](https://github.com/giantswarm/releases/tree/master/capa/v31.1.1)
     - [v31.1.0](https://github.com/giantswarm/releases/tree/master/capa/v31.1.0)
   - v31.0
     - [v31.0.0](https://github.com/giantswarm/releases/tree/master/capa/v31.0.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - v30.1.4
 - v31.0.0
 - v31.1.0
+- v31.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -69,6 +69,13 @@
       "releaseTimestamp": "2025-07-31T20:10:32+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-08-20T10:00:00+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v31.1.1/README.md
+++ b/capa/v31.1.1/README.md
@@ -1,0 +1,156 @@
+# :zap: Giant Swarm Release v31.1.0 for CAPA :zap:
+
+This release updates Kubernetes to the latest patch release v1.31.11.
+
+During control plane upgrades, short-term warnings are now prevented by setting a fixed instead of dynamic AMI lookup string. This leads to nodes being rolled once when upgrading to this release.
+
+We added an option to set the IMDSv2 request hop limit for EC2 instances ‒ this is usually not needed, except if security requirements such as AWS SCPs (service control policies) dictate a maximum.
+
+Karpenter support keeps getting better: node-termination-handler is not installed anymore if only Karpenter node pools are used, as the same function is built into Karpenter (pod draining and EC2 instance termination handling). Nodes in such pools now also use the reduced IAM permission set (can be toggled in exceptional cases).
+
+## Changes compared to v31.0.0
+
+### Components
+
+- cluster-aws from v3.4.0 to v3.6.0
+- Kubernetes from v1.31.9 to [v1.31.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.11)
+
+### cluster-aws [v3.4.0...v3.6.0](https://github.com/giantswarm/cluster-aws/compare/v3.4.0...v3.6.0)
+
+#### Added
+
+- Add `giantswarm.io/role: nodes` by default to private subnets used for nodes. Can be overwritten.
+- Make IMDSv2 hop limit configurable
+
+#### Changed
+
+- Chart: Update `cluster` to v2.5.0.
+- Only deploy `node-termination-handler` when there are non-karpenter node pools because karpenter takes care of node draining
+- Change `imageLookupFormat` to use a static string rather than CAPI replacing the OS and Kubernetes versions. This rolls control plane nodes.
+
+#### Fixed
+
+- Use reduced IAM permissions on `karpenter` worker nodes instance profile. This can be toggled back with `global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers`.
+
+### Apps
+
+- aws-nth-bundle from v1.2.1 to v1.2.2
+- capi-node-labeler from v1.1.1 to v1.1.2
+- cert-exporter from v2.9.7 to v2.9.8
+- cilium from v1.2.1 to v1.2.2
+- cluster-autoscaler from v1.31.2-gs2 to v1.31.3-gs1
+- coredns from v1.25.0 to v1.26.0
+- etcd-defrag from v1.0.5 to v1.0.6
+- etcd-k8s-res-count-exporter from v1.10.5 to v1.10.6
+- k8s-audit-metrics from v0.10.4 to v0.10.5
+- k8s-dns-node-cache from v2.8.1 to v2.9.0
+- karpenter-bundle from v2.0.0 to v2.1.0
+- karpenter-nodepools from v0.1.0 to v0.2.0
+- node-exporter from v1.20.3 to v1.20.4
+- security-bundle from v1.11.0 to v1.12.0
+- teleport-kube-agent from v0.10.5 to v0.10.6
+
+
+### aws-nth-bundle [v1.2.1...v1.2.2](https://github.com/giantswarm/aws-nth-bundle/compare/v1.2.1...v1.2.2)
+
+#### Changed
+
+- Upgrade Node Termination Handler to 1.21.0.
+
+### capi-node-labeler [v1.1.1...v1.1.2](https://github.com/giantswarm/capi-node-labeler-app/compare/v1.1.1...v1.1.2)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cert-exporter [v2.9.7...v2.9.8](https://github.com/giantswarm/cert-exporter/compare/v2.9.7...v2.9.8)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.2.1...v1.2.2](https://github.com/giantswarm/cilium-app/compare/v1.2.1...v1.2.2)
+
+#### Changed
+
+- Upgrade Cilium to [v1.17.6](https://github.com/cilium/cilium/releases/tag/v1.17.6).
+- Updated E2E tests to use apptest-framework v1.14.0
+- Increase Cilium operator resource limits.
+
+#### Removed
+
+- Remove deprecated "partial" mode from Kube Proxy Replacement options.
+
+### cluster-autoscaler [v1.31.2-gs2...v1.31.3-gs1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.31.2-gs2...v1.31.3-gs1)
+
+#### Changed
+
+- Chart: Update to upstream v1.31.3.
+
+### coredns [v1.25.0...v1.26.0](https://github.com/giantswarm/coredns-app/compare/v1.25.0...v1.26.0)
+
+#### Changed
+
+- Update `coredns` image to [1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2).
+
+### etcd-defrag [v1.0.5...v1.0.6](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.5...v1.0.6)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.29.0. ([#43](https://github.com/giantswarm/etcd-defrag-app/pull/43))
+
+### etcd-k8s-res-count-exporter [v1.10.5...v1.10.6](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.5...v1.10.6)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-audit-metrics [v0.10.4...v0.10.5](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.4...v0.10.5)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-dns-node-cache [v2.8.1...v2.9.0](https://github.com/giantswarm/k8s-dns-node-cache-app/compare/v2.8.1...v2.9.0)
+
+#### Changed
+
+- Upgrade application to version 1.26.4 (includes coredns 1.11.3)
+- Increase ServiceMonitor's scrapping interval to 1m.
+- Remove obsolete PSPs
+
+### karpenter-bundle [v2.0.0...v2.1.0](https://github.com/giantswarm/karpenter-bundle/compare/v2.0.0...v2.1.0)
+
+#### Removed
+
+- Remove capa-karpenter-taint-remover because nodes are now in the `MachinePool` CR, so the taint will be removed by CAPI.
+
+### karpenter-nodepools [v0.1.0...v0.2.0](https://github.com/giantswarm/karpenter-nodepools/compare/v0.1.0...v0.2.0)
+
+#### Changed
+
+- Improve json schema.
+- Change subnet selector to avoid CNI subnets.
+
+### node-exporter [v1.20.3...v1.20.4](https://github.com/giantswarm/node-exporter-app/compare/v1.20.3...v1.20.4)
+
+#### Changed
+
+- Go: Update to v1.24.5.
+
+### security-bundle [v1.11.0...v1.12.0](https://github.com/giantswarm/security-bundle/compare/v1.11.0...v1.12.0)
+
+#### Changed
+
+- Update `trivy-operator` (app) to v0.11.1.
+- Update `trivy` (app) to v0.14.0.
+- Update `falco` (app) to v0.10.1.
+- Update `cloudnative-pg` (app) to v0.0.10.
+- Update `starboard-exporter` (app) to v0.8.2.
+- Updated E2E tests to use apptest-framework v1.14.0
+
+### teleport-kube-agent [v0.10.5...v0.10.6](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.5...v0.10.6)
+
+#### Changed
+
+- AppVersion upgrade to 17.5.4

--- a/capa/v31.1.1/announcement.md
+++ b/capa/v31.1.1/announcement.md
@@ -1,3 +1,3 @@
 **Workload cluster release v31.1.1 for CAPA is available**. This release updates Kubernetes to v1.31.11, prevents short-term warnings during control plane upgrades, adds an option to set the IMDSv2 request hop limit for EC2 instances, and improves Karpenter support.
 
-Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.1.0).
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.1.1).

--- a/capa/v31.1.1/announcement.md
+++ b/capa/v31.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.1.1 for CAPA is available**. This release updates Kubernetes to v1.31.11, prevents short-term warnings during control plane upgrades, adds an option to set the IMDSv2 request hop limit for EC2 instances, and improves Karpenter support.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.1.0).

--- a/capa/v31.1.1/kustomization.yaml
+++ b/capa/v31.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v31.1.1/release.diff
+++ b/capa/v31.1.1/release.diff
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
+kind: Release							kind: Release
+metadata:							metadata:
+  name: aws-31.1.0					      |	  name: aws-31.1.1
+spec:								spec:
+  apps:								  apps:
+  - name: aws-ebs-csi-driver					  - name: aws-ebs-csi-driver
+    version: 3.0.5						    version: 3.0.5
+    dependsOn:							    dependsOn:
+    - cloud-provider-aws					    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors			  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0						    version: 0.1.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: aws-nth-bundle					  - name: aws-nth-bundle
+    version: 1.2.2						    version: 1.2.2
+  - name: aws-pod-identity-webhook				  - name: aws-pod-identity-webhook
+    version: 1.19.1						    version: 1.19.1
+    dependsOn:							    dependsOn:
+    - cert-manager						    - cert-manager
+  - name: capi-node-labeler					  - name: capi-node-labeler
+    version: 1.1.2						    version: 1.1.2
+  - name: cert-exporter						  - name: cert-exporter
+    version: 2.9.8						    version: 2.9.8
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: cert-manager						  - name: cert-manager
+    version: 3.9.1						    version: 3.9.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources			  - name: cert-manager-crossplane-resources
+    catalog: cluster						    catalog: cluster
+    version: 0.1.0						    version: 0.1.0
+  - name: chart-operator-extensions				  - name: chart-operator-extensions
+    version: 1.1.2						    version: 1.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cilium						  - name: cilium
+    version: 1.2.2					      |	    version: 1.2.2-a16c05bd116bc5d9428c7ab26c18949a9361f46c
+							      >	    catalog: default-test
+  - name: cilium-crossplane-resources				  - name: cilium-crossplane-resources
+    catalog: cluster						    catalog: cluster
+    version: 0.2.1						    version: 0.2.1
+  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
+    version: 0.1.3						    version: 0.1.3
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cloud-provider-aws					  - name: cloud-provider-aws
+    version: 1.31.5-gs1						    version: 1.31.5-gs1
+    dependsOn:							    dependsOn:
+    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler					  - name: cluster-autoscaler
+    version: 1.31.3-gs1						    version: 1.31.3-gs1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: coredns						  - name: coredns
+    version: 1.26.0						    version: 1.26.0
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns-extensions					  - name: coredns-extensions
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag						  - name: etcd-defrag
+    version: 1.0.6						    version: 1.0.6
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
+    version: 1.10.6						    version: 1.10.6
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: external-dns						  - name: external-dns
+    version: 3.2.0						    version: 3.2.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: irsa-servicemonitors					  - name: irsa-servicemonitors
+    version: 0.1.0						    version: 0.1.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
+    version: 0.10.5						    version: 0.10.5
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
+    version: 2.9.0						    version: 2.9.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: karpenter-bundle					  - name: karpenter-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 2.1.0						    version: 2.1.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: karpenter-nodepools					  - name: karpenter-nodepools
+    catalog: giantswarm						    catalog: giantswarm
+    version: 0.2.0						    version: 0.2.0
+    dependsOn:							    dependsOn:
+    - karpenter							    - karpenter
+  - name: metrics-server					  - name: metrics-server
+    version: 2.6.0						    version: 2.6.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: net-exporter						  - name: net-exporter
+    version: 1.23.0						    version: 1.23.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: network-policies					  - name: network-policies
+    catalog: cluster						    catalog: cluster
+    version: 0.1.1						    version: 0.1.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: node-exporter						  - name: node-exporter
+    version: 1.20.4						    version: 1.20.4
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: observability-bundle					  - name: observability-bundle
+    version: 2.0.0						    version: 2.0.0
+    dependsOn:							    dependsOn:
+    - coredns							    - coredns
+  - name: observability-policies				  - name: observability-policies
+    version: 0.0.2						    version: 0.0.2
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
+    version: 0.5.0						    version: 0.5.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: security-bundle					  - name: security-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 1.12.0						    version: 1.12.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: teleport-kube-agent					  - name: teleport-kube-agent
+    version: 0.10.6						    version: 0.10.6
+  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
+    version: 5.5.1						    version: 5.5.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
+    version: 3.3.1						    version: 3.3.1
+  components:							  components:
+  - name: cluster-aws						  - name: cluster-aws
+    catalog: cluster						    catalog: cluster
+    version: 3.6.0						    version: 3.6.0
+  - name: flatcar						  - name: flatcar
+    version: 4152.2.3						    version: 4152.2.3
+  - name: kubernetes						  - name: kubernetes
+    version: 1.31.11						    version: 1.31.11
+  - name: os-tooling						  - name: os-tooling
+    version: 1.26.1						    version: 1.26.1
+  date: "2025-07-31T20:10:32Z"				      |	  date: "2025-08-20T10:00:00Z"
+  state: active							  state: active

--- a/capa/v31.1.1/release.yaml
+++ b/capa/v31.1.1/release.yaml
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-31.1.1
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.5
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.2
+  - name: aws-pod-identity-webhook
+    version: 1.19.1
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.1.2
+  - name: cert-exporter
+    version: 2.9.8
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.2.2-a16c05bd116bc5d9428c7ab26c18949a9361f46c
+    catalog: default-test
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.31.5-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.31.3-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.26.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.6
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.6
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.5
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-bundle
+    catalog: giantswarm
+    version: 2.1.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-nodepools
+    catalog: giantswarm
+    version: 0.2.0
+    dependsOn:
+    - karpenter
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.4
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.0.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.12.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.6
+  - name: vertical-pod-autoscaler
+    version: 5.5.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 3.3.1
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 3.6.0
+  - name: flatcar
+    version: 4152.2.3
+  - name: kubernetes
+    version: 1.31.11
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-08-20T10:00:00Z"
+  state: active

--- a/capa/v31.1.1/release.yaml
+++ b/capa/v31.1.1/release.yaml
@@ -36,7 +36,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cilium
-    version: 1.2.2-a16c05bd116bc5d9428c7ab26c18949a9361f46c
+    version: 1.2.2-504bdfd611995c9b6588dafa2279c26a41983f8c
     catalog: default-test
   - name: cilium-crossplane-resources
     catalog: cluster


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

Throw-away release. Ignore

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).
