### PR TITLE
Dummy test for node roll detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to all Giant Swarm installations.
 ## AWS
 
 - v31
+  - v31.2
+    - [v31.2.0](https://github.com/giantswarm/releases/tree/master/capa/v31.2.0)
   - v31.1
     - [v31.1.1](https://github.com/giantswarm/releases/tree/master/capa/v31.1.1)
     - [v31.1.0](https://github.com/giantswarm/releases/tree/master/capa/v31.1.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - v31.0.0
 - v31.1.0
 - v31.1.1
+- v31.2.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "31.2.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-09-03T14:21:48+02:00",
+      "releaseTimestamp": "2025-09-03T17:59:18+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
       "isStable": true
     }

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -62,6 +62,13 @@
       "releaseTimestamp": "2025-08-21T18:17:23+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.1.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "31.2.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-08-29T10:53:20+02:00",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "31.2.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-08-29T10:53:20+02:00",
+      "releaseTimestamp": "2025-08-29T10:58:39+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
       "isStable": true
     }

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "31.2.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-08-29T10:58:39+02:00",
+      "releaseTimestamp": "2025-08-29T11:32:38+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
       "isStable": true
     }

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "31.2.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-08-29T11:32:38+02:00",
+      "releaseTimestamp": "2025-09-03T14:16:49+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
       "isStable": true
     }

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -66,7 +66,7 @@
     {
       "version": "31.2.0",
       "isDeprecated": false,
-      "releaseTimestamp": "2025-09-03T14:16:49+02:00",
+      "releaseTimestamp": "2025-09-03T14:21:48+02:00",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v31.2.0/README.md",
       "isStable": true
     }

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -7,7 +7,6 @@
 ### Components
 
 - cluster-aws from v3.6.1 to v4.0.1
