### PR TITLE
Fix Release CR version mismatch in PR preview charts

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -110,7 +110,7 @@ jobs:
 
             yq -i ".name = \"${TARGET_CHART}\"" "${TARGET_CHART}/Chart.yaml"
             yq -i ".version = \"${CHART_PUBLISH_VERSION}\"" "${TARGET_CHART}/Chart.yaml"
-            yq -i ".global.release.version = \"${RELEASE_VERSION_CLEAN}\"" "${TARGET_CHART}/values.yaml"
+            yq -i ".global.release.version = \"${CHART_PUBLISH_VERSION}\"" "${TARGET_CHART}/values.yaml"
 
             echo "Chart name:              $(yq '.name' "${TARGET_CHART}/Chart.yaml")"
             echo "Chart version (OCI tag): $(yq '.version' "${TARGET_CHART}/Chart.yaml")"


### PR DESCRIPTION
PR preview charts are published with SHA-suffixed versions (e.g. `35.0.0-<sha>`),
but `global.release.version` was set to the clean version (`35.0.0`). This caused
the Release CR to be created without the SHA suffix, so clusters referencing the
preview version couldn't find a matching Release CR.

Use `CHART_PUBLISH_VERSION` instead of `RELEASE_VERSION_CLEAN` for
`global.release.version` so the Release CR name matches the chart version.
On main/master these values are identical, so only PR preview builds are affected.