### PR TITLE
Update notify action with fixes

### DIFF
--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -73,9 +73,9 @@ jobs:
       - name: Get announcement.md
         id: get_announcement_md
         run: |
-          LINK="https://raw.githubusercontent.com/giantswarm/releases/refs/heads/master/${{ github.event.inputs.provider }}/${{ github.event.inputs.version }}/announcement.md"
+          export LINK="https://raw.githubusercontent.com/giantswarm/releases/refs/heads/master/${{ github.event.inputs.provider }}/${{ github.event.inputs.version }}/announcement.md"
           wget $LINK
-          echo announcement=$(cat announcement.md) >> "$GITHUB_OUTPUT"
+          echo $(cat announcement.md) >> "$GITHUB_OUTPUT"
   
   send_messages:
     name: Send Messages


### PR DESCRIPTION
This fixes the JSON output in the `gather_channels` step. In addition, the parameter to find the `announcement.md` file is now a version number rather than an URL