### PR TITLE
Request observability-bundle 2.5.0 on next releases

### DIFF
--- a/azure/requests.yaml
+++ b/azure/requests.yaml
@@ -7,6 +7,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.3.0"
+  - name: observability-bundle
+    version: ">= 2.5.0"
 - name: "< 32.0.0"
   requests:
   - name: flatcar

--- a/capa/requests.yaml
+++ b/capa/requests.yaml
@@ -7,6 +7,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.3.0"
+  - name: observability-bundle
+    version: ">= 2.5.0"
 - name: "< 32.0.0"
   requests:
   - name: flatcar

--- a/cloud-director/requests.yaml
+++ b/cloud-director/requests.yaml
@@ -7,6 +7,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.3.0"
+  - name: observability-bundle
+    version: ">= 2.5.0"
 - name: "< 32.0.0"
   requests:
   - name: flatcar

--- a/vsphere/requests.yaml
+++ b/vsphere/requests.yaml
@@ -11,6 +11,8 @@ releases:
   requests:
   - name: cilium
     version: ">= 1.3.0"
+  - name: observability-bundle
+    version: ">= 2.5.0"
 - name: "< 32.0.0"
   requests:
   - name: flatcar


### PR DESCRIPTION
This PR requests the new observability-bundle `v2.5.0` to be part of the upcoming releases on all providers.