### PR TITLE
Testing CAPZ 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ different states, namely `active`, `deprecated` and `wip`. With pull requests
 merged to the `master` branch, workload cluster releases get automatically deployed
 to all Giant Swarm installations.
 
+CAPZ controller testing!
+
 ## AWS
 
 - v34


### PR DESCRIPTION
Testing CAPZ rebase to 1.23.0.

`/run releases-test-suites TARGET_SUITES=./providers/capz`