### PR TITLE
Add /rebase PR-comment command with conflict auto-resolver

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -1,0 +1,181 @@
+name: Rebase (Comment Trigger)
+
+# /rebase rebases the PR branch onto master and auto-resolves merge
+# conflicts in */releases.json and */kustomization.yaml by taking the
+# union of entries and re-sorting by semver. Any conflict outside those
+# two files aborts the rebase and leaves the PR untouched.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rebase:
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/rebase') &&
+      github.repository == 'giantswarm/releases' &&
+      (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Add eyes reaction
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ github.event.comment.id }},
+              content: 'eyes'
+            })
+
+      - name: Get PR branch
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.issue.number }}
+            });
+            core.setOutput('branch', pr.data.head.ref);
+            core.setOutput('base', pr.data.base.ref);
+            core.setOutput('head_repo_full_name', pr.data.head.repo.full_name);
+            core.setOutput('same_repo', pr.data.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`);
+
+      - name: Refuse forks
+        if: steps.pr.outputs.same_repo != 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.issue.number }},
+              body: '`/rebase` is only supported for PRs from branches in this repo (not forks).'
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ github.event.comment.id }},
+              content: '-1'
+            });
+            core.setFailed('fork PR');
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          fetch-depth: 0
+          token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/rebase-resolver/go.mod
+
+      - name: Build resolver
+        run: |
+          cd tools/rebase-resolver
+          go build -o /tmp/rebase-resolver .
+
+      - name: Rebase onto base branch
+        id: rebase
+        env:
+          BASE: ${{ steps.pr.outputs.base }}
+        run: |
+          set -u
+          git config --global user.name 'taylorbot'
+          git config --global user.email 'dev@giantswarm.io'
+          git fetch origin "$BASE"
+
+          # Avoid editor prompts during rebase --continue.
+          export GIT_EDITOR=true
+          export GIT_SEQUENCE_EDITOR=true
+
+          if git rebase "origin/$BASE"; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Loop: try to auto-resolve each conflict stop with the resolver.
+          # If the resolver exits non-zero, it means there are conflicts in
+          # files it doesn't handle — abort the rebase and fail.
+          while [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; do
+            if ! /tmp/rebase-resolver; then
+              echo "Resolver could not handle all conflicts, aborting rebase."
+              git rebase --abort || true
+              echo "status=unresolvable" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+
+            if git diff --cached --quiet; then
+              # Resolver left nothing staged; this commit is now empty.
+              git rebase --skip || { git rebase --abort || true; exit 1; }
+            else
+              git rebase --continue || { git rebase --abort || true; exit 1; }
+            fi
+          done
+
+          echo "status=resolved" >> "$GITHUB_OUTPUT"
+
+      - name: Push rebased branch
+        if: steps.rebase.outputs.status == 'clean' || steps.rebase.outputs.status == 'resolved'
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          git push --force-with-lease origin "HEAD:$BRANCH"
+
+      - name: Comment success
+        if: steps.rebase.outputs.status == 'clean' || steps.rebase.outputs.status == 'resolved'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          script: |
+            const status = '${{ steps.rebase.outputs.status }}';
+            const note = status === 'resolved'
+              ? 'Auto-resolved conflicts in `releases.json` / `kustomization.yaml` by taking the union and re-sorting by semver.'
+              : 'Rebased cleanly, no conflicts.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.issue.number }},
+              body: `:arrows_counterclockwise: Rebased onto \`${{ steps.pr.outputs.base }}\`.\n\n${note}`
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ github.event.comment.id }},
+              content: '+1'
+            });
+
+      - name: Comment failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          script: |
+            const status = '${{ steps.rebase.outputs.status }}';
+            const body = status === 'unresolvable'
+              ? ':warning: **Rebase failed.**\n\nThere are conflicts in files outside `releases.json` / `kustomization.yaml` that I cannot safely auto-resolve. Please rebase manually.\n\nCheck the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+              : ':warning: **Rebase failed.** See the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.issue.number }},
+              body: body
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ github.event.comment.id }},
+              content: '-1'
+            });

