### PR TITLE
CAPI: Release v33.1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ to all Giant Swarm installations.
 
 - v33
   - v33.1
+    - [v33.1.1](https://github.com/giantswarm/releases/tree/master/capa/v33.1.1)
     - [v33.1.0](https://github.com/giantswarm/releases/tree/master/capa/v33.1.0)
   - v33.0
-    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/capa/archived/v33.0.0)
     - [v33.0.1](https://github.com/giantswarm/releases/tree/master/capa/v33.0.1)
+    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/capa/archived/v33.0.0)
 
 - v32
   - v32.1
@@ -148,10 +149,11 @@ to all Giant Swarm installations.
 
 - v33
   - v33.1
+    - [v33.1.1](https://github.com/giantswarm/releases/tree/master/azure/v33.1.1)
     - [v33.1.0](https://github.com/giantswarm/releases/tree/master/azure/v33.1.0)
   - v33.0
-    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v33.0.0)
     - [v33.0.1](https://github.com/giantswarm/releases/tree/master/azure/v33.0.1)
+    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/azure/archived/v33.0.0)
 
 - v32
   - v32.1
@@ -327,10 +329,11 @@ to all Giant Swarm installations.
 
 - v33
   - v33.1
+    - [v33.1.1](https://github.com/giantswarm/releases/tree/master/vsphere/v33.1.1)
     - [v33.1.0](https://github.com/giantswarm/releases/tree/master/vsphere/v33.1.0)
   - v33.0
-    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/archived/v33.0.0)
     - [v33.0.1](https://github.com/giantswarm/releases/tree/master/vsphere/v33.0.1)
+    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/vsphere/archived/v33.0.0)
 
 - v32
   - v32.1
@@ -379,10 +382,11 @@ to all Giant Swarm installations.
 
 - v33
   - v33.1
+    - [v33.1.1](https://github.com/giantswarm/releases/tree/master/cloud-director/v33.1.1)
     - [v33.1.0](https://github.com/giantswarm/releases/tree/master/cloud-director/v33.1.0)
   - v33.0
-    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/cloud-director/archived/v33.0.0)
     - [v33.0.1](https://github.com/giantswarm/releases/tree/master/cloud-director/archived/v33.0.1)
+    - [v33.0.0](https://github.com/giantswarm/releases/tree/master/cloud-director/archived/v33.0.0)
 
 - v32
   - v32.1

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - v32.1.0
 - v33.0.1
 - v33.1.0
+- v33.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/azure/releases.json
+++ b/azure/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2025-12-03T15:28:21Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v33.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "33.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-12-16T15:16:14Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v33.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/azure/v33.1.1/README.md
+++ b/azure/v33.1.1/README.md
@@ -1,0 +1,15 @@
+# :zap: Giant Swarm Release v33.1.1 for Azure :zap:
+
+This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+## Changes compared to v33.1.0
+
+### Apps
+
+- coredns from v1.28.2 to v1.28.3
+
+### coredns [v1.28.2...v1.28.3](https://github.com/giantswarm/coredns-app/compare/v1.28.2...v1.28.3)
+
+#### Changed
+
+- Update `coredns` image to [1.13.2](https://github.com/coredns/coredns/releases/tag/v1.13.2).

--- a/azure/v33.1.1/announcement.md
+++ b/azure/v33.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v33.1.1 for Azure is available**. This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-azure/releases/azure-33.1.1).

--- a/azure/v33.1.1/kustomization.yaml
+++ b/azure/v33.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v33.1.1/release.diff
+++ b/azure/v33.1.1/release.diff
@@ -1,0 +1,126 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: azure-33.1.0                                            |    name: azure-33.1.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: azure-cloud-controller-manager                             - name: azure-cloud-controller-manager
+    version: 1.32.7-1                                                  version: 1.32.7-1
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager                                   - name: azure-cloud-node-manager
+    version: 1.32.7                                                    version: 1.32.7
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver                                       - name: azuredisk-csi-driver
+    version: 1.32.9                                                    version: 1.32.9
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: azurefile-csi-driver                                       - name: azurefile-csi-driver
+    version: 1.32.5                                                    version: 1.32.5
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                                    version: 2.9.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                                     version: 1.3.2
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: coredns                                                    - name: coredns
+    version: 1.28.2                                             |      version: 1.28.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                                   version: 1.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                                   version: 0.10.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                                    version: 1.20.9
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                                     version: 2.3.2
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                                    version: 1.15.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+                                                                >      dependsOn:
+                                                                >      - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-azure                                              - name: cluster-azure
+    catalog: cluster                                                   catalog: cluster
+    version: 4.4.0                                                     version: 4.4.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                                  version: 4459.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                                    version: 1.33.6
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                                    version: 1.26.2
+  date: "2025-12-03T15:28:21Z"                                  |    date: "2025-12-16T15:16:14Z"
+  state: active                                                      state: active

--- a/azure/v33.1.1/release.yaml
+++ b/azure/v33.1.1/release.yaml
@@ -1,0 +1,126 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: azure-33.1.1
+spec:
+  apps:
+  - name: azure-cloud-controller-manager
+    version: 1.32.7-1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager
+    version: 1.32.7
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver
+    version: 1.32.9
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: azurefile-csi-driver
+    version: 1.32.5
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: cert-exporter
+    version: 2.9.14
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.2
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: coredns
+    version: 1.28.3
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.10
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.9
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.3.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.15.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-azure
+    catalog: cluster
+    version: 4.4.0
+  - name: flatcar
+    version: 4459.2.1
+  - name: kubernetes
+    version: 1.33.6
+  - name: os-tooling
+    version: 1.26.2
+  date: "2025-12-16T15:16:14Z"
+  state: active

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - v32.1.0
 - v33.0.1
 - v33.1.0
+- v33.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -48,6 +48,13 @@
       "releaseTimestamp": "2025-12-03T15:28:03Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v33.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "33.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-12-16T15:16:13Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v33.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v33.1.1/README.md
+++ b/capa/v33.1.1/README.md
@@ -1,0 +1,15 @@
+# :zap: Giant Swarm Release v33.1.1 for CAPA :zap:
+
+This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+## Changes compared to v33.1.0
+
+### Apps
+
+- coredns from v1.28.2 to v1.28.3
+
+### coredns [v1.28.2...v1.28.3](https://github.com/giantswarm/coredns-app/compare/v1.28.2...v1.28.3)
+
+#### Changed
+
+- Update `coredns` image to [1.13.2](https://github.com/coredns/coredns/releases/tag/v1.13.2).

--- a/capa/v33.1.1/announcement.md
+++ b/capa/v33.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v33.1.1 for CAPA is available**. This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-33.1.1).

--- a/capa/v33.1.1/kustomization.yaml
+++ b/capa/v33.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v33.1.1/release.diff
+++ b/capa/v33.1.1/release.diff
@@ -1,0 +1,146 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-33.1.0                                              |    name: aws-33.1.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 3.3.0                                                     version: 3.3.0
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.3.0                                                     version: 1.3.0
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                                    version: 2.9.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.0                                                     version: 0.1.0
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                                     version: 1.3.2
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.1                                                     version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 1.33.2-1                                                  version: 1.33.2-1
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.33.1-2                                                  version: 1.33.1-2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.28.2                                             |      version: 1.28.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                                   version: 1.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.0                                                     version: 0.1.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                                   version: 0.10.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter                                                  - name: karpenter
+    version: 1.4.0                                                     version: 1.4.0
+  - name: karpenter-crossplane-resources                             - name: karpenter-crossplane-resources
+    version: 0.5.1                                                     version: 0.5.1
+  - name: karpenter-taint-remover                                    - name: karpenter-taint-remover
+    version: 1.0.1                                                     version: 1.0.1
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                                    version: 1.20.9
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                                     version: 2.3.2
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                                    version: 1.15.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+                                                                >      dependsOn:
+                                                                >      - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 6.4.1                                                     version: 6.4.1
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                                  version: 4459.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                                    version: 1.33.6
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                                    version: 1.26.2
+  date: "2025-12-03T15:28:03Z"                                  |    date: "2025-12-16T15:16:13Z"
+  state: active                                                      state: active

--- a/capa/v33.1.1/release.yaml
+++ b/capa/v33.1.1/release.yaml
@@ -1,0 +1,146 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-33.1.1
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 3.3.0
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.3.0
+  - name: aws-pod-identity-webhook
+    version: 2.1.0
+    dependsOn:
+    - cert-manager
+  - name: cert-exporter
+    version: 2.9.14
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.2
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 1.33.2-1
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.33.1-2
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.28.3
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.10
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter
+    version: 1.4.0
+  - name: karpenter-crossplane-resources
+    version: 0.5.1
+  - name: karpenter-taint-remover
+    version: 1.0.1
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.9
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.3.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.15.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 6.4.1
+  - name: flatcar
+    version: 4459.2.1
+  - name: kubernetes
+    version: 1.33.6
+  - name: os-tooling
+    version: 1.26.2
+  date: "2025-12-16T15:16:13Z"
+  state: active

--- a/cloud-director/kustomization.yaml
+++ b/cloud-director/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - v32.0.0
 - v32.1.0
 - v33.1.0
+- v33.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/cloud-director/releases.json
+++ b/cloud-director/releases.json
@@ -27,6 +27,13 @@
       "releaseTimestamp": "2025-12-03T15:28:51Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v33.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "33.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-12-16T15:16:17Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/cloud-director/v33.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/cloud-director/v33.1.1/README.md
+++ b/cloud-director/v33.1.1/README.md
@@ -1,0 +1,15 @@
+# :zap: Giant Swarm Release v33.1.1 for VMware Cloud Director :zap:
+
+This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+## Changes compared to v33.1.0
+
+### Apps
+
+- coredns from v1.28.2 to v1.28.3
+
+### coredns [v1.28.2...v1.28.3](https://github.com/giantswarm/coredns-app/compare/v1.28.2...v1.28.3)
+
+#### Changed
+
+- Update `coredns` image to [1.13.2](https://github.com/coredns/coredns/releases/tag/v1.13.2).

--- a/cloud-director/v33.1.1/announcement.md
+++ b/cloud-director/v33.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v33.1.1 for VMware Cloud Director is available**. This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-cloud-director/releases/cloud-director-33.1.1).

--- a/cloud-director/v33.1.1/kustomization.yaml
+++ b/cloud-director/v33.1.1/kustomization.yaml
@@ -1,0 +1,20 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      # Need to target index 2 here as `cloud-director` itself already contains a hyphen.
+      delimiter: "-"
+      index: 2
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/cloud-director/v33.1.1/release.diff
+++ b/cloud-director/v33.1.1/release.diff
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: cloud-director-33.1.0                                   |    name: cloud-director-33.1.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                                    version: 2.9.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                                     version: 1.3.2
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-cloud-director                              - name: cloud-provider-cloud-director
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.28.2                                             |      version: 1.28.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                                   version: 1.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                                   version: 0.10.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                                    version: 1.20.9
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                                     version: 2.3.2
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                                    version: 1.15.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+                                                                >      dependsOn:
+                                                                >      - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  components:                                                        components:
+  - name: cluster-cloud-director                                     - name: cluster-cloud-director
+    catalog: cluster                                                   catalog: cluster
+    version: 2.4.0                                                     version: 2.4.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                                  version: 4459.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                                    version: 1.33.6
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                                    version: 1.26.2
+  date: "2025-12-03T15:28:51Z"                                  |    date: "2025-12-16T15:16:17Z"
+  state: active                                                      state: active

--- a/cloud-director/v33.1.1/release.yaml
+++ b/cloud-director/v33.1.1/release.yaml
@@ -1,0 +1,112 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: cloud-director-33.1.1
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.9.14
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.2
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-cloud-director
+    version: 0.5.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.28.3
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.10
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.9
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.3.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.15.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  components:
+  - name: cluster-cloud-director
+    catalog: cluster
+    version: 2.4.0
+  - name: flatcar
+    version: 4459.2.1
+  - name: kubernetes
+    version: 1.33.6
+  - name: os-tooling
+    version: 1.26.2
+  date: "2025-12-16T15:16:17Z"
+  state: active

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - v32.1.0
 - v33.0.1
 - v33.1.0
+- v33.1.1
 transformers:
 - |
   apiVersion: builtin

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -34,6 +34,13 @@
       "releaseTimestamp": "2025-12-03T15:28:37Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v33.1.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "33.1.1",
+      "isDeprecated": false,
+      "releaseTimestamp": "2025-12-16T15:16:16Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v33.1.1/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v33.1.1/README.md
+++ b/vsphere/v33.1.1/README.md
@@ -1,0 +1,15 @@
+# :zap: Giant Swarm Release v33.1.1 for vSphere :zap:
+
+This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+## Changes compared to v33.1.0
+
+### Apps
+
+- coredns from v1.28.2 to v1.28.3
+
+### coredns [v1.28.2...v1.28.3](https://github.com/giantswarm/coredns-app/compare/v1.28.2...v1.28.3)
+
+#### Changed
+
+- Update `coredns` image to [1.13.2](https://github.com/coredns/coredns/releases/tag/v1.13.2).

--- a/vsphere/v33.1.1/announcement.md
+++ b/vsphere/v33.1.1/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v33.1.1 for vSphere is available**. This patch release fixes an issue with the installation of the Teleport Kube Agent app.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-33.1.1).

--- a/vsphere/v33.1.1/kustomization.yaml
+++ b/vsphere/v33.1.1/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v33.1.1/release.diff
+++ b/vsphere/v33.1.1/release.diff
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: vsphere-33.1.0                                          |    name: vsphere-33.1.1
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.9.14                                                    version: 2.9.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.9.4                                                     version: 3.9.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.2                                                     version: 1.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.3.2                                                     version: 1.3.2
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-vsphere                                     - name: cloud-provider-vsphere
+    version: 2.0.1                                                     version: 2.0.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.28.2                                             |      version: 1.28.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.3                                                     version: 1.2.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.11                                                   version: 1.10.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.2.0                                                     version: 3.2.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.10                                                   version: 0.10.10
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.9.1                                                     version: 2.9.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: kube-vip                                                   - name: kube-vip
+    version: 0.2.0                                                     version: 0.2.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: kube-vip-cloud-provider                                    - name: kube-vip-cloud-provider
+    version: 0.3.0                                                     version: 0.3.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.7.0                                                     version: 2.7.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.0                                                    version: 1.23.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.9                                                    version: 1.20.9
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.3.2                                                     version: 2.3.2
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.3                                                     version: 0.0.3
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.5.0                                                     version: 0.5.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.15.0                                                    version: 1.15.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.7                                                    version: 0.10.7
+                                                                >      dependsOn:
+                                                                >      - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.1                                                     version: 6.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.1                                                     version: 4.1.1
+  - name: vsphere-csi-driver                                         - name: vsphere-csi-driver
+    version: 3.4.2                                                     version: 3.4.2
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  components:                                                        components:
+  - name: cluster-vsphere                                            - name: cluster-vsphere
+    catalog: cluster                                                   catalog: cluster
+    version: 3.4.0                                                     version: 3.4.0
+  - name: flatcar                                                    - name: flatcar
+    version: 4459.2.1                                                  version: 4459.2.1
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.33.6                                                    version: 1.33.6
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.26.2                                                    version: 1.26.2
+  date: "2025-12-03T15:28:37Z"                                  |    date: "2025-12-16T15:16:16Z"
+  state: active                                                      state: active

--- a/vsphere/v33.1.1/release.yaml
+++ b/vsphere/v33.1.1/release.yaml
@@ -1,0 +1,124 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-33.1.1
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.9.14
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.9.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.3.2
+  - name: cilium-servicemonitors
+    version: 0.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.0.1
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.28.3
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.2
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.3
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.11
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.2.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.10
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.1
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.2.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.7.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.1
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.9
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.3.2
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.3
+    dependsOn:
+    - kyverno-crds
+  - name: prometheus-blackbox-exporter
+    version: 0.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.15.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.7
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.1
+  - name: vsphere-csi-driver
+    version: 3.4.2
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 3.4.0
+  - name: flatcar
+    version: 4459.2.1
+  - name: kubernetes
+    version: 1.33.6
+  - name: os-tooling
+    version: 1.26.2
+  date: "2025-12-16T15:16:16Z"
+  state: active


### PR DESCRIPTION
This patch release fixes an issue with the installation of the Teleport Kube Agent app.