### PR TITLE
tools/breakingchanges: detect etcd changes bundled by kubeadm

### DIFF
--- a/tools/breakingchanges/pkg/detector.go
+++ b/tools/breakingchanges/pkg/detector.go
@@ -18,9 +18,11 @@ type Detector struct {
 	componentMappingDone bool
 
 	// Caches to avoid redundant fetches in consolidated PRs
-	flatcarCache    map[string]string // "fromVer->toVer" -> changelog
-	kubernetesCache map[string]string // "fromVer->toVer" -> changelog
-	componentCache  map[string]string // "component@fromVer->toVer" -> diff
+	flatcarCache     map[string]string // "fromVer->toVer" -> changelog
+	kubernetesCache  map[string]string // "fromVer->toVer" -> changelog
+	componentCache   map[string]string // "component@fromVer->toVer" -> diff
+	etcdVersionCache map[string]string // k8sVersion -> etcdVersion (from kubeadm constants)
+	etcdCache        map[string]string // "fromEtcd->toEtcd" -> filtered changelog
 }
 
 // NewDetector creates a new Detector instance
@@ -39,6 +41,8 @@ func NewDetector(anthropicAPIKey, githubToken string) (*Detector, error) {
 		flatcarCache:         make(map[string]string),
 		kubernetesCache:      make(map[string]string),
 		componentCache:       make(map[string]string),
+		etcdVersionCache:     make(map[string]string),
+		etcdCache:            make(map[string]string),
 	}, nil
 }
 
@@ -234,6 +238,12 @@ func (d *Detector) logContentSummary(externalChanges, componentDiffs map[string]
 		fmt.Println("⚠️  Kubernetes changelog: NOT FETCHED")
 	}
 
