### PR TITLE
CAPA: Release v35.0.0 - Do not merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ to all Giant Swarm installations.
 
 ## AWS
 
+- v35
+  - v35.0
+    - [v35.0.0](https://github.com/giantswarm/releases/tree/master/capa/v35.0.0)
+
 - v34
   - v34.1
     - [v34.1.0](https://github.com/giantswarm/releases/tree/master/capa/v34.1.0)

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - v33.1.4
 - v34.0.0
 - v34.1.0
+- v35.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/v35.0.0/README.md
+++ b/capa/v35.0.0/README.md
@@ -1,0 +1,9 @@
+# :zap: Giant Swarm Release v35.0.0 for CAPA :zap:
+
+## Changes compared to v34.1.0
+
+### Apps
+
+- aws-ebs-csi-driver from v4.1.1 to v5.0.0
+- aws-nth-bundle from v1.3.0 to v1.23.1
+- cloud-provider-aws from v2.0.0 to v2.1.0

--- a/capa/v35.0.0/README.md
+++ b/capa/v35.0.0/README.md
@@ -4,6 +4,8 @@
 
 ### Apps
 
-- aws-ebs-csi-driver from v4.1.1 to v5.0.0
-- aws-nth-bundle from v1.3.0 to v1.23.1
+- aws-ebs-csi-driver from v4.1.1 to v4.2.0
+- aws-efs-csi-driver-bundle v3.3.0 (new)
+- aws-nth-bundle from v1.3.0 to v1.4.0
 - cloud-provider-aws from v2.0.0 to v2.1.0
+- karpenter from v2.1.0 to v2.3.0

--- a/capa/v35.0.0/README.md
+++ b/capa/v35.0.0/README.md
@@ -5,7 +5,6 @@
 ### Apps
 
 - aws-ebs-csi-driver from v4.1.1 to v4.2.0
-- aws-efs-csi-driver-bundle v3.3.0 (new)
 - aws-nth-bundle from v1.3.0 to v1.4.0
 - cloud-provider-aws from v2.0.0 to v2.1.0
 - karpenter from v2.1.0 to v2.3.0

--- a/capa/v35.0.0/announcement.md
+++ b/capa/v35.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v35.0.0 for CAPA is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-35.0.0).

--- a/capa/v35.0.0/kustomization.yaml
+++ b/capa/v35.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v35.0.0/release.diff
+++ b/capa/v35.0.0/release.diff
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1			apiVersion: release.giantswarm.io/v1alpha1
+kind: Release							kind: Release
+metadata:							metadata:
+  name: aws-34.1.0					   |	  name: aws-35.0.0
+spec:								spec:
+  apps:								  apps:
+  - name: aws-ebs-csi-driver					  - name: aws-ebs-csi-driver
+    version: 4.1.1					   |	    version: 5.0.0
+    dependsOn:							    dependsOn:
+    - cloud-provider-aws					    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors			  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.2						    version: 0.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: aws-nth-bundle					  - name: aws-nth-bundle
+    version: 1.3.0					   |	    version: 1.23.1
+  - name: aws-pod-identity-webhook				  - name: aws-pod-identity-webhook
+    version: 2.2.0						    version: 2.2.0
+    dependsOn:							    dependsOn:
+    - cert-manager						    - cert-manager
+  - name: cert-exporter						  - name: cert-exporter
+    version: 2.9.16						    version: 2.9.16
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: cert-manager						  - name: cert-manager
+    version: 3.11.0						    version: 3.11.0
+    dependsOn:							    dependsOn:
+    - alloy-logs						    - alloy-logs
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources			  - name: cert-manager-crossplane-resources
+    catalog: cluster						    catalog: cluster
+    version: 0.1.0						    version: 0.1.0
+  - name: chart-operator-extensions				  - name: chart-operator-extensions
+    version: 1.1.3						    version: 1.1.3
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cilium						  - name: cilium
+    version: 1.4.1						    version: 1.4.1
+  - name: cilium-crossplane-resources				  - name: cilium-crossplane-resources
+    catalog: cluster						    catalog: cluster
+    version: 0.2.1						    version: 0.2.1
+  - name: cilium-servicemonitors				  - name: cilium-servicemonitors
+    version: 0.1.4						    version: 0.1.4
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: cloud-provider-aws					  - name: cloud-provider-aws
+    version: 2.0.0					   |	    version: 2.1.0
+    dependsOn:							    dependsOn:
+    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler					  - name: cluster-autoscaler
+    version: 1.34.3-1						    version: 1.34.3-1
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: coredns						  - name: coredns
+    version: 1.29.1						    version: 1.29.1
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: coredns-extensions					  - name: coredns-extensions
+    version: 0.1.3						    version: 0.1.3
+    dependsOn:							    dependsOn:
+    - vertical-pod-autoscaler-crd				    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag						  - name: etcd-defrag
+    version: 1.2.4						    version: 1.2.4
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter				  - name: etcd-k8s-res-count-exporter
+    version: 1.10.14						    version: 1.10.14
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: external-dns						  - name: external-dns
+    version: 3.4.0						    version: 3.4.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: irsa-servicemonitors					  - name: irsa-servicemonitors
+    version: 0.1.1						    version: 0.1.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: k8s-audit-metrics					  - name: k8s-audit-metrics
+    version: 0.10.13						    version: 0.10.13
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: k8s-dns-node-cache					  - name: k8s-dns-node-cache
+    version: 2.9.2						    version: 2.9.2
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: karpenter						  - name: karpenter
+    version: 2.1.0						    version: 2.1.0
+  - name: karpenter-crossplane-resources			  - name: karpenter-crossplane-resources
+    version: 0.5.1						    version: 0.5.1
+  - name: karpenter-taint-remover				  - name: karpenter-taint-remover
+    version: 1.0.2						    version: 1.0.2
+  - name: metrics-server					  - name: metrics-server
+    version: 2.8.0						    version: 2.8.0
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: net-exporter						  - name: net-exporter
+    version: 1.23.1						    version: 1.23.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: network-policies					  - name: network-policies
+    catalog: cluster						    catalog: cluster
+    version: 0.1.3						    version: 0.1.3
+    dependsOn:							    dependsOn:
+    - cilium							    - cilium
+  - name: node-exporter						  - name: node-exporter
+    version: 1.20.11						    version: 1.20.11
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: node-problem-detector					  - name: node-problem-detector
+    version: 0.5.2						    version: 0.5.2
+  - name: observability-bundle					  - name: observability-bundle
+    version: 2.6.0						    version: 2.6.0
+    dependsOn:							    dependsOn:
+    - coredns							    - coredns
+  - name: observability-policies				  - name: observability-policies
+    version: 0.0.4						    version: 0.0.4
+    dependsOn:							    dependsOn:
+    - kyverno-crds						    - kyverno-crds
+  - name: priority-classes					  - name: priority-classes
+    version: 0.3.1						    version: 0.3.1
+  - name: prometheus-blackbox-exporter				  - name: prometheus-blackbox-exporter
+    version: 0.5.1						    version: 0.5.1
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: security-bundle					  - name: security-bundle
+    catalog: giantswarm						    catalog: giantswarm
+    version: 1.17.0						    version: 1.17.0
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: teleport-kube-agent					  - name: teleport-kube-agent
+    version: 0.10.8						    version: 0.10.8
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler				  - name: vertical-pod-autoscaler
+    version: 6.1.2						    version: 6.1.2
+    dependsOn:							    dependsOn:
+    - prometheus-operator-crd					    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd				  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2						    version: 4.1.2
+  components:							  components:
+  - name: cluster-aws						  - name: cluster-aws
+    catalog: cluster						    catalog: cluster
+    version: 7.4.0						    version: 7.4.0
+  - name: flatcar						  - name: flatcar
+    version: 4459.2.3						    version: 4459.2.3
+  - name: kubernetes						  - name: kubernetes
+    version: 1.34.5						    version: 1.34.5
+  - name: os-tooling						  - name: os-tooling
+    version: 1.26.4						    version: 1.26.4
+  date: "2026-03-02T15:01:14Z"				   |	  date: "2026-03-13T10:02:32Z"
+  state: active						   |	  state: testing

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -88,7 +88,7 @@ spec:
     - kyverno-crds
   - name: karpenter
     catalog: default-test
-    version: 2.2.0-92275600fe179979ccd41eba8f4cacdf2f9363d8
+    version: 2.1.0-6dc17e86bcd47b58260bdc4cd60c6bf6522cfaff
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -88,7 +88,7 @@ spec:
     - kyverno-crds
   - name: karpenter
     catalog: default-test
-    version: 2.1.0-6dc17e86bcd47b58260bdc4cd60c6bf6522cfaff
+    version: 2.1.0-770a6cdefe784d3ce5848083b7bcdab0fb8fd61c
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   apps:
   - name: aws-ebs-csi-driver
-    catalog: default-test
-    version: 4.1.2-79857ccea4f40f4a2c1f3d3e8d3c0918f35324be
+    version: 4.2.0
   - name: aws-efs-csi-driver-bundle
     catalog: giantswarm-test
     version: 3.2.0-4f6ccaf22d41aa8dc72f9d1d38bea9369bfadfb6
@@ -17,8 +16,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: aws-nth-bundle
-    catalog: default-test
-    version: 1.3.0-3df1c10fc81ef469f947d09aca39ba0fe09d2711
+    version: 1.4.0
   - name: aws-pod-identity-webhook
     version: 2.2.0
     dependsOn:
@@ -49,8 +47,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cloud-provider-aws
-    catalog: default-test
-    version: 2.1.0-671a9af06962874c1cecd8baaa10de9586635d5c
+    version: 2.1.0
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler
@@ -90,8 +87,7 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: karpenter
-    catalog: default-test
-    version: 2.2.0-ac27f8ab93520a17b7b419e91dee195549dd6836
+    version: 2.3.0
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -6,11 +6,6 @@ spec:
   apps:
   - name: aws-ebs-csi-driver
     version: 4.2.0
-  - name: aws-efs-csi-driver-bundle
-    catalog: giantswarm-test
-    version: 3.2.0-4f6ccaf22d41aa8dc72f9d1d38bea9369bfadfb6
-    dependsOn:
-    - cloud-provider-aws
   - name: aws-ebs-csi-driver-servicemonitors
     version: 0.1.2
     dependsOn:

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -88,7 +88,7 @@ spec:
     - kyverno-crds
   - name: karpenter
     catalog: default-test
-    version: 2.1.0-770a6cdefe784d3ce5848083b7bcdab0fb8fd61c
+    version: 2.1.0-7fc18ce6dccbfacb5bf535987511f879814c30c4
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -1,7 +1,7 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-35.0.0-test35
+  name: aws-35.0.0
 spec:
   apps:
   - name: aws-ebs-csi-driver

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -6,7 +6,7 @@ spec:
   apps:
   - name: aws-ebs-csi-driver
     catalog: default-test
-    version: 4.1.1-d908db9d2dc3a11a34d05f9b0995425c7ddaea51
+    version: 5.0.0-79857ccea4f40f4a2c1f3d3e8d3c0918f35324be
     dependsOn:
     - cloud-provider-aws
   - name: aws-ebs-csi-driver-servicemonitors
@@ -15,7 +15,7 @@ spec:
     - prometheus-operator-crd
   - name: aws-nth-bundle
     catalog: default-test
-    version: 1.3.0-ab19cf01f3221e8c8bf4d81ecf000c8fb580fddf
+    version: 1.23.1-3df1c10fc81ef469f947d09aca39ba0fe09d2711
   - name: aws-pod-identity-webhook
     version: 2.2.0
     dependsOn:
@@ -47,7 +47,7 @@ spec:
     - prometheus-operator-crd
   - name: cloud-provider-aws
     catalog: default-test
-    version: 2.1.0-671a9af06962874c1cecd8baaa10de9586635d5c
+    version: 2.1.0-b54724bdc4be0bce8b8c74654334ab44218887a2
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler
@@ -88,7 +88,7 @@ spec:
     - kyverno-crds
   - name: karpenter
     catalog: default-test
-    version: 2.1.0-7fc18ce6dccbfacb5bf535987511f879814c30c4
+    version: 2.2.0-ac27f8ab93520a17b7b419e91dee195549dd6836
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -6,7 +6,7 @@ spec:
   apps:
   - name: aws-ebs-csi-driver
     catalog: default-test
-    version: 4.1.1-ab80d2e3debbf80e693d69e11b72494af0908577
+    version: 4.1.1-d908db9d2dc3a11a34d05f9b0995425c7ddaea51
     dependsOn:
     - cloud-provider-aws
   - name: aws-ebs-csi-driver-servicemonitors
@@ -144,7 +144,7 @@ spec:
   components:
   - name: cluster-aws
     catalog: cluster
-    version: 7.4.0
+    version: 7.6.1
   - name: flatcar
     version: 4459.2.3
   - name: kubernetes

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-35.0.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 5.0.0
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.23.1
+  - name: aws-pod-identity-webhook
+    version: 2.2.0
+    dependsOn:
+    - cert-manager
+  - name: cert-exporter
+    version: 2.9.16
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.11.0
+    dependsOn:
+    - alloy-logs
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.0
+  - name: chart-operator-extensions
+    version: 1.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.4.1
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 2.1.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.34.3-1
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.29.1
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.4
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.14
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.13
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.9.2
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter
+    version: 2.1.0
+  - name: karpenter-crossplane-resources
+    version: 0.5.1
+  - name: karpenter-taint-remover
+    version: 1.0.2
+  - name: metrics-server
+    version: 2.8.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.11
+    dependsOn:
+    - kyverno-crds
+  - name: node-problem-detector
+    version: 0.5.2
+  - name: observability-bundle
+    version: 2.6.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.1
+  - name: prometheus-blackbox-exporter
+    version: 0.5.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.17.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.8
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 7.4.0
+  - name: flatcar
+    version: 4459.2.3
+  - name: kubernetes
+    version: 1.34.5
+  - name: os-tooling
+    version: 1.26.4
+  date: "2026-03-13T10:02:32Z"
+  state: testing

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -1,11 +1,12 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  name: aws-35.0.0
+  name: aws-35.0.0-test35
 spec:
   apps:
   - name: aws-ebs-csi-driver
-    version: 5.0.0
+    catalog: default-test
+    version: 4.1.1-ab80d2e3debbf80e693d69e11b72494af0908577
     dependsOn:
     - cloud-provider-aws
   - name: aws-ebs-csi-driver-servicemonitors
@@ -13,7 +14,8 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: aws-nth-bundle
-    version: 1.23.1
+    catalog: default-test
+    version: 1.3.0-ab19cf01f3221e8c8bf4d81ecf000c8fb580fddf
   - name: aws-pod-identity-webhook
     version: 2.2.0
     dependsOn:
@@ -44,7 +46,8 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: cloud-provider-aws
-    version: 2.1.0
+    catalog: default-test
+    version: 2.1.0-671a9af06962874c1cecd8baaa10de9586635d5c
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler
@@ -84,7 +87,8 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: karpenter
-    version: 2.1.0
+    catalog: default-test
+    version: 2.1.0-6dc17e86bcd47b58260bdc4cd60c6bf6522cfaff
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover
@@ -148,4 +152,4 @@ spec:
   - name: os-tooling
     version: 1.26.4
   date: "2026-03-13T10:02:32Z"
-  state: testing
+  state: preview

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -88,7 +88,7 @@ spec:
     - kyverno-crds
   - name: karpenter
     catalog: default-test
-    version: 2.1.0-6dc17e86bcd47b58260bdc4cd60c6bf6522cfaff
+    version: 2.2.0-92275600fe179979ccd41eba8f4cacdf2f9363d8
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -6,7 +6,10 @@ spec:
   apps:
   - name: aws-ebs-csi-driver
     catalog: default-test
-    version: 5.0.0-79857ccea4f40f4a2c1f3d3e8d3c0918f35324be
+    version: 4.1.2-79857ccea4f40f4a2c1f3d3e8d3c0918f35324be
+  - name: aws-efs-csi-driver-bundle
+    catalog: giantswarm-test
+    version: 3.2.0-4f6ccaf22d41aa8dc72f9d1d38bea9369bfadfb6
     dependsOn:
     - cloud-provider-aws
   - name: aws-ebs-csi-driver-servicemonitors
@@ -15,7 +18,7 @@ spec:
     - prometheus-operator-crd
   - name: aws-nth-bundle
     catalog: default-test
-    version: 1.23.1-3df1c10fc81ef469f947d09aca39ba0fe09d2711
+    version: 1.3.0-3df1c10fc81ef469f947d09aca39ba0fe09d2711
   - name: aws-pod-identity-webhook
     version: 2.2.0
     dependsOn:
@@ -47,7 +50,7 @@ spec:
     - prometheus-operator-crd
   - name: cloud-provider-aws
     catalog: default-test
-    version: 2.1.0-b54724bdc4be0bce8b8c74654334ab44218887a2
+    version: 2.1.0-671a9af06962874c1cecd8baaa10de9586635d5c
     dependsOn:
     - vertical-pod-autoscaler-crd
   - name: cluster-autoscaler


### PR DESCRIPTION
## Summary

Testing release for upstream chart migration validation.

- Update `aws-ebs-csi-driver` from v4.1.1 to v5.0.0
- Update `aws-nth-bundle` from v1.3.0 to v1.23.1
- Update `cloud-provider-aws` from v2.0.0 to v2.1.0

Release state: **testing**

Related issue: https://github.com/giantswarm/giantswarm/issues/35593

## Related PRs

- https://github.com/giantswarm/aws-efs-csi-driver/pull/245
- https://github.com/giantswarm/aws-lb-controller-bundle/pull/214
- https://github.com/giantswarm/aws-ebs-csi-driver-app/pull/383
- https://github.com/giantswarm/karpenter-app/pull/198
- https://github.com/giantswarm/aws-nth-bundle/pull/58