--- a/tools/rebase-resolver/go.mod
+++ b/tools/rebase-resolver/go.mod
@@ -1,0 +1,8 @@
+module github.com/giantswarm/releases/tools/rebase-resolver
+
+go 1.25.5
+
+require (
+	github.com/blang/semver/v4 v4.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/tools/rebase-resolver/go.sum
+++ b/tools/rebase-resolver/go.sum
@@ -1,0 +1,6 @@
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/rebase-resolver/main.go
+++ b/tools/rebase-resolver/main.go
@@ -1,0 +1,339 @@
+// rebase-resolver auto-resolves conflicts in */releases.json and
+// */kustomization.yaml files left behind by `git rebase origin/master`.
+//
+// Both files are ordered lists keyed by semver. A conflict between two
+// release PRs is almost always a bookkeeping clash, not a semantic one, so
+// the correct merged result is the union of entries sorted by semver.
+//
+// The tool reads the "ours" (stage 2) and "theirs" (stage 3) versions from
+// the git index, merges them, writes the result, and `git add`s the file.
+// Any conflict in a file this tool doesn't know how to resolve is left
+// alone and reported on stderr with a non-zero exit code.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"gopkg.in/yaml.v3"
+)
+
+type releaseEntry struct {
+	Version          string `json:"version"`
+	IsDeprecated     bool   `json:"isDeprecated"`
+	ReleaseTimestamp string `json:"releaseTimestamp"`
+	ChangelogUrl     string `json:"changelogUrl"`
+	IsStable         bool   `json:"isStable"`
+}
+
+type releasesFile struct {
+	Releases []releaseEntry `json:"releases"`
+}
+
+func main() {
+	conflicted, err := conflictedFiles()
+	if err != nil {
+		fail("list conflicted files: %v", err)
+	}
+	if len(conflicted) == 0 {
+		return
+	}
+
+	var unhandled []string
+	for _, path := range conflicted {
+		base := filepath.Base(path)
+		switch base {
+		case "releases.json":
+			if err := resolveReleasesJSON(path); err != nil {
+				fail("resolve %s: %v", path, err)
+			}
+		case "kustomization.yaml":
+			if err := resolveKustomization(path); err != nil {
+				fail("resolve %s: %v", path, err)
+			}
+		default:
+			unhandled = append(unhandled, path)
+		}
+	}
+
+	if len(unhandled) > 0 {
+		fmt.Fprintln(os.Stderr, "unresolved conflicts:")
+		for _, p := range unhandled {
+			fmt.Fprintln(os.Stderr, "  "+p)
+		}
+		os.Exit(2)
+	}
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func conflictedFiles() ([]string, error) {
+	out, err := exec.Command("git", "diff", "--name-only", "--diff-filter=U").Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// readStage returns the given git index stage of path:
+//
+//	1 = common ancestor, 2 = ours, 3 = theirs
+func readStage(path string, stage int) ([]byte, error) {
+	var stderr bytes.Buffer
+	cmd := exec.Command("git", "show", fmt.Sprintf(":%d:%s", stage, path))
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git show :%d:%s: %v: %s", stage, path, err, stderr.String())
+	}
+	return out, nil
+}
+
+func gitAdd(path string) error {
+	return exec.Command("git", "add", "--", path).Run()
+}
+
+// resolveReleasesJSON merges the "ours" and "theirs" copies of
+// releases.json by union-of-entries (keyed on version), sorted ascending
+// by semver, and writes the result back to disk.
+func resolveReleasesJSON(path string) error {
+	ours, err := readStage(path, 2)
+	if err != nil {
+		return err
+	}
+	theirs, err := readStage(path, 3)
+	if err != nil {
+		return err
+	}
+
+	merged, err := mergeReleasesJSON(ours, theirs)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, merged, 0644); err != nil {
+		return err
+	}
+	return gitAdd(path)
+}
+
+func mergeReleasesJSON(ours, theirs []byte) ([]byte, error) {
+	var a, b releasesFile
+	if err := json.Unmarshal(ours, &a); err != nil {
+		return nil, fmt.Errorf("parse ours: %v", err)
+	}
+	if err := json.Unmarshal(theirs, &b); err != nil {
+		return nil, fmt.Errorf("parse theirs: %v", err)
+	}
+
+	byVersion := make(map[string]releaseEntry)
+	for _, r := range a.Releases {
+		byVersion[r.Version] = r
+	}
+	// On same-version conflict, prefer "theirs" (the PR's version) since
+	// that's the author's intent and rebase semantics.
+	for _, r := range b.Releases {
+		byVersion[r.Version] = r
+	}
+
+	merged := make([]releaseEntry, 0, len(byVersion))
+	for _, r := range byVersion {
+		merged = append(merged, r)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return semverLess(merged[i].Version, merged[j].Version)
+	})
+
+	out := releasesFile{Releases: merged}
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// resolveKustomization merges the "ours" and "theirs" copies of
+// kustomization.yaml. Only the `resources` list is re-merged; all other
+// fields are taken from "ours" (master), because kustomization
+// scaffolding changes are made separately from release adds and should
+// not be re-derived here.
+func resolveKustomization(path string) error {
+	ours, err := readStage(path, 2)
+	if err != nil {
+		return err
+	}
+	theirs, err := readStage(path, 3)
+	if err != nil {
+		return err
+	}
+
+	merged, err := mergeKustomization(ours, theirs)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, merged, 0644); err != nil {
+		return err
+	}
+	return gitAdd(path)
+}
+
+// mergeKustomization rewrites only the top-level `resources:` list block
+// of "ours", replacing it with the semver-sorted union of resources from
+// both sides. Every byte outside that block is preserved verbatim, so
+// comments, formatting, and the quirk of column-zero list items are
+// retained — avoiding cosmetic diffs on every rebase.
+func mergeKustomization(ours, theirs []byte) ([]byte, error) {
+	oursResources, err := extractResources(ours)
+	if err != nil {
+		return nil, fmt.Errorf("parse ours: %v", err)
+	}
+	theirsResources, err := extractResources(theirs)
+	if err != nil {
+		return nil, fmt.Errorf("parse theirs: %v", err)
+	}
+
+	union := sortedUnion(append(oursResources, theirsResources...))
+	return rewriteResourcesBlock(ours, union)
+}
+
+func extractResources(data []byte) ([]string, error) {
+	var doc struct {
+		Resources []string `yaml:"resources"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	return doc.Resources, nil
+}
+
+// rewriteResourcesBlock locates the top-level `resources:` key in a
+// kustomization.yaml document and replaces the contiguous run of list
+// items below it with the provided resources. It preserves the original
+// list-item indentation (whatever prefix like "- " or "  - " the file
+// already uses) and leaves the rest of the file byte-for-byte identical.
+func rewriteResourcesBlock(doc []byte, resources []string) ([]byte, error) {
+	// Keep the trailing-newline status of the input so the output matches.
+	hasTrailingNL := bytes.HasSuffix(doc, []byte("\n"))
+	content := doc
+	if hasTrailingNL {
+		content = doc[:len(doc)-1]
+	}
+	lines := strings.Split(string(content), "\n")
+
+	startIdx := -1
+	for i, l := range lines {
+		// Top-level `resources:` only (no leading whitespace).
+		if l == "resources:" || strings.HasPrefix(l, "resources:") && !isIndented(l) {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx == -1 {
+		return nil, fmt.Errorf("resources: key not found")
+	}
+
+	// Determine the item prefix from the first existing list item, or
+	// default to "- " (column-zero) which matches the repo convention.
+	itemPrefix := "- "
+	endIdx := startIdx + 1
+	for endIdx < len(lines) {
+		l := lines[endIdx]
+		trimmed := strings.TrimLeft(l, " \t")
+		if !strings.HasPrefix(trimmed, "- ") && trimmed != "-" {
+			break
+		}
+		if endIdx == startIdx+1 {
+			// Record the exact prefix the file uses.
+			itemPrefix = l[:len(l)-len(trimmed)] + "- "
+		}
+		endIdx++
+	}
+
+	var b bytes.Buffer
+	for i := 0; i <= startIdx; i++ {
+		b.WriteString(lines[i])
+		b.WriteByte('\n')
+	}
+	for _, r := range resources {
+		b.WriteString(itemPrefix)
+		b.WriteString(r)
+		b.WriteByte('\n')
+	}
+	for i := endIdx; i < len(lines); i++ {
+		b.WriteString(lines[i])
+		if i < len(lines)-1 {
+			b.WriteByte('\n')
+		}
+	}
+	if hasTrailingNL {
+		b.WriteByte('\n')
+	}
+	return b.Bytes(), nil
+}
+
+func isIndented(s string) bool {
+	return len(s) > 0 && (s[0] == ' ' || s[0] == '\t')
+}
+
+func sortedUnion(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, s := range items {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return semverLess(out[i], out[j])
+	})
+	return out
+}
+
+// semverLess compares two version strings lexicographically by semver.
+// It strips an optional leading "v" and falls back to string comparison
+// for anything that doesn't parse — this keeps non-semver resource
+// entries (if they ever appear) from panicking the tool.
+func semverLess(a, b string) bool {
+	av, aok := parseSemver(a)
+	bv, bok := parseSemver(b)
+	switch {
+	case aok && bok:
+		return av.LT(bv)
+	case aok:
+		return true
+	case bok:
+		return false
+	default:
+		return a < b
+	}
+}
+
+func parseSemver(s string) (semver.Version, bool) {
+	v, err := semver.ParseTolerant(strings.TrimPrefix(s, "v"))
+	if err != nil {
+		return semver.Version{}, false
+	}
+	return v, true
+}

--- a/tools/rebase-resolver/main_test.go
+++ b/tools/rebase-resolver/main_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const oursReleases = `{
+  "releases": [
+    {"version": "33.1.4", "isDeprecated": false, "releaseTimestamp": "2026-01-22T20:26:21Z", "changelogUrl": "x/v33.1.4", "isStable": true},
+    {"version": "33.2.0", "isDeprecated": false, "releaseTimestamp": "2026-04-21T13:45:36Z", "changelogUrl": "x/v33.2.0", "isStable": true}
+  ]
+}`
+
+const theirsReleases = `{
+  "releases": [
+    {"version": "33.1.4", "isDeprecated": false, "releaseTimestamp": "2026-01-22T20:26:21Z", "changelogUrl": "x/v33.1.4", "isStable": true},
+    {"version": "34.0.0", "isDeprecated": false, "releaseTimestamp": "2026-04-01T00:00:00Z", "changelogUrl": "x/v34.0.0", "isStable": true}
+  ]
+}`
+
+func TestMergeReleasesJSON_UnionAndSort(t *testing.T) {
+	merged, err := mergeReleasesJSON([]byte(oursReleases), []byte(theirsReleases))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got releasesFile
+	if err := json.Unmarshal(merged, &got); err != nil {
+		t.Fatalf("merged output is not valid JSON: %v", err)
+	}
+
+	versions := make([]string, len(got.Releases))
+	for i, r := range got.Releases {
+		versions[i] = r.Version
+	}
+	want := []string{"33.1.4", "33.2.0", "34.0.0"}
+	if !equalSlices(versions, want) {
+		t.Errorf("versions = %v, want %v", versions, want)
+	}
+}
+
+func TestMergeReleasesJSON_PrefersTheirsOnVersionCollision(t *testing.T) {
+	ours := `{"releases": [{"version": "1.0.0", "isDeprecated": false, "releaseTimestamp": "2020", "changelogUrl": "old", "isStable": false}]}`
+	theirs := `{"releases": [{"version": "1.0.0", "isDeprecated": true,  "releaseTimestamp": "2021", "changelogUrl": "new", "isStable": true}]}`
+
+	merged, err := mergeReleasesJSON([]byte(ours), []byte(theirs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got releasesFile
+	if err := json.Unmarshal(merged, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got.Releases) != 1 {
+		t.Fatalf("expected 1 entry after dedup, got %d", len(got.Releases))
+	}
+	r := got.Releases[0]
+	if r.ChangelogUrl != "new" || !r.IsDeprecated || !r.IsStable {
+		t.Errorf("expected theirs to win, got %+v", r)
+	}
+}
+
+func TestMergeReleasesJSON_SortsBySemverNotLex(t *testing.T) {
+	ours := `{"releases": [{"version": "9.0.0", "isDeprecated": false, "releaseTimestamp": "", "changelogUrl": "", "isStable": true}]}`
+	theirs := `{"releases": [{"version": "10.0.0", "isDeprecated": false, "releaseTimestamp": "", "changelogUrl": "", "isStable": true}]}`
+
+	merged, err := mergeReleasesJSON([]byte(ours), []byte(theirs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got releasesFile
+	_ = json.Unmarshal(merged, &got)
+	if got.Releases[0].Version != "9.0.0" || got.Releases[1].Version != "10.0.0" {
+		t.Errorf("semver sort wrong, got %s then %s", got.Releases[0].Version, got.Releases[1].Version)
+	}
+}
+
+const oursKustomization = `commonAnnotations:
+  giantswarm.io/docs: https://docs.example
+resources:
+- v33.1.4
+- v33.2.0
+transformers:
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+`
+
+const theirsKustomization = `commonAnnotations:
+  giantswarm.io/docs: https://docs.example
+resources:
+- v33.1.4
+- v34.0.0
+transformers:
+- |
+  apiVersion: builtin
+  kind: PrefixSuffixTransformer
+`
+
+func TestMergeKustomization_UnionAndSort(t *testing.T) {
+	merged, err := mergeKustomization([]byte(oursKustomization), []byte(theirsKustomization))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		CommonAnnotations map[string]string `yaml:"commonAnnotations"`
+		Resources         []string          `yaml:"resources"`
+		Transformers     []string          `yaml:"transformers"`
+	}
+	if err := yaml.Unmarshal(merged, &got); err != nil {
+		t.Fatalf("merged output is not valid YAML: %v\n%s", err, merged)
+	}
+
+	want := []string{"v33.1.4", "v33.2.0", "v34.0.0"}
+	if !equalSlices(got.Resources, want) {
+		t.Errorf("resources = %v, want %v", got.Resources, want)
+	}
+	if got.CommonAnnotations["giantswarm.io/docs"] != "https://docs.example" {
+		t.Errorf("commonAnnotations not preserved: %+v", got.CommonAnnotations)
+	}
+	if len(got.Transformers) != 1 || !strings.Contains(got.Transformers[0], "PrefixSuffixTransformer") {
+		t.Errorf("transformers not preserved: %+v", got.Transformers)
+	}
+}
+
+func TestMergeKustomization_PreservesColumnZeroListStyle(t *testing.T) {
+	// Matches the style used across giantswarm/releases kustomization files.
+	ours := "commonAnnotations:\n  giantswarm.io/docs: x\nresources:\n- v33.1.4\n- v33.2.0\ntransformers:\n- |\n  apiVersion: builtin\n"
+	theirs := "commonAnnotations:\n  giantswarm.io/docs: x\nresources:\n- v33.1.4\n- v34.0.0\ntransformers:\n- |\n  apiVersion: builtin\n"
+
+	merged, err := mergeKustomization([]byte(ours), []byte(theirs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := string(merged)
+	// The merged resources must be at column zero, not indented.
+	want := "resources:\n- v33.1.4\n- v33.2.0\n- v34.0.0\ntransformers:"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected column-zero list style preserved.\n--- want contains ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
+func TestMergeKustomization_DedupSameVersion(t *testing.T) {
+	ours := "resources:\n- v1.0.0\n- v2.0.0\n"
+	theirs := "resources:\n- v1.0.0\n- v2.0.0\n- v3.0.0\n"
+
+	merged, err := mergeKustomization([]byte(ours), []byte(theirs))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got struct {
+		Resources []string `yaml:"resources"`
+	}
+	_ = yaml.Unmarshal(merged, &got)
+	want := []string{"v1.0.0", "v2.0.0", "v3.0.0"}
+	if !equalSlices(got.Resources, want) {
+		t.Errorf("resources = %v, want %v", got.Resources, want)
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v9.0.0", "v10.0.0", true},
+		{"v10.0.0", "v9.0.0", false},
+		{"33.1.4", "33.2.0", true},
+		{"v33.2.0", "v34.0.0", true},
+		{"v34.0.0", "v34.0.0", false},
+	}
+	for _, c := range cases {
+		if got := semverLess(c.a, c.b); got != c.want {
+			t.Errorf("semverLess(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Adds a `/rebase` PR comment command that rebases the PR onto the base branch and auto-resolves merge conflicts in `*/releases.json` and `*/kustomization.yaml` by taking the union of entries and re-sorting by semver.

This removes the manual-rebase toil when a major release PR sits open while patches/minors land in between (e.g. #2215), and also covers drift from unrelated merges (Renovate, etc.).

Conflicts outside those two files abort the rebase — the PR is left untouched and the bot comments back.

- Resolver: `tools/rebase-resolver/` (own Go module, 6 unit tests + verified end-to-end against a simulated PR #2215-style conflict)
- Workflow: `.github/workflows/rebase.yaml` (MEMBER/OWNER/COLLABORATOR only, rejects fork PRs)