-- Flatcar from v4152.2.3 to [v4230.2.2](https://www.flatcar-linux.org/releases/#release-4230.2.2)
 - Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
 
 ### cluster-aws [v3.6.1...v4.0.1](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.1)

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -7,7 +7,6 @@
 ### Components
 
 - cluster-aws from v3.6.1 to v4.0.0
-- Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
 
 ### cluster-aws [v3.6.1...v4.0.0](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.0)
 

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -7,7 +7,6 @@
 ### Components
 
 - cluster-aws from v3.6.1 to v4.0.1
-- Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
 
 ### cluster-aws [v3.6.1...v4.0.1](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.1)
 

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -1,0 +1,130 @@
+# :zap: Giant Swarm Release v31.2.0 for CAPA :zap:
+
+<< Add description here >>
+
+## Changes compared to v31.1.1
+
+### Components
+
+- cluster-aws from v3.6.1 to v4.0.0
+- Flatcar from v4152.2.3 to [v4230.2.2](https://www.flatcar-linux.org/releases/#release-4230.2.2)
+- Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
+
+### cluster-aws [v3.6.1...v4.0.0](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.0)
+
+#### Added
+
+- Add `global.connectivity.network.nodePortIngressRuleCidrBlocks` value to allow configuring the CIDRs in the NodePort security group ingress rules.
+- Expose new `machinepool` values to configure the karpenter node pools:
+- `consolidateAfter`
+- `consolidationBudgets`
+- `consolidationPolicy`
+
+#### Changed
+
+- Chart: Update `cluster` to v2.6.1.
+
+#### Removed
+
+- Remove Helm chart that creates karpenter node pools, because they will be created by a kubernetes controller running in the management cluster.
+
+### Apps
+
+- capi-node-labeler from v1.1.2 to v1.1.3
+- cert-exporter from v2.9.8 to v2.9.9
+- cilium from v1.2.2 to v1.2.3
+- cloud-provider-aws from v1.31.5-gs1 to v1.32.3-gs1
+- cluster-autoscaler from v1.31.3-gs1 to v1.32.2-gs1
+- coredns from v1.26.0 to v1.27.0
+- etcd-defrag from v1.0.6 to v1.0.7
+- etcd-k8s-res-count-exporter from v1.10.6 to v1.10.7
+- k8s-audit-metrics from v0.10.5 to v0.10.6
+- node-exporter from v1.20.4 to v1.20.5
+- observability-bundle from v2.0.0 to v2.1.0
+- vertical-pod-autoscaler from v5.5.1 to v6.0.0
+- vertical-pod-autoscaler-crd from v3.3.1 to v4.0.0
+
+
+### capi-node-labeler [v1.1.2...v1.1.3](https://github.com/giantswarm/capi-node-labeler-app/compare/v1.1.2...v1.1.3)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cert-exporter [v2.9.8...v2.9.9](https://github.com/giantswarm/cert-exporter/compare/v2.9.8...v2.9.9)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.2.2...v1.2.3](https://github.com/giantswarm/cilium-app/compare/v1.2.2...v1.2.3)
+
+#### Changed
+
+- Improve the k8s service host autodiscovery mechanism
+- Upgrade Cilium to [v1.17.7](https://github.com/cilium/cilium/releases/tag/v1.17.7).
+
+### cloud-provider-aws [v1.31.5-gs1...v1.32.3-gs1](https://github.com/giantswarm/aws-cloud-controller-manager-app/compare/v1.31.5-gs1...v1.32.3-gs1)
+
+#### Changed
+
+- Chart: Update to upstream v1.32.3.
+
+### cluster-autoscaler [v1.31.3-gs1...v1.32.2-gs1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.31.3-gs1...v1.32.2-gs1)
+
+#### Changed
+
+- Chart: Update to upstream v1.32.2.
+
+### coredns [v1.26.0...v1.27.0](https://github.com/giantswarm/coredns-app/compare/v1.26.0...v1.27.0)
+
+#### Changed
+
+- Updated E2E tests to use apptest-framework v1.14.0
+- Update `coredns` image to [1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3).
+
+### etcd-defrag [v1.0.6...v1.0.7](https://github.com/giantswarm/etcd-defrag-app/compare/v1.0.6...v1.0.7)
+
+#### Changed
+
+- Chart: Update dependency ahrtr/etcd-defrag to v0.30.0. ([#46](https://github.com/giantswarm/etcd-defrag-app/pull/46))
+
+### etcd-k8s-res-count-exporter [v1.10.6...v1.10.7](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.6...v1.10.7)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### k8s-audit-metrics [v0.10.5...v0.10.6](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.5...v0.10.6)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### node-exporter [v1.20.4...v1.20.5](https://github.com/giantswarm/node-exporter-app/compare/v1.20.4...v1.20.5)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### observability-bundle [v2.0.0...v2.1.0](https://github.com/giantswarm/observability-bundle/compare/v2.0.0...v2.1.0)
+
+#### Changed
+
+- Upgrade `kube-prometheus-stack` to 76.4.0
+  - Bumps prometheus-operator and CRDs to 0.84.1
+  - Bumps prometheus to 3.5.0
+- Update alloy-app to 0.12.1
+  - Bumps alloy to 1.10.1
+
+### vertical-pod-autoscaler [v5.5.1...v6.0.0](https://github.com/giantswarm/vertical-pod-autoscaler-app/compare/v5.5.1...v6.0.0)
+
+#### Changed
+
+- Chart: Update Helm release vertical-pod-autoscaler to v11.0.0. ([#362](https://github.com/giantswarm/vertical-pod-autoscaler-app/pull/362))
+
+### vertical-pod-autoscaler-crd [v3.3.1...v4.0.0](https://github.com/giantswarm/vertical-pod-autoscaler-crd/compare/v3.3.1...v4.0.0)
+
+#### Changed
+
+- Chart: Sync to upstream. ([#154](https://github.com/giantswarm/vertical-pod-autoscaler-crd/pull/154))

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -7,7 +7,6 @@
 ### Components
 
 - cluster-aws from v3.6.1 to v4.0.0
-- Flatcar from v4152.2.3 to [v4230.2.2](https://www.flatcar-linux.org/releases/#release-4230.2.2)
 - Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
 
 ### cluster-aws [v3.6.1...v4.0.0](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.0)

--- a/capa/v31.2.0/README.md
+++ b/capa/v31.2.0/README.md
@@ -6,9 +6,11 @@
 
 ### Components
 
-- cluster-aws from v3.6.1 to v4.0.0
+- cluster-aws from v3.6.1 to v4.0.1
+- Flatcar from v4152.2.3 to [v4230.2.2](https://www.flatcar-linux.org/releases/#release-4230.2.2)
+- Kubernetes from v1.31.11 to [v1.31.12](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1.31.12)
 
-### cluster-aws [v3.6.1...v4.0.0](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.0)
+### cluster-aws [v3.6.1...v4.0.1](https://github.com/giantswarm/cluster-aws/compare/v3.6.1...v4.0.1)
 
 #### Added
 
@@ -20,6 +22,7 @@
 
 #### Changed
 
+- Chart: Update `cluster` to v2.6.2.
 - Chart: Update `cluster` to v2.6.1.
 
 #### Removed
@@ -30,15 +33,16 @@
 
 - capi-node-labeler from v1.1.2 to v1.1.3
 - cert-exporter from v2.9.8 to v2.9.9
-- cilium from v1.2.2 to v1.2.3
-- cloud-provider-aws from v1.31.5-gs1 to v1.32.3-gs1
-- cluster-autoscaler from v1.31.3-gs1 to v1.32.2-gs1
+- cert-manager from v3.9.1 to v3.9.2
+- cilium from v1.2.2 to v1.3.0
 - coredns from v1.26.0 to v1.27.0
 - etcd-defrag from v1.0.6 to v1.0.7
 - etcd-k8s-res-count-exporter from v1.10.6 to v1.10.7
 - k8s-audit-metrics from v0.10.5 to v0.10.6
+- k8s-dns-node-cache from v2.9.0 to v2.9.1
+- metrics-server from v2.6.0 to v2.7.0
 - node-exporter from v1.20.4 to v1.20.5
-- observability-bundle from v2.0.0 to v2.1.0
+- observability-bundle from v2.0.0 to v2.2.0
 - vertical-pod-autoscaler from v5.5.1 to v6.0.0
 - vertical-pod-autoscaler-crd from v3.3.1 to v4.0.0
 
@@ -55,24 +59,19 @@
 
 - Go: Update dependencies.
 
-### cilium [v1.2.2...v1.2.3](https://github.com/giantswarm/cilium-app/compare/v1.2.2...v1.2.3)
+### cert-manager [v3.9.1...v3.9.2](https://github.com/giantswarm/cert-manager-app/compare/v3.9.1...v3.9.2)
 
 #### Changed
 
+- Add `alloy` ingress rules for cainjector metrics ingestion.
+
+### cilium [v1.2.2...v1.3.0](https://github.com/giantswarm/cilium-app/compare/v1.2.2...v1.3.0)
+
+#### Changed
+
+- Upgrade Cilium to [v1.18.1](https://github.com/cilium/cilium/releases/tag/v1.18.1).
 - Improve the k8s service host autodiscovery mechanism
 - Upgrade Cilium to [v1.17.7](https://github.com/cilium/cilium/releases/tag/v1.17.7).
-
-### cloud-provider-aws [v1.31.5-gs1...v1.32.3-gs1](https://github.com/giantswarm/aws-cloud-controller-manager-app/compare/v1.31.5-gs1...v1.32.3-gs1)
-
-#### Changed
-
-- Chart: Update to upstream v1.32.3.
-
-### cluster-autoscaler [v1.31.3-gs1...v1.32.2-gs1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.31.3-gs1...v1.32.2-gs1)
-
-#### Changed
-
-- Chart: Update to upstream v1.32.2.
 
 ### coredns [v1.26.0...v1.27.0](https://github.com/giantswarm/coredns-app/compare/v1.26.0...v1.27.0)
 
@@ -99,16 +98,31 @@
 
 - Go: Update dependencies.
 
+### k8s-dns-node-cache [v2.9.0...v2.9.1](https://github.com/giantswarm/k8s-dns-node-cache-app/compare/v2.9.0...v2.9.1)
+
+#### Changed
+
+- Update PolicyException apiVersion to v2.
+
+### metrics-server [v2.6.0...v2.7.0](https://github.com/giantswarm/metrics-server-app/compare/v2.6.0...v2.7.0)
+
+#### Changed
+
+- Chart: Update PolicyExceptions to v2.
+
 ### node-exporter [v1.20.4...v1.20.5](https://github.com/giantswarm/node-exporter-app/compare/v1.20.4...v1.20.5)
 
 #### Changed
 
 - Go: Update dependencies.
 
-### observability-bundle [v2.0.0...v2.1.0](https://github.com/giantswarm/observability-bundle/compare/v2.0.0...v2.1.0)
+### observability-bundle [v2.0.0...v2.2.0](https://github.com/giantswarm/observability-bundle/compare/v2.0.0...v2.2.0)
 
 #### Changed
 
+- Upgrade `kube-prometheus-stack` to 77.0.1
+  - Bumps prometheus-operator and CRDs to 0.85.0
+- Update alloy-app to 0.13.0
 - Upgrade `kube-prometheus-stack` to 76.4.0
   - Bumps prometheus-operator and CRDs to 0.84.1
   - Bumps prometheus to 3.5.0

--- a/capa/v31.2.0/announcement.md
+++ b/capa/v31.2.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v31.2.0 for CAPA is available**. << Add description here >>
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-31.2.0).

--- a/capa/v31.2.0/kustomization.yaml
+++ b/capa/v31.2.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -141,10 +141,10 @@ spec:                                                              spec:
     catalog: cluster                                                   catalog: cluster
     version: 3.6.1                                              |      version: 4.0.0
   - name: flatcar                                                    - name: flatcar
-    version: 4152.2.3                                           |      version: 4230.2.2
+    version: 4152.2.3                                                  version: 4152.2.3
   - name: kubernetes                                                 - name: kubernetes
     version: 1.31.11                                            |      version: 1.31.12
   - name: os-tooling                                                 - name: os-tooling
     version: 1.26.1                                                    version: 1.26.1
-  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T10:53:20Z"
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T10:58:39Z"
   state: active                                                      state: active

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -141,10 +141,10 @@ spec:                                                              spec:
     catalog: cluster                                                   catalog: cluster
     version: 3.6.1                                              |      version: 4.0.1
   - name: flatcar                                                    - name: flatcar
-    version: 4152.2.3                                           |      version: 4230.2.2
+    version: 4152.2.3                                                  version: 4152.2.3
   - name: kubernetes                                                 - name: kubernetes
     version: 1.31.11                                            |      version: 1.31.12
   - name: os-tooling                                                 - name: os-tooling
     version: 1.26.1                                                    version: 1.26.1
-  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-09-03T14:16:49Z"
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-09-03T14:21:48Z"
   state: active                                                      state: active

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -25,7 +25,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: cert-manager                                               - name: cert-manager
-    version: 3.9.1                                                     version: 3.9.1
+    version: 3.9.1                                              |      version: 3.9.2
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
@@ -36,7 +36,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: cilium                                                     - name: cilium
-    version: 1.2.2                                              |      version: 1.2.3
+    version: 1.2.2                                              |      version: 1.3.0
   - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
     catalog: cluster                                                   catalog: cluster
     version: 0.2.1                                                     version: 0.2.1
@@ -45,11 +45,11 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: cloud-provider-aws                                         - name: cloud-provider-aws
-    version: 1.31.5-gs1                                         |      version: 1.32.3-gs1
+    version: 1.31.5-gs1                                                version: 1.31.5-gs1
     dependsOn:                                                         dependsOn:
     - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler                                         - name: cluster-autoscaler
-    version: 1.31.3-gs1                                         |      version: 1.32.2-gs1
+    version: 1.31.3-gs1                                                version: 1.31.3-gs1
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: coredns                                                    - name: coredns
@@ -81,7 +81,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
-    version: 2.9.0                                                     version: 2.9.0
+    version: 2.9.0                                              |      version: 2.9.1
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: karpenter-bundle                                           - name: karpenter-bundle
@@ -95,7 +95,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - karpenter                                                        - karpenter
   - name: metrics-server                                             - name: metrics-server
-    version: 2.6.0                                                     version: 2.6.0
+    version: 2.6.0                                              |      version: 2.7.0
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: net-exporter                                               - name: net-exporter
@@ -112,7 +112,7 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: observability-bundle                                       - name: observability-bundle
-    version: 2.0.0                                              |      version: 2.1.0
+    version: 2.0.0                                              |      version: 2.2.0
     dependsOn:                                                         dependsOn:
     - coredns                                                          - coredns
   - name: observability-policies                                     - name: observability-policies
@@ -139,12 +139,12 @@ spec:                                                              spec:
   components:                                                        components:
   - name: cluster-aws                                                - name: cluster-aws
     catalog: cluster                                                   catalog: cluster
-    version: 3.6.1                                              |      version: 4.0.0
+    version: 3.6.1                                              |      version: 4.0.1
   - name: flatcar                                                    - name: flatcar
-    version: 4152.2.3                                                  version: 4152.2.3
+    version: 4152.2.3                                           |      version: 4230.2.2
   - name: kubernetes                                                 - name: kubernetes
-    version: 1.31.11                                                   version: 1.31.11
+    version: 1.31.11                                            |      version: 1.31.12
   - name: os-tooling                                                 - name: os-tooling
     version: 1.26.1                                                    version: 1.26.1
-  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T11:32:38Z"
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-09-03T14:16:49Z"
   state: active                                                      state: active

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -143,8 +143,8 @@ spec:                                                              spec:
   - name: flatcar                                                    - name: flatcar
     version: 4152.2.3                                                  version: 4152.2.3
   - name: kubernetes                                                 - name: kubernetes
-    version: 1.31.11                                            |      version: 1.31.12
+    version: 1.31.11                                                   version: 1.31.11
   - name: os-tooling                                                 - name: os-tooling
     version: 1.26.1                                                    version: 1.26.1
-  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-09-03T14:21:48Z"
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-09-03T17:59:18Z"
   state: active                                                      state: active

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-31.1.1                                              |    name: aws-31.2.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 3.0.5                                                     version: 3.0.5
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.2.2                                                     version: 1.2.2
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 1.19.1                                                    version: 1.19.1
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: capi-node-labeler                                          - name: capi-node-labeler
+    version: 1.1.2                                              |      version: 1.1.3
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.8                                              |      version: 2.9.9
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.1                                                     version: 3.9.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.0                                                     version: 0.1.0
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.2.2                                              |      version: 1.2.3
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.1                                                     version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 1.31.5-gs1                                         |      version: 1.32.3-gs1
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.31.3-gs1                                         |      version: 1.32.2-gs1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.26.0                                             |      version: 1.27.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.0.6                                              |      version: 1.0.7
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.6                                             |      version: 1.10.7
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.5                                             |      version: 0.10.6
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.0                                                     version: 2.9.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter-bundle                                           - name: karpenter-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter-nodepools                                        - name: karpenter-nodepools
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 0.2.0                                                     version: 0.2.0
+    dependsOn:                                                         dependsOn:
+    - karpenter                                                        - karpenter
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.6.0                                                     version: 2.6.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.4                                             |      version: 1.20.5
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.0.0                                              |      version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.2                                                     version: 0.0.2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.12.0                                                    version: 1.12.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.6                                                    version: 0.10.6
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 5.5.1                                              |      version: 6.0.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 3.3.1                                              |      version: 4.0.0
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 3.6.1                                              |      version: 4.0.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4152.2.3                                           |      version: 4230.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.31.11                                            |      version: 1.31.12
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.1                                                    version: 1.26.1
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T10:53:20Z"
+  state: active                                                      state: active

--- a/capa/v31.2.0/release.diff
+++ b/capa/v31.2.0/release.diff
@@ -143,8 +143,8 @@ spec:                                                              spec:
   - name: flatcar                                                    - name: flatcar
     version: 4152.2.3                                                  version: 4152.2.3
   - name: kubernetes                                                 - name: kubernetes
-    version: 1.31.11                                            |      version: 1.31.12
+    version: 1.31.11                                                   version: 1.31.11
   - name: os-tooling                                                 - name: os-tooling
     version: 1.26.1                                                    version: 1.26.1
-  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T10:58:39Z"
+  date: "2025-08-21T18:17:23Z"                                  |    date: "2025-08-29T11:32:38Z"
   state: active                                                      state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -141,10 +141,10 @@ spec:
     catalog: cluster
     version: 4.0.0
   - name: flatcar
-    version: 4230.2.2
+    version: 4152.2.3
   - name: kubernetes
     version: 1.31.12
   - name: os-tooling
     version: 1.26.1
-  date: "2025-08-29T10:53:20Z"
+  date: "2025-08-29T10:58:39Z"
   state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -45,11 +45,11 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cloud-provider-aws
-    version: 1.32.3-gs1
+    version: 1.31.5-gs1
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler
-    version: 1.32.2-gs1
+    version: 1.31.3-gs1
     dependsOn:
     - kyverno-crds
   - name: coredns
@@ -139,7 +139,7 @@ spec:
   components:
   - name: cluster-aws
     catalog: cluster
-    version: 4.0.0
+    version: 3.6.1
   - name: flatcar
     version: 4152.2.3
   - name: kubernetes

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-31.2.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.0.5
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.2.2
+  - name: aws-pod-identity-webhook
+    version: 1.19.1
+    dependsOn:
+    - cert-manager
+  - name: capi-node-labeler
+    version: 1.1.3
+  - name: cert-exporter
+    version: 2.9.9
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.2.3
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.32.3-gs1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.32.2-gs1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.27.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.0.7
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.7
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.6
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-bundle
+    catalog: giantswarm
+    version: 2.1.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter-nodepools
+    catalog: giantswarm
+    version: 0.2.0
+    dependsOn:
+    - karpenter
+  - name: metrics-server
+    version: 2.6.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.5
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.1.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.2
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.12.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.6
+  - name: vertical-pod-autoscaler
+    version: 6.0.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.0.0
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 4.0.0
+  - name: flatcar
+    version: 4230.2.2
+  - name: kubernetes
+    version: 1.31.12
+  - name: os-tooling
+    version: 1.26.1
+  date: "2025-08-29T10:53:20Z"
+  state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -141,10 +141,10 @@ spec:
     catalog: cluster
     version: 4.0.1
   - name: flatcar
-    version: 4230.2.2
+    version: 4152.2.3
   - name: kubernetes
     version: 1.31.12
   - name: os-tooling
     version: 1.26.1
-  date: "2025-09-03T14:16:49Z"
+  date: "2025-09-03T14:21:48Z"
   state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -143,8 +143,8 @@ spec:
   - name: flatcar
     version: 4152.2.3
   - name: kubernetes
-    version: 1.31.12
+    version: 1.31.11
   - name: os-tooling
     version: 1.26.1
-  date: "2025-09-03T14:21:48Z"
+  date: "2025-09-03T17:59:18Z"
   state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -143,8 +143,8 @@ spec:
   - name: flatcar
     version: 4152.2.3
   - name: kubernetes
-    version: 1.31.12
+    version: 1.31.11
   - name: os-tooling
     version: 1.26.1
-  date: "2025-08-29T10:58:39Z"
+  date: "2025-08-29T11:32:38Z"
   state: active

--- a/capa/v31.2.0/release.yaml
+++ b/capa/v31.2.0/release.yaml
@@ -25,7 +25,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: cert-manager
-    version: 3.9.1
+    version: 3.9.2
     dependsOn:
     - prometheus-operator-crd
   - name: cert-manager-crossplane-resources
@@ -36,7 +36,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cilium
-    version: 1.2.3
+    version: 1.3.0
   - name: cilium-crossplane-resources
     catalog: cluster
     version: 0.2.1
@@ -81,7 +81,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: k8s-dns-node-cache
-    version: 2.9.0
+    version: 2.9.1
     dependsOn:
     - kyverno-crds
   - name: karpenter-bundle
@@ -95,7 +95,7 @@ spec:
     dependsOn:
     - karpenter
   - name: metrics-server
-    version: 2.6.0
+    version: 2.7.0
     dependsOn:
     - kyverno-crds
   - name: net-exporter
@@ -112,7 +112,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: observability-bundle
-    version: 2.1.0
+    version: 2.2.0
     dependsOn:
     - coredns
   - name: observability-policies
@@ -139,12 +139,12 @@ spec:
   components:
   - name: cluster-aws
     catalog: cluster
-    version: 3.6.1
+    version: 4.0.1
   - name: flatcar
-    version: 4152.2.3
+    version: 4230.2.2
   - name: kubernetes
-    version: 1.31.11
+    version: 1.31.12
   - name: os-tooling
     version: 1.26.1
-  date: "2025-08-29T11:32:38Z"
+  date: "2025-09-03T14:16:49Z"
   state: active


### PR DESCRIPTION
Only for testing purpose
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [ ] Release uses latest stable Flatcar
- [ ] Release uses latest Kubernetes patch version
- [ ] Release uses latest supported version of all default apps

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).