### PR TITLE
fix release description backup restore logic

### DIFF
--- a/.github/workflows/update-release.yaml
+++ b/.github/workflows/update-release.yaml
@@ -465,11 +465,16 @@ jobs:
             ANNOUNCEMENT_BACKUP=""
             if [ -f "${PROVIDER_DIR}/${RELEASE_NAME}/README.md" ] && ! grep -q "<< Add description here >>" "${PROVIDER_DIR}/${RELEASE_NAME}/README.md"; then
               # Extract existing README description (line 3, which is the warning/description)
-              README_DESCRIPTION_BACKUP=$(sed -n '3p' "${PROVIDER_DIR}/${RELEASE_NAME}/README.md" || true)
+              # Only backup if line 3 is a real description (not a markdown heading), to avoid
+              # capturing devctl-generated section headers when the placeholder was deleted without replacement
+              _line3=$(sed -n '3p' "${PROVIDER_DIR}/${RELEASE_NAME}/README.md" || true)
+              if [[ -n "$_line3" ]] && [[ "$_line3" != \#* ]]; then
+                README_DESCRIPTION_BACKUP="$_line3"
+              fi
             fi
             if [ -f "${PROVIDER_DIR}/${RELEASE_NAME}/announcement.md" ] && ! grep -q "<< Add description here >>" "${PROVIDER_DIR}/${RELEASE_NAME}/announcement.md"; then
               # Extract existing announcement description (everything after "**. ")
-              ANNOUNCEMENT_BACKUP=$(sed -n '1p' "${PROVIDER_DIR}/${RELEASE_NAME}/announcement.md" | sed 's/.*\*\*\. //' || true)
+              ANNOUNCEMENT_BACKUP=$(sed -n '1p' "${PROVIDER_DIR}/${RELEASE_NAME}/announcement.md" | sed 's/.*\*\*\. *//' || true)
             fi
 
             if ! output=$(eval "$DEVCTL_COMMAND" 2>&1 | uniq); then


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35749

Claude was quite the little helper with this one! Here's what was going on, broken down by both the `announcement.md` file and the `README.md` file.

**`announcement.md`**
---
Line 1 of this file is formatted like so -> `**Workload cluster release v33.0.1 for Azure is available**.`. There is a newline immediately following the period at the end of the line, but if there is no description, there is no space after the period. 

The old `sed` command to backup the description after the title on line 472 was structured like this -> `sed 's/.*\*\*\. //'`. The regex expected `**. ` (two asterisks, a period, **and a space**). In the cases where the description was removed, the line would end with no space, the pattern would not match, and the entire line would be returned unchanged. This would result in:

`ANNOUNCEMENT_BACKUP="**Workload cluster release v34.1.0 for Azure is available**."`

Since that's non-empty, the `-n` check on line 671 would pass and the restore on line 690 would result in:

`NEW_LINE_1="**Workload cluster release v34.1.0 for Azure is available**. **Workload cluster release v34.1.0 for Azure is available**."`

The fixed space in the regex should now only set the backup variable if a description is present after the title.

**`README.md`**
---
This one is much more simple, the backup logic just captures line 3, it just expects that to be a description. We can mitigate this ensuring that line is *not* a markdown header for now, and only backup and restore if it's raw text.


I still think it's work looking at doing AI generation for these, but this should fix the *immediate* bug.


