### PR TITLE
Consolidate archive and deprecate PRs

### DIFF
--- a/.github/workflows/archive-releases.yaml
+++ b/.github/workflows/archive-releases.yaml
@@ -286,6 +286,10 @@ jobs:
 
             ${{ steps.archive_script.outputs.archived_releases_pr_body_section }}
 
+            ---
+
+            /skip-ci This change does not affect what's being tested by CI.
+
           branch: auto-archive-capi-releases
           base: master
           labels: |

--- a/.github/workflows/deprecate-releases.yaml
+++ b/.github/workflows/deprecate-releases.yaml
@@ -216,6 +216,10 @@ jobs:
             ## Verify in Grafana
 
             You can check which releases are currently in use in the [CAPI Releases Dashboard](https://giantswarm.grafana.net/d/be9a0bh8mbwn4e/capi-releases?orgId=1&from=now-6h&to=now&timezone=browser).
+
+            ---
+
+            /skip-ci This change does not affect what's being tested by CI.
           branch: auto-deprecate-capi-releases
           base: master
           labels: |


### PR DESCRIPTION
## Example Deprecate PR Body

<details>

## Automated Release Deprecation for CAPI

This PR automatically marks outdated releases across all CAPI providers as deprecated.
A release is kept active if it meets any of the following criteria:

- Currently in use
- Latest of supported major versions
- Required for upgrade path

### Modified Configuration

- `capa/releases.json` - Updated deprecated status for relevant versions.
- `vsphere/releases.json` - Updated deprecated status for relevant versions.
- `cloud-director/releases.json` - Updated deprecated status for relevant versions.

### Releases Deprecated in this PR

#### CAPA

| Major Version | Releases Deprecated |
|---------------|---------------------|
| v28           | v28.5.5             |
| v29           | v29.6.4             |
| v30           | v30.1.5             |

#### CAPV

| Major Version | Releases Deprecated |
|---------------|---------------------|
| v30           | v30.1.4             |
| v33           | v33.0.0             |

#### CAPVCD

| Major Version | Releases Deprecated |
|---------------|---------------------|
| v31           | v31.1.0             |
| v33           | v33.0.0             |

## Verify in Grafana

You can check which releases are currently in use in the [CAPI Releases Dashboard](https://giantswarm.grafana.net/d/be9a0bh8mbwn4e/capi-releases?orgId=1&from=now-6h&to=now&timezone=browser).

</details>

## Example Archive PR Body

<details>

## Automated Release Archiving for CAPI

This PR archives deprecated releases across all CAPI providers.
Archived releases are moved from `<provider>/<version>` to `<provider>/archived/<version>`.

### Releases Archived in this PR

#### CAPA

| Major Version | Releases Archived |
|---------------|-------------------|
| v28           | v28.5.5           |
| v29           | v29.6.4           |
| v30           | v30.1.5           |

#### CAPV

| Major Version | Releases Archived |
|---------------|-------------------|
| v30           | v30.1.4           |
| v33           | v33.0.0           |

#### CAPVCD

| Major Version | Releases Archived |
|---------------|-------------------|
| v31           | v31.1.0           |
| v33           | v33.0.0           |

#### CAPZ

| Major Version | Releases Archived |
|---------------|-------------------|
| v29           | v29.5.1           |

</details>