### PR TITLE
Fix grep exit code in release action and strip v prefix from devctl version

### DIFF
--- a/.github/actions/create-release-individual/action.yml
+++ b/.github/actions/create-release-individual/action.yml
@@ -50,8 +50,8 @@ runs:
 
         # Extract apps table (starts with "| APP NAME")
         APPS=$(echo "$RAW" | awk '/^\| APP NAME/{found=1} found && /^\| COMPONENT NAME/{exit} found{print}')
-        APP_COUNT=$(echo "$APPS" | grep -c '^|' | awk '{print $1 - 2}')  # subtract header + separator
-        [[ "$APP_COUNT" -lt 0 ]] && APP_COUNT=0
+        APP_COUNT=$(echo "$APPS" | grep -c '^|' || true)  # grep returns 1 if no matches
+        APP_COUNT=$((APP_COUNT > 2 ? APP_COUNT - 2 : 0))  # subtract header + separator
 
         # Build formatted output
         FORMATTED=""

--- a/.github/actions/install-devctl/action.yml
+++ b/.github/actions/install-devctl/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         mkdir -p /tmp/devctl_install && cd /tmp/devctl_install
         LATEST_DEVCTL_TAG=$(gh release view --repo giantswarm/devctl --json tagName --jq '.tagName')
-        echo "version=${LATEST_DEVCTL_TAG}" >> $GITHUB_OUTPUT
+        echo "version=${LATEST_DEVCTL_TAG#v}" >> $GITHUB_OUTPUT
         ASSET_NAME="devctl-${LATEST_DEVCTL_TAG}-linux-amd64.tar.gz"
         gh release download --repo giantswarm/devctl "$LATEST_DEVCTL_TAG" --pattern "$ASSET_NAME"
         tar -xzf "$ASSET_NAME"


### PR DESCRIPTION
Two fixes for the release workflow:

1. **grep exit code**: `grep -c '^|'` returns exit code 1 when no matches are found, which with `set -o pipefail` kills the script. Added `|| true` to handle empty apps output.
2. **v prefix mismatch**: `install-devctl` outputs `v7.37.2` but `devctl` internally uses `7.37.2` (no prefix), so `DEVCTL_UNSAFE_FORCE_VERSION` never matched. Strip the `v` prefix from the output.