+	if etcdContent, ok := externalChanges["Etcd"]; ok {
+		fmt.Printf("Etcd changelog: %d chars (preview: %s...)\n", len(etcdContent), truncate(etcdContent, 100))
+	} else {
+		fmt.Println("Etcd changelog: not applicable (same bundled version) or not fetched")
+	}
+
 	fmt.Printf("Component diffs: %d components\n", len(componentDiffs))
 	for name := range componentDiffs {
 		fmt.Printf("  - %s\n", name)
@@ -376,6 +386,9 @@ func buildExternalChangelogsSection(externalChanges map[string]string) string {
 		limit := 10000
 		if component == "Kubernetes" {
 			limit = 50000 // K8s changelogs need more space for Urgent Upgrade Notes and detailed API changes
+		}
+		if component == "Etcd" {
+			limit = 25000 // Etcd CHANGELOG slice spans multiple patches — bug-fix lines are the signal
 		}
 
 		if len(changelog) > limit {

--- a/tools/breakingchanges/pkg/etcd.go
+++ b/tools/breakingchanges/pkg/etcd.go
@@ -1,0 +1,228 @@
+package breakingchanges
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Etcd version shipped with kubeadm is not set in release.yaml — kubeadm bakes
+// it in via the `SupportedEtcdVersion` map in cmd/kubeadm/app/constants/constants.go.
+// We resolve the bundled etcd version for a given Kubernetes tag and, when it
+// changes across the upgrade, pull the relevant etcd CHANGELOG section.
+
+// resolveEtcdVersionForK8s returns the etcd version kubeadm bundles for the
+// given Kubernetes version (e.g. "1.34.1" -> "3.6.4"). The trailing image tag
+// suffix (e.g. "-0") is stripped. Lookups are cached.
+func (d *Detector) resolveEtcdVersionForK8s(ctx context.Context, k8sVersion string) (string, error) {
+	k8sVersion = strings.TrimPrefix(k8sVersion, "v")
+	if cached, ok := d.etcdVersionCache[k8sVersion]; ok {
+		return cached, nil
+	}
+
+	minor := parseK8sMinorVersion(k8sVersion)
+	if minor == 0 {
+		return "", fmt.Errorf("could not parse minor version from %q", k8sVersion)
+	}
+
+	url := fmt.Sprintf("https://raw.githubusercontent.com/kubernetes/kubernetes/v%s/cmd/kubeadm/app/constants/constants.go", k8sVersion)
+	content, err := d.fetchURL(ctx, url)
+	if err != nil {
+		return "", fmt.Errorf("fetch kubeadm constants for k8s v%s: %w", k8sVersion, err)
+	}
+
+	etcdVersion, err := parseSupportedEtcdVersion(content, minor)
+	if err != nil {
+		return "", err
+	}
+
+	d.etcdVersionCache[k8sVersion] = etcdVersion
+	return etcdVersion, nil
+}
+
+// parseSupportedEtcdVersion extracts the etcd version for a given Kubernetes
+// minor from the text of kubeadm's constants.go. Handles the standard map
+// layout: `SupportedEtcdVersion = map[uint8]string{ 34: "3.6.4-0", ... }`.
+func parseSupportedEtcdVersion(constantsGo string, k8sMinor int) (string, error) {
+	blockRe := regexp.MustCompile(`(?s)SupportedEtcdVersion\s*=\s*map\[uint8\]string\s*\{(.*?)\}`)
+	blockMatch := blockRe.FindStringSubmatch(constantsGo)
+	if len(blockMatch) < 2 {
+		return "", fmt.Errorf("SupportedEtcdVersion map not found in constants.go")
+	}
+
+	entryRe := regexp.MustCompile(`(?m)^\s*(\d+)\s*:\s*"([^"]+)"`)
+	for _, match := range entryRe.FindAllStringSubmatch(blockMatch[1], -1) {
+		minor, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+		if minor == k8sMinor {
+			return stripEtcdImageSuffix(match[2]), nil
+		}
+	}
+
+	return "", fmt.Errorf("no etcd version listed for Kubernetes minor %d", k8sMinor)
+}
+
+// stripEtcdImageSuffix removes the image-tag rev suffix kubeadm appends (e.g.
+// "3.6.4-0" -> "3.6.4"). Etcd CHANGELOGs use the unsuffixed form.
+func stripEtcdImageSuffix(v string) string {
+	if idx := strings.Index(v, "-"); idx > 0 {
+		return v[:idx]
+	}
+	return v
+}
+
+// fetchEtcdChangelog returns a filtered slice of the etcd CHANGELOG covering
+// the versions between fromVer (exclusive) and toVer (inclusive). If the minor
+// changes (e.g. 3.5 -> 3.6), the returned text is prefixed with a strong
+// warning — etcd minor bumps typically include storage-format or API changes.
+func (d *Detector) fetchEtcdChangelog(ctx context.Context, fromVer, toVer string) (string, error) {
+	fromVer = strings.TrimPrefix(fromVer, "v")
+	toVer = strings.TrimPrefix(toVer, "v")
+	cacheKey := fmt.Sprintf("%s->%s", fromVer, toVer)
+	if cached, ok := d.etcdCache[cacheKey]; ok {
+		return cached, nil
+	}
+
+	fromMinor, err := parseEtcdMinor(fromVer)
+	if err != nil {
+		return "", err
+	}
+	toMinor, err := parseEtcdMinor(toVer)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# etcd bundled by kubeadm: v%s -> v%s\n\n", fromVer, toVer))
+
+	if fromMinor != toMinor {
+		sb.WriteString("## ⚠️ ETCD MINOR-VERSION BUMP ⚠️\n\n")
+		sb.WriteString(fmt.Sprintf("kubeadm switches the bundled etcd from the %s line to the %s line across this Kubernetes upgrade.\n", fromMinor, toMinor))
+		sb.WriteString("Minor etcd bumps are high-risk: storage format, WAL, and default behaviour changes are routine at this boundary. Treat this as a release-blocker concern until verified in a test cluster.\n\n")
+	}
+
+	// Pull the target minor's CHANGELOG — that's where the new entries live.
+	targetURL := fmt.Sprintf("https://raw.githubusercontent.com/etcd-io/etcd/main/CHANGELOG/CHANGELOG-%s.md", toMinor)
+	targetBody, err := d.fetchURL(ctx, targetURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch etcd CHANGELOG-%s.md: %w", toMinor, err)
+	}
+
+	// If crossing minors, include the full CHANGELOG-<toMinor>.md up to toVer.
+	// Otherwise, only include entries strictly between fromVer and toVer.
+	var filtered string
+	if fromMinor != toMinor {
+		filtered = extractEtcdUpTo(targetBody, toVer)
+	} else {
+		filtered = extractEtcdBetween(targetBody, fromVer, toVer)
+	}
+	if strings.TrimSpace(filtered) == "" {
+		filtered = fmt.Sprintf("No CHANGELOG entries found between v%s and v%s. Review the full changelog manually: %s\n", fromVer, toVer, targetURL)
+	}
+	sb.WriteString(filtered)
+
+	result := sb.String()
+	d.etcdCache[cacheKey] = result
+	return result, nil
+}
+
+// parseEtcdMinor extracts the "MAJOR.MINOR" prefix of an etcd version.
+// e.g. "3.6.4" -> "3.6".
+func parseEtcdMinor(version string) (string, error) {
+	re := regexp.MustCompile(`^(\d+\.\d+)`)
+	match := re.FindStringSubmatch(version)
+	if len(match) < 2 {
+		return "", fmt.Errorf("could not parse etcd minor from %q", version)
+	}
+	return match[1], nil
+}
+
+// etcdReleaseHeaderRe matches etcd CHANGELOG patch release headers, e.g.
+// "## v3.6.4 (2025-07-31)" or "## v3.6.11 (TBC)".
+var etcdReleaseHeaderRe = regexp.MustCompile(`(?m)^##\s+v(\d+\.\d+\.\d+)\b`)
+
+// extractEtcdBetween returns CHANGELOG sections for releases strictly greater
+// than fromVer and up to (and including) toVer. Assumes standard etcd format
+// where releases are listed newest-first.
+func extractEtcdBetween(changelog, fromVer, toVer string) string {
+	sections := splitEtcdSections(changelog)
+	var sb strings.Builder
+	for _, sec := range sections {
+		if compareSemver(sec.version, fromVer) > 0 && compareSemver(sec.version, toVer) <= 0 {
+			sb.WriteString(sec.body)
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+// extractEtcdUpTo returns CHANGELOG sections for releases up to (and including)
+// toVer. Used when the minor differs from the source so we include every entry
+// in the target minor up to the bundled patch.
+func extractEtcdUpTo(changelog, toVer string) string {
+	sections := splitEtcdSections(changelog)
+	var sb strings.Builder
+	for _, sec := range sections {
+		if compareSemver(sec.version, toVer) <= 0 {
+			sb.WriteString(sec.body)
+			sb.WriteString("\n")
+		}
+	}
+	return sb.String()
+}
+
+type etcdSection struct {
+	version string
+	body    string
+}
+
+// splitEtcdSections breaks an etcd CHANGELOG into per-release sections.
+func splitEtcdSections(changelog string) []etcdSection {
+	indexes := etcdReleaseHeaderRe.FindAllStringSubmatchIndex(changelog, -1)
+	if len(indexes) == 0 {
+		return nil
+	}
+
+	var sections []etcdSection
+	for i, idx := range indexes {
+		start := idx[0]
+		end := len(changelog)
+		if i+1 < len(indexes) {
+			end = indexes[i+1][0]
+		}
+		version := changelog[idx[2]:idx[3]]
+		sections = append(sections, etcdSection{
+			version: version,
+			body:    strings.TrimSpace(changelog[start:end]),
+		})
+	}
+	return sections
+}
+
+// compareSemver compares two dotted versions (e.g. "3.6.4", "3.5.21").
+// Returns negative if a < b, zero if equal, positive if a > b.
+func compareSemver(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	n := len(aParts)
+	if len(bParts) > n {
+		n = len(bParts)
+	}
+	for i := 0; i < n; i++ {
+		var ai, bi int
+		if i < len(aParts) {
+			ai, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bi, _ = strconv.Atoi(bParts[i])
+		}
+		if ai != bi {
+			return ai - bi
+		}
+	}
+	return 0
+}

--- a/tools/breakingchanges/pkg/etcd_test.go
+++ b/tools/breakingchanges/pkg/etcd_test.go
@@ -1,0 +1,131 @@
+package breakingchanges
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSupportedEtcdVersion(t *testing.T) {
+	constantsGo := `
+	// SupportedEtcdVersion lists officially supported etcd versions.
+	SupportedEtcdVersion = map[uint8]string{
+		31: "3.5.21-0",
+		32: "3.5.21-0",
+		33: "3.5.21-0",
+		34: "3.6.4-0",
+	}
+`
+	cases := []struct {
+		minor int
+		want  string
+	}{
+		{33, "3.5.21"},
+		{34, "3.6.4"},
+	}
+	for _, tc := range cases {
+		got, err := parseSupportedEtcdVersion(constantsGo, tc.minor)
+		if err != nil {
+			t.Fatalf("minor %d: unexpected error: %v", tc.minor, err)
+		}
+		if got != tc.want {
+			t.Errorf("minor %d: got %q, want %q", tc.minor, got, tc.want)
+		}
+	}
+
+	if _, err := parseSupportedEtcdVersion(constantsGo, 99); err == nil {
+		t.Error("expected error for missing minor 99")
+	}
+}
+
+func TestStripEtcdImageSuffix(t *testing.T) {
+	cases := map[string]string{
+		"3.6.4-0": "3.6.4",
+		"3.5.21":  "3.5.21",
+	}
+	for in, want := range cases {
+		if got := stripEtcdImageSuffix(in); got != want {
+			t.Errorf("stripEtcdImageSuffix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		sign int // -1, 0, +1
+	}{
+		{"3.6.4", "3.6.4", 0},
+		{"3.6.4", "3.6.5", -1},
+		{"3.6.10", "3.6.9", 1},
+		{"3.5.21", "3.6.0", -1},
+	}
+	for _, tc := range cases {
+		got := compareSemver(tc.a, tc.b)
+		if (got == 0 && tc.sign != 0) || (got < 0 && tc.sign >= 0) || (got > 0 && tc.sign <= 0) {
+			t.Errorf("compareSemver(%q, %q) = %d, want sign %d", tc.a, tc.b, got, tc.sign)
+		}
+	}
+}
+
+func TestExtractEtcdBetween(t *testing.T) {
+	changelog := `
+## v3.6.11 (TBC)
+
+- should be excluded (greater than toVer)
+
+---
+
+## v3.6.10 (2026-04-01)
+
+- should be included
+
+---
+
+## v3.6.9 (2026-03-20)
+
+- should be included
+
+---
+
+## v3.6.8 (2026-02-13)
+
+- should be excluded (equal to fromVer)
+`
+	got := extractEtcdBetween(changelog, "3.6.8", "3.6.10")
+	if !strings.Contains(got, "v3.6.10") || !strings.Contains(got, "v3.6.9") {
+		t.Errorf("expected 3.6.9 and 3.6.10 in slice, got:\n%s", got)
+	}
+	if strings.Contains(got, "v3.6.11") {
+		t.Errorf("expected 3.6.11 (TBC) to be excluded, got:\n%s", got)
+	}
+	if strings.Contains(got, "v3.6.8") {
+		t.Errorf("expected fromVer 3.6.8 to be excluded, got:\n%s", got)
+	}
+}
+
+func TestExtractEtcdUpTo(t *testing.T) {
+	changelog := `
+## v3.6.5 (2025-07-31)
+
+- included
+
+---
+
+## v3.6.4 (2025-06-15)
+
+- included
+
+---
+
+## v3.6.3 (2025-05-01)
+
+- included
+`
+	got := extractEtcdUpTo(changelog, "3.6.4")
+	if !strings.Contains(got, "v3.6.4") || !strings.Contains(got, "v3.6.3") {
+		t.Errorf("expected 3.6.3 and 3.6.4 in slice, got:\n%s", got)
+	}
+	if strings.Contains(got, "v3.6.5") {
+		t.Errorf("expected 3.6.5 (greater than toVer) to be excluded, got:\n%s", got)
+	}
+}

--- a/tools/breakingchanges/pkg/fetchers.go
+++ b/tools/breakingchanges/pkg/fetchers.go
@@ -146,9 +146,49 @@ func (d *Detector) fetchExternalChangelogs(ctx context.Context, changes []Versio
 
 		result[change.Component] = content
 		fmt.Printf("✓ Fetched %s changelog (%d bytes)\n", change.Component, len(content))
+
+		// For Kubernetes changes, also resolve the bundled etcd versions via
+		// kubeadm and fetch the etcd CHANGELOG when it differs. This covers
+		// the case where release.yaml doesn't declare etcd but kubeadm bumps
+		// it under the hood — the source of the v33→v34 quorum incident.
+		if change.Component == "Kubernetes" {
+			d.fetchEtcdForK8sChange(ctx, change, result)
+		}
 	}
 
 	return result, nil
+}
+
+// fetchEtcdForK8sChange resolves the bundled etcd version from kubeadm for the
+// from/to Kubernetes versions and, if they differ, adds the relevant etcd
+// CHANGELOG slice to result under the "Etcd" key.
+func (d *Detector) fetchEtcdForK8sChange(ctx context.Context, change VersionChange, result map[string]string) {
+	fromEtcd, err := d.resolveEtcdVersionForK8s(ctx, change.FromVersion)
+	if err != nil {
+		fmt.Printf("Warning: could not resolve etcd version for Kubernetes v%s: %v\n", change.FromVersion, err)
+		return
+	}
+	toEtcd, err := d.resolveEtcdVersionForK8s(ctx, change.ToVersion)
+	if err != nil {
+		fmt.Printf("Warning: could not resolve etcd version for Kubernetes v%s: %v\n", change.ToVersion, err)
+		return
+	}
+
+	fmt.Printf("  → kubeadm bundles etcd v%s (k8s v%s) -> etcd v%s (k8s v%s)\n",
+		fromEtcd, change.FromVersion, toEtcd, change.ToVersion)
+
+	if fromEtcd == toEtcd {
+		return
+	}
+
+	changelog, err := d.fetchEtcdChangelog(ctx, fromEtcd, toEtcd)
+	if err != nil {
+		fmt.Printf("Warning: Failed to fetch etcd changelog: %v\n", err)
+		return
+	}
+
+	result["Etcd"] = changelog
+	fmt.Printf("✓ Fetched etcd changelog v%s -> v%s (%d bytes)\n", fromEtcd, toEtcd, len(changelog))
 }
 
 // processFlatcarChangelog extracts Flatcar release notes from JSON

--- a/tools/breakingchanges/pkg/llm.go
+++ b/tools/breakingchanges/pkg/llm.go
@@ -253,7 +253,36 @@ Analyze the provided release information and identify any breaking changes. Cons
    
    **Check context**: If upgrading 1.33.5→1.34.1, only report changes NEW in 1.34
 
-3. **Component Changes** (Apps and Components) - Review diffs even without "BREAKING" keyword
+3. **Etcd Changes** - Bundled etcd version comes from kubeadm, NOT from release.yaml
+
+   The "Etcd" section in the context is derived by resolving kubeadm's
+   `+"`SupportedEtcdVersion`"+` map for the from/to Kubernetes tags. If that
+   section is present, etcd changed under the hood during this upgrade and
+   MUST be reviewed regardless of whether release.yaml mentions etcd.
+
+   **PRIORITY 1 - MINOR-VERSION BUMP** (Critical):
+   - If the section header contains "ETCD MINOR-VERSION BUMP", treat this as
+     a critical finding. Minor etcd jumps (e.g. 3.5 -> 3.6) can change the
+     on-disk storage version, WAL format, or default server flags. In the
+     past, a 3.5 -> 3.6 kubeadm switch has left customer clusters unable to
+     achieve quorum during control-plane rollover. Always surface.
+
+   **PRIORITY 2 - Bug-fix lines that describe quorum, consensus, or data
+   integrity issues** (Critical):
+   - "Fix Race between read index and leader change"
+   - "Fix Stale reads caused by process pausing"
+   - "Data corruption", "WAL", "snapshot", "split-brain"
+   - These indicate the PREVIOUS version had a bug that could surface
+     during the upgrade window. Report them.
+
+   **PRIORITY 3 - Security advisories (CVEs)**:
+   - Report any CVE mentioned in the etcd section as high/critical depending
+     on scope.
+
+   **DO NOT** report generic dependency bumps (golang.org/x/net, otel SDK)
+   unless they carry a CVE note.
+
+4. **Component Changes** (Apps and Components) - Review diffs even without "BREAKING" keyword
    
    **What to look for in component diffs:**
    - **Configuration changes**: 
@@ -289,7 +318,7 @@ Analyze the provided release information and identify any breaking changes. Cons
    - **Minor bumps** (X.Y → X.Y+1 or X.Y+2): Often include configuration or behavior changes
    - **Patch bumps** (X.Y.Z → X.Y.Z+1): Usually safe, but still check for important fixes
 
-4. **Dependency Changes**
+5. **Dependency Changes**
    - Major version bumps that indicate breaking changes
    - Check nested dependencies (e.g., if cluster-azure uses cluster chart)
    - For Giant Swarm components (cluster-*, *-app), minor version bumps often include important changes


### PR DESCRIPTION
The etcd version kubeadm bundles is baked into the `SupportedEtcdVersion` map in kubeadm — not declared in release.yaml. Between k8s 1.33 and 1.34 that's a 3.5.21 → 3.6.4 jump, which the breaking-changes detector was blind to.

Changes:
- Resolve the bundled etcd version from kubeadm's `constants.go` at the from/to k8s tags.
- When they differ, fetch the etcd CHANGELOG and slice to the relevant window.
- Minor bumps (e.g. 3.5 → 3.6) get a prominent warning header in the LLM context.
- Prompt updated to flag minor bumps and quorum/consensus/data-integrity fixes as critical.

Motivated by a recent v33 → v34 upgrade where a kubeadm etcd bump surfaced a bug that cost quorum.