### PR TITLE
Fix duplicate release announcements in Slack

### DIFF
--- a/.github/workflows/publish-github-release.yaml
+++ b/.github/workflows/publish-github-release.yaml
@@ -115,6 +115,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Get provider lists
         id: providers
@@ -125,14 +127,35 @@ jobs:
         env:
           RELEASES: ${{ needs.get-releases.outputs.releases }}
           GH_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
         run: |
           DISPLAY_NAMES='${{ steps.providers.outputs.display_names }}'
+
+          # Only announce releases whose release.yaml was ADDED in the
+          # commits of this push. Subsequent pushes that only modify the
+          # same release.yaml (e.g. deprecate/archive) must not re-announce.
+          if [[ -z "$GITHUB_EVENT_BEFORE" || "$GITHUB_EVENT_BEFORE" =~ ^0+$ ]]; then
+            # workflow_dispatch or initial push: fall back to the HEAD commit.
+            RANGE="${GITHUB_SHA}^..${GITHUB_SHA}"
+          else
+            RANGE="${GITHUB_EVENT_BEFORE}..${GITHUB_SHA}"
+          fi
+
+          declare -A ADDED_RELEASES
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            ADDED_RELEASES["${f%/release.yaml}"]=1
+          done < <(git diff --name-only --diff-filter=A "$RANGE" -- ':(glob)*/v*.*.*/release.yaml' 2>/dev/null || true)
 
           # Group releases by version and collect provider display names
           declare -A VERSION_PROVIDERS
           declare -A VERSION_TAGS
 
           for release in $(echo "$RELEASES" | jq -r '.[]'); do
+            if [[ -z "${ADDED_RELEASES[$release]:-}" ]]; then
+              continue
+            fi
+
             dir_name="${release%/v*.*.*}"
             version="${release#${dir_name}/}"
 
@@ -141,23 +164,8 @@ jobs:
               continue
             fi
 
-            # Check if this release was actually created (not pre-existing)
             api_name=$(echo '${{ steps.providers.outputs.dir_to_api }}' | jq -r --arg d "$dir_name" '.[$d] // $d')
             tag="${api_name}/${version}"
-            created_at=$(gh release view "$tag" --json createdAt --jq '.createdAt' 2>/dev/null || echo "")
-
-            if [[ -z "$created_at" ]]; then
-              continue
-            fi
-
-            # Check if it was created recently (within the last 30 minutes)
-            created_ts=$(date -d "$created_at" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null || echo "0")
-            now_ts=$(date +%s)
-            age=$(( now_ts - created_ts ))
-            if [[ $age -gt 1800 ]]; then
-              continue
-            fi
-
             display=$(echo "$DISPLAY_NAMES" | jq -r --arg d "$dir_name" '.[$d] // $d')
 
             if [[ -n "${VERSION_PROVIDERS[$version]:-}" ]]; then


### PR DESCRIPTION
Fixes duplicate Slack announcements when a deprecate/archive PR merges shortly after a release PR.

**Cause**: `notify-news-product` announced any GitHub release whose `createdAt` was within a 30-minute wall-clock window. Every push to master that touched a `release.yaml` re-ran the job, and deprecate/archive PRs (which modify existing `release.yaml` files) re-announced the still-fresh release. This produced the 3x announcement seen for VMware Cloud Director v33.3.0 (PR #2267 → #2268 → #2269, all within 16 minutes).

**Fix**: Announce only releases whose `release.yaml` was *added* in the commits of the triggering push (`git diff --diff-filter=A "${before}..${sha}"`, with a `:(glob)` pathspec). Deprecate modifies existing files; archive uses git renames — neither produces an 'A' diff entry. Verified end-to-end against the real commits of PRs #2267, #2268, #2269 plus `workflow_dispatch` and initial-push fallbacks — all five scenarios produce the expected behavior.