### PR TITLE
CAPI: Release v34.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ to all Giant Swarm installations.
 
 ## AWS
 
+- v34
+  - v34.0
+    - [v34.0.0](https://github.com/giantswarm/releases/tree/master/capa/v34.0.0)
+
 - v33
   - v33.1
     - [v33.1.4](https://github.com/giantswarm/releases/tree/master/capa/v33.1.4)
@@ -151,6 +155,10 @@ to all Giant Swarm installations.
     - [v25.0.0](https://github.com/giantswarm/releases/tree/master/capa/archived/v25.0.0)
 
 ## Azure
+
+- v34
+  - v34.0
+    - [v34.0.0](https://github.com/giantswarm/releases/tree/master/azure/v34.0.0)
 
 - v33
   - v33.1
@@ -332,6 +340,10 @@ to all Giant Swarm installations.
 
 ## vSphere
 
+- v34
+  - v34.0
+    - [v34.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/v34.0.0)
+
 - v33
   - v33.1
     - [v33.1.1](https://github.com/giantswarm/releases/tree/master/vsphere/v33.1.1)
@@ -384,6 +396,10 @@ to all Giant Swarm installations.
     - [v27.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/archived/v27.0.0)
 
 ## VMware Cloud Director
+
+- v34
+  - v34.0
+    - [v34.0.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v34.0.0)
 
 - v33
   - v33.1

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - v32.1.0
 - v33.0.1
 - v33.1.1
+- v34.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/azure/releases.json
+++ b/azure/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2025-12-16T15:16:14Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v33.1.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-01-22T09:38:19Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v34.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/azure/v34.0.0/README.md
+++ b/azure/v34.0.0/README.md
@@ -1,0 +1,180 @@
+# :zap: Giant Swarm Release v34.0.0 for Azure :zap:
+
+## Changes compared to v33.1.1
+
+### Components
+
+- cluster-azure from v4.4.0 to v5.1.2
+- Flatcar from v4459.2.1 to [v4459.2.2](https://www.flatcar.org/releases/#release-4459.2.2)
+- Kubernetes from v1.33.6 to [v1.34.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1.34.3)
+- os-tooling from v1.26.2 to v1.26.3
+
+### cluster-azure [v4.4.0...v5.1.2](https://github.com/giantswarm/cluster-azure/compare/v4.4.0...v5.1.2)
+
+#### Added
+
+- Add the `priority-classes` default app, enabled by default. This app provides standardised `PriorityClass` resources like `giantswarm-critical` and `giantswarm-high`, which should replace the previous inconsistent per-app priority classes.
+- Add `"helm.sh/resource-policy": keep` annotation to `AzureCluster` CR so that it doesn't get removed by Helm when uninstalling this chart. The CAPI controllers will take care of removing it, following the expected deletion order.
+
+#### Changed
+
+- Chart: Update `cluster` to v5.1.2.
+- Chart: Update `cluster` to v5.1.1.
+- Chart: Update `cluster` to v5.1.0.
+- Chart: Update `cluster` to v5.0.0.
+
+### Apps
+
+- azure-cloud-controller-manager from v1.32.7-1 to v2.0.0
+- azure-cloud-node-manager from v1.32.7 to v2.0.0
+- azuredisk-csi-driver from v1.32.9 to v2.1.0
+- azurefile-csi-driver from v1.32.5 to v2.0.0
+- cert-exporter from v2.9.14 to v2.9.15
+- cilium from v1.3.2 to v1.3.4
+- coredns from v1.28.3 to v1.29.1
+- etcd-k8s-res-count-exporter from v1.10.11 to v1.10.12
+- external-dns from v3.2.0 to v3.4.0
+- k8s-audit-metrics from v0.10.10 to v0.10.11
+- network-policies from v0.1.1 to v0.1.3
+- node-exporter from v1.20.9 to v1.20.10
+- observability-bundle from v2.3.2 to v2.5.0
+- Added priority-classes v0.3.0
+- security-bundle from v1.15.0 to v1.16.1
+
+### azure-cloud-controller-manager [v1.32.7-1...v2.0.0](https://github.com/giantswarm/azure-cloud-controller-manager-app/compare/v1.32.7-1...v2.0.0)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.3. ([#132](https://github.com/giantswarm/azure-cloud-controller-manager-app/pull/132))
+
+### azure-cloud-node-manager [v1.32.7...v2.0.0](https://github.com/giantswarm/azure-cloud-node-manager-app/compare/v1.32.7...v2.0.0)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.3. ([#118](https://github.com/giantswarm/azure-cloud-node-manager-app/pull/118))
+
+### azuredisk-csi-driver [v1.32.9...v2.1.0](https://github.com/giantswarm/azuredisk-csi-driver-app/compare/v1.32.9...v2.1.0)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.0. ([#118](https://github.com/giantswarm/azuredisk-csi-driver-app/pull/118))
+- Chart: Update to upstream v1.33.7. ([#114](https://github.com/giantswarm/azuredisk-csi-driver-app/pull/114))
+
+### azurefile-csi-driver [v1.32.5...v2.0.0](https://github.com/giantswarm/azurefile-csi-driver-app/compare/v1.32.5...v2.0.0)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.2. ([#71](https://github.com/giantswarm/azurefile-csi-driver-app/pull/71))
+
+### cert-exporter [v2.9.14...v2.9.15](https://github.com/giantswarm/cert-exporter/compare/v2.9.14...v2.9.15)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.3.2...v1.3.4](https://github.com/giantswarm/cilium-app/compare/v1.3.2...v1.3.4)
+
+#### Changed
+
+- Upgrade Cilium to [v1.18.6](https://github.com/cilium/cilium/releases/tag/v1.18.6).
+- Upgrade Cilium to [v1.18.5](https://github.com/cilium/cilium/releases/tag/v1.18.5).
+
+### coredns [v1.28.3...v1.29.1](https://github.com/giantswarm/coredns-app/compare/v1.28.3...v1.29.1)
+
+#### Changed
+
+- Update `coredns` image to [1.14.1](https://github.com/coredns/coredns/releases/tag/v1.14.1).
+- Update `coredns` image to [1.14.0](https://github.com/coredns/coredns/releases/tag/v1.14.0).
+
+### etcd-k8s-res-count-exporter [v1.10.11...v1.10.12](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.11...v1.10.12)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### external-dns [v3.2.0...v3.4.0](https://github.com/giantswarm/external-dns-app/compare/v3.2.0...v3.4.0)
+
+#### Changed
+
+- Sync to upstream helm chart [1.20.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.20.0).
+  - Add option to set annotationPrefix.
+  - Fixed the missing schema for .provider.webhook.serviceMonitor configs.
+  - Fixed incorrect indentation of selector labels under spec.template.spec.topologySpreadConstraints when topologySpreadConstraints is set.
+- Use kubectl-apply-job when installing CRDs.
+- Upgrade external-dns to v0.20.0.
+- Update DNSEndpoints CRD.
+- Sync to upstream helm chart `1.19.0`.
+  - Grant `discovery.k8s.io/endpointslices` permission only when using `service` source.
+  - Update RBAC for `Service` source to support `EndpointSlices`.
+  - Allow extraArgs to also be a map enabling overrides of individual values.
+  - Set defaults for `automountServiceAccountToken` and `serviceAccount.automountServiceAccountToken` to `true` in Helm chart values.
+  - Correctly handle `txtPrefix` and `txtSuffix` arguments when both are provided.
+  - Add ability to generate schema with `helm plugin schema`.
+  - Regenerate JSON schema with `helm-values-schema-json' plugin.
+  - Added ability to configure `imagePullSecrets` via helm `global` value.
+  - Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values.
+  - Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function.
+  - Added support for `extraContainers` argument.
+  - Added support for setting `excludeDomains` argument.
+  - Added support for setting `dnsConfig`.
+  - Added support for webhook providers.
+- Restrict managed record types to A and CNAME.
+
+### k8s-audit-metrics [v0.10.10...v0.10.11](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.10...v0.10.11)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### network-policies [v0.1.1...v0.1.3](https://github.com/giantswarm/network-policies-app/compare/v0.1.1...v0.1.3)
+
+#### Added
+
+- Add support for Kamaji.
+
+#### Fixed
+
+- Fixed broken templating.
+
+### node-exporter [v1.20.9...v1.20.10](https://github.com/giantswarm/node-exporter-app/compare/v1.20.9...v1.20.10)
+
+#### Removed
+
+- Repository: Remove integration tests.
+
+### observability-bundle [v2.3.2...v2.5.0](https://github.com/giantswarm/observability-bundle/compare/v2.3.2...v2.5.0)
+
+#### Added
+
+- Add KSM metrics `kube_servicemonitor_info` and `kube_podmonitor_info` for ServiceMonitor and PodMonitor resources
+- Add KSM metrics `kube_podlog_info` for PodLog resource
+
+#### Changed
+
+- Upgrade `kube-prometheus-stack-app` to 19.0.0
+- Update alloy-app to 0.16.0
+  - Bumps alloy to 1.12.0
+
+#### Fixed
+
+- Fixed KSM metrics for endpoints
+
+### priority-classes [v0.3.0](https://github.com/giantswarm/priority-classes/releases/tag/v0.3.0)
+
+#### Changed
+
+- Label now uses chart version instead of app version.
+
+#### Removed
+
+- Removed appVersion (only version is used now).
+
+### security-bundle [v1.15.0...v1.16.1](https://github.com/giantswarm/security-bundle/compare/v1.15.0...v1.16.1)
+
+#### Changed
+
+- Add missing dependency to all apps.
+- Allow to set multiple dependencies on the depends-on annotation.
+- Rename `edgedb` to `gel`.
+- Update `cloudnative-pg` (app) to v0.0.12.
+- Update `gel` (app) to v1.0.1.

--- a/azure/v34.0.0/announcement.md
+++ b/azure/v34.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.0.0 for Azure is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-azure/releases/azure-34.0.0).

--- a/azure/v34.0.0/kustomization.yaml
+++ b/azure/v34.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v34.0.0/release.diff
+++ b/azure/v34.0.0/release.diff
@@ -1,0 +1,128 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: azure-33.1.1                                            |    name: azure-34.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: azure-cloud-controller-manager                             - name: azure-cloud-controller-manager
+    version: 1.32.7-1                                           |      version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager                                   - name: azure-cloud-node-manager
+    version: 1.32.7                                             |      version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver                                       - name: azuredisk-csi-driver
+    version: 1.32.9                                             |      version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: azurefile-csi-driver                                       - name: azurefile-csi-driver
+    version: 1.32.5                                             |      version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                             |      version: 2.9.15
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                              |      version: 1.3.4
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: coredns                                                    - name: coredns
+    version: 1.28.3                                             |      version: 1.29.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                            |      version: 1.10.12
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                              |      version: 3.4.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                            |      version: 0.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                              |      version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                             |      version: 1.20.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                              |      version: 2.5.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+                                                                >    - name: priority-classes
+                                                                >      version: 0.3.0
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                             |      version: 1.16.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-azure                                              - name: cluster-azure
+    catalog: cluster                                                   catalog: cluster
+    version: 4.4.0                                              |      version: 5.1.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                           |      version: 4459.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                             |      version: 1.34.3
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                             |      version: 1.26.3
+  date: "2025-12-16T15:16:14Z"                                  |    date: "2026-01-22T09:38:19Z"
+  state: active                                                      state: active

--- a/azure/v34.0.0/release.yaml
+++ b/azure/v34.0.0/release.yaml
@@ -1,0 +1,128 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: azure-34.0.0
+spec:
+  apps:
+  - name: azure-cloud-controller-manager
+    version: 2.0.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager
+    version: 2.0.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver
+    version: 2.1.0
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: azurefile-csi-driver
+    version: 2.0.0
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: cert-exporter
+    version: 2.9.15
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.4
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: coredns
+    version: 1.29.1
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.12
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.10
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.5.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.0
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.16.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-azure
+    catalog: cluster
+    version: 5.1.2
+  - name: flatcar
+    version: 4459.2.2
+  - name: kubernetes
+    version: 1.34.3
+  - name: os-tooling
+    version: 1.26.3
+  date: "2026-01-22T09:38:19Z"
+  state: active

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - v33.1.2
 - v33.1.3
 - v33.1.4
+- v34.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -83,6 +83,13 @@
       "releaseTimestamp": "2026-01-22T20:26:21Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v33.1.4/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-01-23T12:11:29Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v34.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v34.0.0/README.md
+++ b/capa/v34.0.0/README.md
@@ -1,0 +1,198 @@
+# :zap: Giant Swarm Release v34.0.0 for CAPA :zap:
+
+## Changes compared to v33.1.4
+
+### Components
+
+- cluster-aws from v6.4.3 to v7.2.5
+- Flatcar from v4459.2.1 to [v4459.2.2](https://www.flatcar.org/releases/#release-4459.2.2)
+- Kubernetes from v1.33.6 to [v1.34.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1.34.3)
+- os-tooling from v1.26.2 to v1.26.3
+
+### cluster-aws [v6.4.3...v7.2.5](https://github.com/giantswarm/cluster-aws/compare/v6.4.3...v7.2.5)
+
+#### :warning: Breaking Changes
+
+- The following IAM permissions have been removed from the control plane nodes
+- autoscaling:SetDesiredCapacity
+- autoscaling:TerminateInstanceInAutoScalingGroup
+- Removed `global.providerSpecific.reducedInstanceProfileIamPermissionsForWorkers` value, as that's the default behavior now. It cannot be overridden anymore.
+
+#### Added
+
+- Add `kubernetes.io/cluster/$clusterName: "owned"` and `sigs.k8s.io/cluster-api-provider-aws/cluster/$clusterName: "owned"` tags to the `IRSAClaim` CR so that resources created by Crossplane contain the expected tags. This also allows to find the S3 buckets that need to be deleted when removing a cluster.
+- *This change will roll the control plane nodes* Add `preKubeadmCommand` to wait for the API server load balancer DNS to be resolvable before running kubeadm on control plane nodes. This prevents kubeadm from failing when the ELB DNS record hasn't propagated yet.
+- *This change will roll the nodes* Add Crossplane IAM Roles, policies and instance profiles for worker and control plane nodes. Instead of having an IAM Role per node pool, now we'll use the same for all node pools.
+- Add the `priority-classes` default app, enabled by default. This app provides standardised `PriorityClass` resources like `giantswarm-critical` and `giantswarm-high`, which should replace the previous inconsistent per-app priority classes.
+- *This change will roll the nodes on Karpenter node pools* Attach the `lb` Security Group to Karpenter nodes.
+- *This change will roll the nodes on Karpenter node pools* Name instance on AWS after the nodepool name.
+
+#### Changed
+
+- Chart: Update `cluster` to v5.1.2.
+- Chart: Update `cluster` to v5.1.1.
+- Chart: Update `cluster` to v5.1.0.
+- Chart: Update `cluster` to v5.0.0.
+- Reduce redundant parts of JSON schema for Karpenter vs. MachinePool types of node pools
+- Adjust node max pods based on the `nodeCidrMaskSize`
+
+#### Fixed
+
+- Fix Karpenter schema definition: changed from `app` schema to `helmRelease` schema to correctly reflect that Karpenter is deployed as a HelmRelease resource. This fixes incorrect field definitions in `extraConfigs` (capitalized enum values `ConfigMap`/`Secret` and `optional` field instead of `priority`).
+- Fix Karpenter NodePool subnet filtering: when users define custom `subnetTags`, the default `giantswarm.io/role: "nodes"` filter is no longer applied, allowing full control over subnet selection. The cluster ownership tag (`sigs.k8s.io/cluster-api-provider-aws/cluster/<cluster-name>: owned`) is still enforced for security.
+- Fix Karpenter HelmRelease: add missing `valuesFrom` parent field for `extraConfigs`, enabling customers to use custom ConfigMaps and Secrets for Karpenter configuration.
+- Ensure `AWSCluster.spec.network.subnets.tags` is not rendered as `null`
+- Add missing documentation for node pools (health checks were not listed)
+- Ensure defaulting `maxHealthyPercentage` since Helm does not use the default from the schema
+
+#### Removed
+
+- Remove `RolePolicyAttachment` crossplane custom resources as they are not needed when using `Role` and `RolePolicy`.
+
+### Apps
+
+- cert-exporter from v2.9.14 to v2.9.15
+- cilium from v1.3.2 to v1.3.4
+- cloud-provider-aws from v1.33.2-1 to v2.0.0
+- cluster-autoscaler from v1.33.1-2 to v1.34.1-1
+- coredns from v1.28.3 to v1.29.1
+- etcd-k8s-res-count-exporter from v1.10.11 to v1.10.12
+- external-dns from v3.2.0 to v3.4.0
+- k8s-audit-metrics from v0.10.10 to v0.10.11
+- network-policies from v0.1.1 to v0.1.3
+- node-exporter from v1.20.9 to v1.20.10
+- Added node-problem-detector v0.5.2
+- observability-bundle from v2.3.2 to v2.5.0
+- Added priority-classes v0.3.0
+- security-bundle from v1.15.0 to v1.16.1
+
+### cert-exporter [v2.9.14...v2.9.15](https://github.com/giantswarm/cert-exporter/compare/v2.9.14...v2.9.15)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.3.2...v1.3.4](https://github.com/giantswarm/cilium-app/compare/v1.3.2...v1.3.4)
+
+#### Changed
+
+- Upgrade Cilium to [v1.18.6](https://github.com/cilium/cilium/releases/tag/v1.18.6).
+- Upgrade Cilium to [v1.18.5](https://github.com/cilium/cilium/releases/tag/v1.18.5).
+
+### cloud-provider-aws [v1.33.2-1...v2.0.0](https://github.com/giantswarm/aws-cloud-controller-manager-app/compare/v1.33.2-1...v2.0.0)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.0.
+
+### cluster-autoscaler [v1.33.1-2...v1.34.1-1](https://github.com/giantswarm/cluster-autoscaler-app/compare/v1.33.1-2...v1.34.1-1)
+
+#### Changed
+
+- Chart: Update to upstream v1.34.1.
+
+### coredns [v1.28.3...v1.29.1](https://github.com/giantswarm/coredns-app/compare/v1.28.3...v1.29.1)
+
+#### Changed
+
+- Update `coredns` image to [1.14.1](https://github.com/coredns/coredns/releases/tag/v1.14.1).
+- Update `coredns` image to [1.14.0](https://github.com/coredns/coredns/releases/tag/v1.14.0).
+
+### etcd-k8s-res-count-exporter [v1.10.11...v1.10.12](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.11...v1.10.12)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### external-dns [v3.2.0...v3.4.0](https://github.com/giantswarm/external-dns-app/compare/v3.2.0...v3.4.0)
+
+#### Changed
+
+- Sync to upstream helm chart [1.20.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/external-dns-helm-chart-1.20.0).
+  - Add option to set annotationPrefix.
+  - Fixed the missing schema for .provider.webhook.serviceMonitor configs.
+  - Fixed incorrect indentation of selector labels under spec.template.spec.topologySpreadConstraints when topologySpreadConstraints is set.
+- Use kubectl-apply-job when installing CRDs.
+- Upgrade external-dns to v0.20.0.
+- Update DNSEndpoints CRD.
+- Sync to upstream helm chart `1.19.0`.
+  - Grant `discovery.k8s.io/endpointslices` permission only when using `service` source.
+  - Update RBAC for `Service` source to support `EndpointSlices`.
+  - Allow extraArgs to also be a map enabling overrides of individual values.
+  - Set defaults for `automountServiceAccountToken` and `serviceAccount.automountServiceAccountToken` to `true` in Helm chart values.
+  - Correctly handle `txtPrefix` and `txtSuffix` arguments when both are provided.
+  - Add ability to generate schema with `helm plugin schema`.
+  - Regenerate JSON schema with `helm-values-schema-json' plugin.
+  - Added ability to configure `imagePullSecrets` via helm `global` value.
+  - Added options to configure `labelFilter` and `managedRecordTypes` via dedicated helm values.
+  - Allow templating `serviceaccount.annotations` keys and values, by rendering them using the `tpl` built-in function.
+  - Added support for `extraContainers` argument.
+  - Added support for setting `excludeDomains` argument.
+  - Added support for setting `dnsConfig`.
+  - Added support for webhook providers.
+- Restrict managed record types to A and CNAME.
+
+### k8s-audit-metrics [v0.10.10...v0.10.11](https://github.com/giantswarm/k8s-audit-metrics/compare/v0.10.10...v0.10.11)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### network-policies [v0.1.1...v0.1.3](https://github.com/giantswarm/network-policies-app/compare/v0.1.1...v0.1.3)
+
+#### Added
+
+- Add support for Kamaji.
+
+#### Fixed
+
+- Fixed broken templating.
+
+### node-exporter [v1.20.9...v1.20.10](https://github.com/giantswarm/node-exporter-app/compare/v1.20.9...v1.20.10)
+
+#### Removed
+
+- Repository: Remove integration tests.
+
+### node-problem-detector [v0.5.2](https://github.com/giantswarm/node-problem-detector-app/releases/tag/v0.5.2)
+
+#### Changed
+
+- Build: Switch to pushing to `default` instead of `playground` catalog as this app will be fully supported in production
+
+### observability-bundle [v2.3.2...v2.5.0](https://github.com/giantswarm/observability-bundle/compare/v2.3.2...v2.5.0)
+
+#### Added
+
+- Add KSM metrics `kube_servicemonitor_info` and `kube_podmonitor_info` for ServiceMonitor and PodMonitor resources
+- Add KSM metrics `kube_podlog_info` for PodLog resource
+
+#### Changed
+
+- Upgrade `kube-prometheus-stack-app` to 19.0.0
+- Update alloy-app to 0.16.0
+  - Bumps alloy to 1.12.0
+
+#### Fixed
+
+- Fixed KSM metrics for endpoints
+
+### priority-classes [v0.3.0](https://github.com/giantswarm/priority-classes/releases/tag/v0.3.0)
+
+#### Changed
+
+- Label now uses chart version instead of app version.
+
+#### Removed
+
+- Removed appVersion (only version is used now).
+
+### security-bundle [v1.15.0...v1.16.1](https://github.com/giantswarm/security-bundle/compare/v1.15.0...v1.16.1)
+
+#### Changed
+
+- Add missing dependency to all apps.
+- Allow to set multiple dependencies on the depends-on annotation.
+- Rename `edgedb` to `gel`.
+- Update `cloudnative-pg` (app) to v0.0.12.
+- Update `gel` (app) to v1.0.1.

--- a/capa/v34.0.0/announcement.md
+++ b/capa/v34.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.0.0 for CAPA is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-34.0.0).

--- a/capa/v34.0.0/kustomization.yaml
+++ b/capa/v34.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v34.0.0/release.diff
+++ b/capa/v34.0.0/release.diff
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-33.1.4                                              |    name: aws-34.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 3.4.1                                                     version: 3.4.1
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.3.0                                                     version: 1.3.0
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                             |      version: 2.9.15
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.0                                                     version: 0.1.0
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                              |      version: 1.3.4
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.1                                                     version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 1.33.2-1                                           |      version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.33.1-2                                           |      version: 1.34.1-1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.28.3                                             |      version: 1.29.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                            |      version: 1.10.12
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                              |      version: 3.4.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                            |      version: 0.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter                                                  - name: karpenter
+    version: 1.4.0                                                     version: 1.4.0
+  - name: karpenter-crossplane-resources                             - name: karpenter-crossplane-resources
+    version: 0.5.1                                                     version: 0.5.1
+  - name: karpenter-taint-remover                                    - name: karpenter-taint-remover
+    version: 1.0.1                                                     version: 1.0.1
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                              |      version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                             |      version: 1.20.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+                                                                >    - name: node-problem-detector
+                                                                >      version: 0.5.2
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                              |      version: 2.5.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+                                                                >    - name: priority-classes
+                                                                >      version: 0.3.0
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                             |      version: 1.16.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 6.4.3                                              |      version: 7.2.5
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                           |      version: 4459.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                             |      version: 1.34.3
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                             |      version: 1.26.3
+  date: "2026-01-22T21:26:21Z"                                  |    date: "2026-01-23T12:11:29Z"
+  state: active                                                      state: active

--- a/capa/v34.0.0/release.yaml
+++ b/capa/v34.0.0/release.yaml
@@ -1,0 +1,150 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-34.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.4.1
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.3.0
+  - name: aws-pod-identity-webhook
+    version: 2.1.0
+    dependsOn:
+    - cert-manager
+  - name: cert-exporter
+    version: 2.9.15
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.4
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 2.0.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.34.1-1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.29.1
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.12
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter
+    version: 1.4.0
+  - name: karpenter-crossplane-resources
+    version: 0.5.1
+  - name: karpenter-taint-remover
+    version: 1.0.1
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.10
+    dependsOn:
+    - kyverno-crds
+  - name: node-problem-detector
+    version: 0.5.2
+  - name: observability-bundle
+    version: 2.5.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.0
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.16.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 7.2.5
+  - name: flatcar
+    version: 4459.2.2
+  - name: kubernetes
+    version: 1.34.3
+  - name: os-tooling
+    version: 1.26.3
+  date: "2026-01-23T12:11:29Z"
+  state: active

--- a/cloud-director/kustomization.yaml
+++ b/cloud-director/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - v32.1.0
 - v33.1.0
 - v33.1.1
+- v34.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/cloud-director/releases.json
+++ b/cloud-director/releases.json
@@ -34,6 +34,13 @@
       "releaseTimestamp": "2025-12-16T15:16:17Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v33.1.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-01-22T09:39:02Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v34.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/cloud-director/v34.0.0/README.md
+++ b/cloud-director/v34.0.0/README.md
@@ -1,0 +1,118 @@
+# :zap: Giant Swarm Release v34.0.0 for VMware Cloud Director :zap:
+
+## Changes compared to v33.1.1
+
+### Components
+
+- cluster-cloud-director from v2.4.0 to v3.1.2
+- Flatcar from v4459.2.1 to [v4459.2.2](https://www.flatcar.org/releases/#release-4459.2.2)
+- Kubernetes from v1.33.6 to [v1.34.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1.34.3)
+- os-tooling from v1.26.2 to v1.26.3
+
+### cluster-cloud-director [v2.4.0...v3.1.2](https://github.com/giantswarm/cluster-cloud-director/compare/v2.4.0...v3.1.2)
+
+#### Added
+
+- Added `fix-dns-nic-allocation.sh` Ignition script to attach DNS servers to correct network interfaces.
+- Add the `priority-classes` default app, enabled by default. This app provides standardised `PriorityClass` resources like `giantswarm-critical` and `giantswarm-high`, which should replace the previous inconsistent per-app priority classes.
+- Add `"helm.sh/resource-policy": keep` annotation to `VCDCluster` CR so that it doesn't get removed by Helm when uninstalling this chart. The CAPI controllers will take care of removing it, following the expected deletion order.
+
+#### Changed
+
+- Fix a race condition when populating `/run/metadata/coreos`.
+- Fix race condition in `ntpd` unit.
+- Chart: Update `cluster` to v5.1.2.
+- Chart: Update `cluster` to v5.1.1.
+- Chart: Update `cluster` to v5.1.0.
+- Chart: Update `cluster` to v5.0.0.
+
+### Apps
+
+- cert-exporter from v2.9.14 to v2.9.15
+- cilium from v1.3.2 to v1.3.4
+- coredns from v1.28.3 to v1.29.1
+- etcd-k8s-res-count-exporter from v1.10.11 to v1.10.12
+- network-policies from v0.1.1 to v0.1.3
+- node-exporter from v1.20.9 to v1.20.10
+- observability-bundle from v2.3.2 to v2.5.0
+- Added priority-classes v0.3.0
+- security-bundle from v1.15.0 to v1.16.1
+
+### cert-exporter [v2.9.14...v2.9.15](https://github.com/giantswarm/cert-exporter/compare/v2.9.14...v2.9.15)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.3.2...v1.3.4](https://github.com/giantswarm/cilium-app/compare/v1.3.2...v1.3.4)
+
+#### Changed
+
+- Upgrade Cilium to [v1.18.6](https://github.com/cilium/cilium/releases/tag/v1.18.6).
+- Upgrade Cilium to [v1.18.5](https://github.com/cilium/cilium/releases/tag/v1.18.5).
+
+### coredns [v1.28.3...v1.29.1](https://github.com/giantswarm/coredns-app/compare/v1.28.3...v1.29.1)
+
+#### Changed
+
+- Update `coredns` image to [1.14.1](https://github.com/coredns/coredns/releases/tag/v1.14.1).
+- Update `coredns` image to [1.14.0](https://github.com/coredns/coredns/releases/tag/v1.14.0).
+
+### etcd-k8s-res-count-exporter [v1.10.11...v1.10.12](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.11...v1.10.12)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### network-policies [v0.1.1...v0.1.3](https://github.com/giantswarm/network-policies-app/compare/v0.1.1...v0.1.3)
+
+#### Added
+
+- Add support for Kamaji.
+
+#### Fixed
+
+- Fixed broken templating.
+
+### node-exporter [v1.20.9...v1.20.10](https://github.com/giantswarm/node-exporter-app/compare/v1.20.9...v1.20.10)
+
+#### Removed
+
+- Repository: Remove integration tests.
+
+### observability-bundle [v2.3.2...v2.5.0](https://github.com/giantswarm/observability-bundle/compare/v2.3.2...v2.5.0)
+
+#### Added
+
+- Add KSM metrics `kube_servicemonitor_info` and `kube_podmonitor_info` for ServiceMonitor and PodMonitor resources
+- Add KSM metrics `kube_podlog_info` for PodLog resource
+
+#### Changed
+
+- Upgrade `kube-prometheus-stack-app` to 19.0.0
+- Update alloy-app to 0.16.0
+  - Bumps alloy to 1.12.0
+
+#### Fixed
+
+- Fixed KSM metrics for endpoints
+
+### priority-classes [v0.3.0](https://github.com/giantswarm/priority-classes/releases/tag/v0.3.0)
+
+#### Changed
+
+- Label now uses chart version instead of app version.
+
+#### Removed
+
+- Removed appVersion (only version is used now).
+
+### security-bundle [v1.15.0...v1.16.1](https://github.com/giantswarm/security-bundle/compare/v1.15.0...v1.16.1)
+
+#### Changed
+
+- Add missing dependency to all apps.
+- Allow to set multiple dependencies on the depends-on annotation.
+- Rename `edgedb` to `gel`.
+- Update `cloudnative-pg` (app) to v0.0.12.
+- Update `gel` (app) to v1.0.1.

--- a/cloud-director/v34.0.0/announcement.md
+++ b/cloud-director/v34.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.0.0 for VMware Cloud Director is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-34.0.0).

--- a/cloud-director/v34.0.0/kustomization.yaml
+++ b/cloud-director/v34.0.0/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      # Need to target index 2 here as `cloud-director` itself already contains a hyphen.
+      delimiter: "-"
+      index: 2
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/cloud-director/v34.0.0/release.diff
+++ b/cloud-director/v34.0.0/release.diff
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: cloud-director-33.1.1                                   |    name: cloud-director-34.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                             |      version: 2.9.15
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                              |      version: 1.3.4
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-cloud-director                              - name: cloud-provider-cloud-director
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.28.3                                             |      version: 1.29.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                            |      version: 1.10.12
+    dependsOn:                                                  <
+    - kyverno-crds                                              <
+  - name: external-dns                                          <
+    version: 3.2.0                                              <
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                   <
+  - name: k8s-audit-metrics                                     <
+    version: 0.10.10                                            <
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                              |      version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                             |      version: 1.20.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                              |      version: 2.5.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                          |    - name: priority-classes
+    version: 0.5.0                                              |      version: 0.3.0
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                   <
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                             |      version: 1.16.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-cloud-director                                     - name: cluster-cloud-director
+    catalog: cluster                                                   catalog: cluster
+    version: 2.4.0                                              |      version: 3.1.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                           |      version: 4459.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                             |      version: 1.34.3
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                             |      version: 1.26.3
+  date: "2025-12-16T15:16:17Z"                                  |    date: "2026-01-22T09:39:02Z"
+  state: active                                                      state: active

--- a/cloud-director/v34.0.0/release.yaml
+++ b/cloud-director/v34.0.0/release.yaml
@@ -1,0 +1,102 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: cloud-director-34.0.0
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.9.15
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.4
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director
+    version: 0.5.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.29.1
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.12
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.10
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.5.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.0
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.16.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-cloud-director
+    catalog: cluster
+    version: 3.1.2
+  - name: flatcar
+    version: 4459.2.2
+  - name: kubernetes
+    version: 1.34.3
+  - name: os-tooling
+    version: 1.26.3
+  date: "2026-01-22T09:39:02Z"
+  state: active

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - v33.0.1
 - v33.1.0
 - v33.1.1
+- v34.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -41,6 +41,13 @@
       "releaseTimestamp": "2025-12-16T15:16:16Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v33.1.1/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-01-22T09:38:42Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v34.0.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -1,8 +1,4 @@
 releases:
-- name: ">= 34.0.0"
-  requests:
-  - name: cloud-provider-vsphere-app
-    version: ">= 2.1.0"
 - name: "< 34.0.0"
   requests:
   - name: cluster-vsphere

--- a/vsphere/v34.0.0/README.md
+++ b/vsphere/v34.0.0/README.md
@@ -1,0 +1,138 @@
+# :zap: Giant Swarm Release v34.0.0 for vSphere :zap:
+
+## Changes compared to v33.1.1
+
+### Components
+
+- cluster-vsphere from v3.4.0 to v4.1.2
+- Flatcar from v4459.2.1 to [v4459.2.2](https://www.flatcar.org/releases/#release-4459.2.2)
+- Kubernetes from v1.33.6 to [v1.34.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1.34.3)
+- os-tooling from v1.26.2 to v1.26.3
+
+### cluster-vsphere [v3.4.0...v4.1.2](https://github.com/giantswarm/cluster-vsphere/compare/v3.4.0...v4.1.2)
+
+#### Added
+
+- Add the `priority-classes` default app, enabled by default. This app provides standardised `PriorityClass` resources like `giantswarm-critical` and `giantswarm-high`, which should replace the previous inconsistent per-app priority classes.
+- Add `"helm.sh/resource-policy": keep` annotation to `VSphereCluster` CR so that it doesn't get removed by Helm when uninstalling this chart. The CAPI controllers will take care of removing it, following the expected deletion order.
+- Add `"helm.sh/resource-policy": keep` annotation to the provider secret. This is to ensure that it isn't removed by Helm, thus leading to a race condition when deleting the cluster as the vSphere cleaner needs it to clean up resources in vSphere.
+
+#### Changed
+
+- Chart: Update `cluster` to v5.1.2.
+- Chart: Update `cluster` to v5.1.1.
+- Chart: Update `cluster` to v5.1.0.
+- Chart: Update `cluster` to v5.0.0.
+- Chart: Update `cluster` to v4.6.0.
+- Chart: Update `cluster` to v4.5.1.
+- Chart: Update `cluster` to v4.5.0.
+
+### Apps
+
+- cert-exporter from v2.9.14 to v2.9.15
+- cilium from v1.3.2 to v1.3.4
+- cloud-provider-vsphere from v2.0.1 to v2.2.0
+- coredns from v1.28.3 to v1.29.1
+- etcd-k8s-res-count-exporter from v1.10.11 to v1.10.12
+- network-policies from v0.1.1 to v0.1.3
+- node-exporter from v1.20.9 to v1.20.10
+- observability-bundle from v2.3.2 to v2.5.0
+- Added priority-classes v0.3.0
+- security-bundle from v1.15.0 to v1.16.1
+- vsphere-csi-driver from v3.4.2 to v3.4.3
+
+### cert-exporter [v2.9.14...v2.9.15](https://github.com/giantswarm/cert-exporter/compare/v2.9.14...v2.9.15)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### cilium [v1.3.2...v1.3.4](https://github.com/giantswarm/cilium-app/compare/v1.3.2...v1.3.4)
+
+#### Changed
+
+- Upgrade Cilium to [v1.18.6](https://github.com/cilium/cilium/releases/tag/v1.18.6).
+- Upgrade Cilium to [v1.18.5](https://github.com/cilium/cilium/releases/tag/v1.18.5).
+
+### cloud-provider-vsphere [v2.0.1...v2.2.0](https://github.com/giantswarm/cloud-provider-vsphere-app/compare/v2.0.1...v2.2.0)
+
+#### Added
+
+- Add kamaji.enabled value. If set to true, a deployment instead of the dameonset will be used for CPI controller components.
+
+#### Changed
+
+- Update to upstream `1.34.0`.
+
+### coredns [v1.28.3...v1.29.1](https://github.com/giantswarm/coredns-app/compare/v1.28.3...v1.29.1)
+
+#### Changed
+
+- Update `coredns` image to [1.14.1](https://github.com/coredns/coredns/releases/tag/v1.14.1).
+- Update `coredns` image to [1.14.0](https://github.com/coredns/coredns/releases/tag/v1.14.0).
+
+### etcd-k8s-res-count-exporter [v1.10.11...v1.10.12](https://github.com/giantswarm/etcd-kubernetes-resources-count-exporter/compare/v1.10.11...v1.10.12)
+
+#### Changed
+
+- Go: Update dependencies.
+
+### network-policies [v0.1.1...v0.1.3](https://github.com/giantswarm/network-policies-app/compare/v0.1.1...v0.1.3)
+
+#### Added
+
+- Add support for Kamaji.
+
+#### Fixed
+
+- Fixed broken templating.
+
+### node-exporter [v1.20.9...v1.20.10](https://github.com/giantswarm/node-exporter-app/compare/v1.20.9...v1.20.10)
+
+#### Removed
+
+- Repository: Remove integration tests.
+
+### observability-bundle [v2.3.2...v2.5.0](https://github.com/giantswarm/observability-bundle/compare/v2.3.2...v2.5.0)
+
+#### Added
+
+- Add KSM metrics `kube_servicemonitor_info` and `kube_podmonitor_info` for ServiceMonitor and PodMonitor resources
+- Add KSM metrics `kube_podlog_info` for PodLog resource
+
+#### Changed
+
+- Upgrade `kube-prometheus-stack-app` to 19.0.0
+- Update alloy-app to 0.16.0
+  - Bumps alloy to 1.12.0
+
+#### Fixed
+
+- Fixed KSM metrics for endpoints
+
+### priority-classes [v0.3.0](https://github.com/giantswarm/priority-classes/releases/tag/v0.3.0)
+
+#### Changed
+
+- Label now uses chart version instead of app version.
+
+#### Removed
+
+- Removed appVersion (only version is used now).
+
+### security-bundle [v1.15.0...v1.16.1](https://github.com/giantswarm/security-bundle/compare/v1.15.0...v1.16.1)
+
+#### Changed
+
+- Add missing dependency to all apps.
+- Allow to set multiple dependencies on the depends-on annotation.
+- Rename `edgedb` to `gel`.
+- Update `cloudnative-pg` (app) to v0.0.12.
+- Update `gel` (app) to v1.0.1.
+
+### vsphere-csi-driver [v3.4.2...v3.4.3](https://github.com/giantswarm/vsphere-csi-driver-app/compare/v3.4.2...v3.4.3)
+
+#### Changed
+
+- Update upstream chart to `v3.3.1`
+- Make deployment `affinity` and `tolerations` configurable in `values.yaml`.

--- a/vsphere/v34.0.0/announcement.md
+++ b/vsphere/v34.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.0.0 for vSphere is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-34.0.0).

--- a/vsphere/v34.0.0/kustomization.yaml
+++ b/vsphere/v34.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v34.0.0/release.diff
+++ b/vsphere/v34.0.0/release.diff
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: vsphere-33.1.1                                          |    name: vsphere-34.0.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                             |      version: 2.9.15
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                              |      version: 1.3.4
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-vsphere                                     - name: cloud-provider-vsphere
+    version: 2.0.1                                              |      version: 2.2.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.28.3                                             |      version: 1.29.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                            |      version: 1.10.12
+    dependsOn:                                                  <
+    - kyverno-crds                                              <
+  - name: external-dns                                          <
+    version: 3.2.0                                              <
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                   <
+  - name: k8s-audit-metrics                                     <
+    version: 0.10.10                                            <
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: kube-vip                                                   - name: kube-vip
+    version: 0.2.0                                                     version: 0.2.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: kube-vip-cloud-provider                                    - name: kube-vip-cloud-provider
+    version: 0.3.0                                                     version: 0.3.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                              |      version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                             |      version: 1.20.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                              |      version: 2.5.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                          |    - name: priority-classes
+    version: 0.5.0                                              |      version: 0.3.0
+    dependsOn:                                                  <
+    - prometheus-operator-crd                                   <
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                             |      version: 1.16.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  - name: vsphere-csi-driver                                         - name: vsphere-csi-driver
+    version: 3.4.2                                              |      version: 3.4.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  components:                                                        components:
+  - name: cluster-vsphere                                            - name: cluster-vsphere
+    catalog: cluster                                                   catalog: cluster
+    version: 3.4.0                                              |      version: 4.1.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                           |      version: 4459.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                             |      version: 1.34.3
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                             |      version: 1.26.3
+  date: "2025-12-16T15:16:16Z"                                  |    date: "2026-01-22T09:38:42Z"
+  state: active                                                      state: active

--- a/vsphere/v34.0.0/release.yaml
+++ b/vsphere/v34.0.0/release.yaml
@@ -1,0 +1,114 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-34.0.0
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.9.15
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.4
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.2.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.29.1
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.12
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.2.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.10
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.5.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.0
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.16.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  - name: vsphere-csi-driver
+    version: 3.4.3
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 4.1.2
+  - name: flatcar
+    version: 4459.2.2
+  - name: kubernetes
+    version: 1.34.3
+  - name: os-tooling
+    version: 1.26.3
+  date: "2026-01-22T09:38:42Z"
+  state: active


### PR DESCRIPTION
For myself, suites to be executed:

```
/run releases-test-suites TARGET_SUITES=./providers/capa/standard
```

```
/run releases-test-suites TARGET_SUITES=./providers/capa/private
```

```
/run releases-test-suites TARGET_SUITES=./providers/capa/upgrade-major
```

```
/run releases-test-suites TARGET_SUITES=./providers/capz/standard
```

```
/run releases-test-suites TARGET_SUITES=./providers/capz/private
```

```
/run releases-test-suites TARGET_SUITES=./providers/capz/upgrade-major
```

```
/run releases-test-suites TARGET_SUITES=./providers/capv/standard
```

```
/run releases-test-suites TARGET_SUITES=./providers/capv/on-capa
```

```
/run releases-test-suites TARGET_SUITES=./providers/capv/on-capz
```

```
/run releases-test-suites TARGET_SUITES=./providers/capv/upgrade-major
```

```
/run releases-test-suites TARGET_SUITES=./providers/capvcd/standard
```

```
/run releases-test-suites TARGET_SUITES=./providers/capvcd/upgrade-major
```