### PR TITLE
Update SDK changelog: enable EKS provider

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add EKS provider to the list of supported providers.
+
 ### Fixed
 
 - Fix `getResourceNameParts` from cutting `cloud-director` 


### PR DESCRIPTION
I missed this when adding support for EKS - the SDK also needs a release and so it needs a CHANGELOG entry first.
