### PR TITLE
tools/breakingchanges: flag apps whose Helm kubeVersion excludes target Kubernetes

### DIFF
--- a/.github/actions/create-controller-readiness-issues/action.yml
+++ b/.github/actions/create-controller-readiness-issues/action.yml
@@ -1,9 +1,6 @@
-name: 'Create Controller Readiness Issues'
-description: 'Creates controller readiness tracking issues for major releases and posts tracking comments on PRs'
+name: 'Create Team Readiness Issues'
+description: 'Creates per-team readiness tracking issues from team-issues.json (emitted by analyze-breaking-changes) and posts tracking comments on PRs'
 inputs:
-  providers:
-    description: 'Space-separated list of providers included in the release (e.g. "aws azure vsphere")'
-    required: true
   version:
     description: 'Release version (e.g. v35.0.0)'
     required: true
@@ -17,80 +14,53 @@ inputs:
     description: 'GitHub token with project write permissions (for adding issues to GitHub Projects)'
     required: false
     default: ''
+  team_issues_file:
+    description: 'Path to the team-issues.json emitted by analyze-breaking-changes'
+    required: false
+    default: 'tools/breakingchanges/team-issues.json'
 runs:
   using: "composite"
   steps:
-    - name: Create readiness issues and post tracking comments
+    - name: Create readiness issues from team-issues.json
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PROJECT_TOKEN: ${{ inputs.project_token }}
-        PROVIDERS: ${{ inputs.providers }}
         VERSION: ${{ inputs.version }}
         PR_NUMBERS: ${{ inputs.pr_numbers }}
+        TEAM_ISSUES_FILE: ${{ inputs.team_issues_file }}
       run: |
-        echo "Providers: $PROVIDERS | Version: $VERSION | PRs: $PR_NUMBERS"
+        set -euo pipefail
 
-        # =====================================================================
-        # CONFIGURATION — to add a provider or team, update the mappings below.
-        # =====================================================================
+        if [[ ! -f "$TEAM_ISSUES_FILE" ]]; then
+          echo "No $TEAM_ISSUES_FILE present — nothing to track."
+          exit 0
+        fi
+
+        TEAM_COUNT=$(jq '.teams | length' "$TEAM_ISSUES_FILE")
+        if [[ "$TEAM_COUNT" -eq 0 ]]; then
+          echo "team-issues.json has no teams — nothing to track."
+          exit 0
+        fi
+
+        echo "Processing $TEAM_COUNT team(s) for $VERSION"
 
         # GitHub Project #273 (giantswarm/roadmap)
         PROJECT_NODE_ID="PVT_kwDOAHNM9M4ABvWx"
         TEAM_FIELD_ID="PVTSSF_lADOAHNM9M4ABvWxzgBApUw"
 
-        # Provider → team mapping (eks excluded — no cloud controller manager)
-        declare -A PROVIDER_TEAM=(
-          [aws]="team-phoenix" [azure]="team-phoenix"
-          [vsphere]="team-rocket" [cloud-director]="team-rocket" [proxmox]="team-rocket"
-        )
-
-        # Team → GitHub label, Project team name
-        declare -A TEAM_LABEL=(
-          [team-phoenix]="team/phoenix" [team-rocket]="team/rocket"
-        )
-        declare -A TEAM_PROJECT_NAME=(
-          [team-phoenix]="Phoenix" [team-rocket]="Rocket"
-        )
-
-        # Provider → display name
-        declare -A PROVIDER_DISPLAY=(
-          [aws]="AWS" [azure]="Azure" [vsphere]="vSphere" [cloud-director]="Cloud Director" [proxmox]="Proxmox"
-        )
-
-        # Provider → controller apps that need updating per Kubernetes version (space-separated)
-        declare -A PROVIDER_APPS=(
-          [aws]="cloud-provider-aws"
-          [azure]="azure-cloud-controller-manager azure-cloud-node-manager"
-          [vsphere]="cloud-provider-vsphere"
-          [cloud-director]="cloud-provider-cloud-director"
-          [proxmox]="cloud-provider-proxmox"
-        )
-
-        # =====================================================================
-
-        # Build team → providers mapping from input
-        declare -A TEAM_PROVIDERS
-        for provider in $PROVIDERS; do
-          team="${PROVIDER_TEAM[$provider]:-}"
-          [[ -z "$team" ]] && echo "Skipping $provider — no controller readiness needed" && continue
-          TEAM_PROVIDERS["$team"]+="$provider "
-        done
-        [[ ${#TEAM_PROVIDERS[@]} -eq 0 ]] && echo "No teams need controller readiness issues." && exit 0
-
-        # Ensure labels exist
         RELEASE_LABEL="release/$VERSION"
-        gh label create "controller-readiness" --repo giantswarm/roadmap \
-          --description "Controller app readiness tracking for major releases" \
+        gh label create "app-readiness" --repo giantswarm/roadmap \
+          --description "App readiness tracking driven by breaking-changes analysis" \
           --color "C2E0C6" 2>/dev/null || true
         gh label create "$RELEASE_LABEL" --repo giantswarm/roadmap \
           --description "Related to release $VERSION" \
           --color "1D76DB" 2>/dev/null || true
 
-        # Add issue to GitHub Project #273 and set Team field.
-        # Uses PROJECT_TOKEN (ISSUE_AUTOMATION) which has project write permissions.
+        # Add issue to GitHub Project #273 and set Team field by partial-name match
+        # against the project's Team single-select options.
         add_to_project() {
-          local issue_number="$1" team_name="$2"
+          local issue_number="$1" team_short="$2"
           [[ -z "$PROJECT_TOKEN" ]] && echo "Warning: no project_token, skipping project integration" && return
 
           local node_id item_id option_id
@@ -109,8 +79,10 @@ runs:
           option_id=$(GH_TOKEN="$PROJECT_TOKEN" gh api graphql -f query='
             { organization(login: "giantswarm") { projectV2(number: 273) {
               field(name: "Team") { ... on ProjectV2SingleSelectField { options { id name } } }
-            }}}' --jq ".data.organization.projectV2.field.options[] | select(.name | contains(\"$team_name\")) | .id" 2>/dev/null) \
+            }}}' --jq ".data.organization.projectV2.field.options[] | select(.name | ascii_downcase | contains(\"$team_short\")) | .id" 2>/dev/null) \
             || { echo "Warning: could not look up Team option"; return; }
+
+          [[ -z "$option_id" ]] && echo "Warning: no project Team option matches '$team_short'" && return
 
           GH_TOKEN="$PROJECT_TOKEN" gh api graphql -f query='
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
@@ -120,81 +92,101 @@ runs:
               }) { projectV2Item { id } }
             }' -f projectId="$PROJECT_NODE_ID" -f itemId="$item_id" \
                -f fieldId="$TEAM_FIELD_ID" -f optionId="$option_id" 2>/dev/null \
-            && echo "Added to project #273, Team: $team_name" \
+            && echo "Added to project #273, Team: $team_short" \
             || echo "Warning: could not set Team field"
         }
 
-        # Process each team
-        TRACKING_ROWS=""
-        for team in "${!TEAM_PROVIDERS[@]}"; do
-          # Build display names and checklist
-          display_names=()
-          CHECKLIST=""
-          for provider in ${TEAM_PROVIDERS[$team]}; do
-            display_names+=("${PROVIDER_DISPLAY[$provider]:-$provider}")
-            for app in ${PROVIDER_APPS[$provider]}; do
-              CHECKLIST+="- [ ] \`$app\` — updated for Kubernetes in $VERSION"$'\n'
-            done
-          done
-          providers_display=$(IFS=', '; echo "${display_names[*]}")
-          echo "--- $team ($providers_display) ---"
+        # Build the new checklist body for a team. Apps already checked off in
+        # the existing issue stay checked when their finding is still present.
+        build_body() {
+          local team="$1" existing_body="$2"
+          local apps_json
+          apps_json=$(jq -c --arg team "$team" '.teams[] | select(.team == $team) | .apps' "$TEAM_ISSUES_FILE")
 
-          ISSUE_TITLE="Controller readiness: $providers_display Release $VERSION"
-          ISSUE_BODY="## Controller Readiness for $providers_display Release $VERSION
+          local checklist=""
+          while IFS= read -r app; do
+            local name version reason action checked
+            name=$(echo "$app" | jq -r '.name')
+            version=$(echo "$app" | jq -r '.version')
+            reason=$(echo "$app" | jq -r '.reason')
+            action=$(echo "$app" | jq -r '.action')
 
-        The major release **$VERSION** has been created. The following cloud controller apps need new versions compatible with the Kubernetes version in this release.
-
-        ### Apps to update
-
-        ${CHECKLIST}
-        ### Context
-
-        - Release PR: [giantswarm/releases#${PR_NUMBERS}](https://github.com/giantswarm/releases/pull/${PR_NUMBERS})
-        - Once all items are checked off and this issue is closed, the release PR will automatically receive a component bump to pick up the new controller versions."
-
-          # Deduplicate: check for existing issue (re-runs / individual matrix runs)
-          EXISTING=$(gh issue list --repo giantswarm/roadmap \
-            --label "controller-readiness" --label "${TEAM_LABEL[$team]}" --label "$RELEASE_LABEL" \
-            --state open --json number --jq '.[0].number')
-
-          if [[ -n "$EXISTING" ]]; then
-            ISSUE_NUMBER="$EXISTING"
-            # Update if any checklist items are missing (e.g. azure matrix run after aws created it)
-            EXISTING_BODY=$(gh issue view "$EXISTING" --repo giantswarm/roadmap --json body --jq '.body')
-            if echo "$ISSUE_BODY" | grep -F '- [ ]' | while read -r line; do
-              echo "$EXISTING_BODY" | grep -qF "$line" || exit 1
-            done; then
-              echo "Issue #$EXISTING already up to date."
-            else
-              echo "Updating issue #$EXISTING to include: $providers_display"
-              gh issue edit "$EXISTING" --repo giantswarm/roadmap --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
+            # Preserve checked state if this app appeared as checked in the existing body.
+            checked=" "
+            if echo "$existing_body" | grep -qE "^- \[x\] \`$name\`"; then
+              checked="x"
             fi
+            checklist+="- [$checked] \`$name\` v$version — $reason"$'\n'
+            checklist+="  - $action"$'\n'
+          done < <(echo "$apps_json" | jq -c '.[]')
+
+          cat <<EOF
+## App readiness for $VERSION
+
+These apps need attention before $VERSION can ship. Check off each one as it is bumped to a compatible version. The release PR will receive a component bump once this issue is closed.
+
+### Apps to update
+
+$checklist
+### Context
+
+- Release PR: [giantswarm/releases#${PR_NUMBERS}](https://github.com/giantswarm/releases/pull/${PR_NUMBERS})
+- Detection: \`tools/breakingchanges\` (Helm \`kubeVersion\` + implicit-coupling fallback)
+EOF
+        }
+
+        TRACKING_ROWS=""
+        # Iterate each team in the JSON.
+        while IFS= read -r team; do
+          # team handle from CODEOWNERS: e.g. "team-phoenix"
+          team_short="${team#team-}"             # "phoenix"
+          team_label="team/${team_short}"        # "team/phoenix"
+
+          ISSUE_TITLE="App readiness: ${team_short^} for $VERSION"
+
+          EXISTING=$(gh issue list --repo giantswarm/roadmap \
+            --label "app-readiness" --label "$team_label" --label "$RELEASE_LABEL" \
+            --state open --json number,body --jq '.[0]')
+
+          EXISTING_NUMBER=$(echo "$EXISTING" | jq -r '.number // empty')
+          EXISTING_BODY=$(echo "$EXISTING" | jq -r '.body // ""')
+
+          ISSUE_BODY=$(build_body "$team" "$EXISTING_BODY")
+
+          if [[ -n "$EXISTING_NUMBER" ]]; then
+            if [[ "$EXISTING_BODY" == "$ISSUE_BODY" ]]; then
+              echo "Issue giantswarm/roadmap#$EXISTING_NUMBER already up to date."
+            else
+              gh issue edit "$EXISTING_NUMBER" --repo giantswarm/roadmap --title "$ISSUE_TITLE" --body "$ISSUE_BODY"
+              echo "Updated giantswarm/roadmap#$EXISTING_NUMBER"
+            fi
+            ISSUE_NUMBER="$EXISTING_NUMBER"
           else
             ISSUE_URL=$(gh issue create --repo giantswarm/roadmap \
               --title "$ISSUE_TITLE" --body "$ISSUE_BODY" \
-              --label "controller-readiness" --label "${TEAM_LABEL[$team]}" --label "$RELEASE_LABEL")
+              --label "app-readiness" --label "$team_label" --label "$RELEASE_LABEL")
             ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
             echo "Created $ISSUE_URL"
-            add_to_project "$ISSUE_NUMBER" "${TEAM_PROJECT_NAME[$team]}"
+            add_to_project "$ISSUE_NUMBER" "$team_short"
           fi
 
-          TRACKING_ROWS+="| $team | $providers_display | giantswarm/roadmap#$ISSUE_NUMBER | open |"$'\n'
-        done
+          TRACKING_ROWS+="| $team | giantswarm/roadmap#$ISSUE_NUMBER | open |"$'\n'
+        done < <(jq -r '.teams[].team' "$TEAM_ISSUES_FILE")
 
-        # Post/update tracking comment on each release PR
-        TRACKING_COMMENT="<!-- CONTROLLER_READINESS_START -->
-        ## Controller readiness tracker
+        # Post/update tracking comment on each release PR.
+        TRACKING_COMMENT="<!-- APP_READINESS_START -->
+        ## App readiness tracker
 
-        | Team | Providers | Issue | Status |
-        |------|-----------|-------|--------|
-        ${TRACKING_ROWS}<!-- CONTROLLER_READINESS_END -->"
+        | Team | Issue | Status |
+        |------|-------|--------|
+        ${TRACKING_ROWS}<!-- APP_READINESS_END -->"
 
         IFS=',' read -ra PR_ARRAY <<< "$PR_NUMBERS"
         for pr in "${PR_ARRAY[@]}"; do
           pr=$(echo "$pr" | xargs)
           [[ -z "$pr" ]] && continue
           COMMENT_ID=$(gh api "repos/$GITHUB_REPOSITORY/issues/$pr/comments" --paginate \
-            --jq '.[] | select(.body | contains("CONTROLLER_READINESS_START")) | .id' | head -1)
+            --jq '.[] | select(.body | contains("APP_READINESS_START")) | .id' | head -1)
           if [[ -n "$COMMENT_ID" ]]; then
             gh api "repos/$GITHUB_REPOSITORY/issues/comments/$COMMENT_ID" -X PATCH -f body="$TRACKING_COMMENT"
             echo "Updated tracking comment on PR #$pr"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -544,11 +544,10 @@ jobs:
       # The check-controller-readiness workflow will post /update-release once controllers are ready,
       # and e2e tests will run after that component bump.
 
-      - name: Create controller readiness issues
+      - name: Create team readiness issues
         if: steps.create_pr.outputs.pull-request-number != '' && needs.dispatcher.outputs.is_manual != 'true'
         uses: ./.github/actions/create-controller-readiness-issues
         with:
-          providers: ${{ steps.filter_providers.outputs.filtered_providers }}
           version: ${{ steps.determine_next_release.outputs.version }}
           pr_numbers: ${{ steps.create_pr.outputs.pull-request-number }}
           github_token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}

--- a/tools/breakingchanges/cmd/detect/main.go
+++ b/tools/breakingchanges/cmd/detect/main.go
@@ -73,6 +73,28 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Emit team-grouped issue payload for the issue-creation workflow step.
+	// The K8s version is the same across consolidated providers, so any
+	// release's YAML works as the source.
+	var k8sVersion string
+	for _, r := range releases {
+		if v := breakingchanges.ExtractKubernetesVersion(r.YAML); v != "" {
+			k8sVersion = v
+			break
+		}
+	}
+	teamPayload := breakingchanges.BuildTeamIssuesPayload(allFindings, k8sVersion)
+	if len(teamPayload.Teams) > 0 {
+		payloadBytes, err := json.MarshalIndent(teamPayload, "", "  ")
+		if err != nil {
+			fmt.Printf("Warning: failed to marshal team-issues payload: %v\n", err)
+		} else if err := os.WriteFile("team-issues.json", payloadBytes, 0644); err != nil {
+			fmt.Printf("Warning: failed to write team-issues.json: %v\n", err)
+		} else {
+			fmt.Printf("Wrote team-issues.json with %d team(s)\n", len(teamPayload.Teams))
+		}
+	}
+
 	// Set GitHub Actions output (using environment file method)
 	githubOutput := os.Getenv("GITHUB_OUTPUT")
 	if githubOutput != "" {

--- a/tools/breakingchanges/pkg/app_compatibility.go
+++ b/tools/breakingchanges/pkg/app_compatibility.go
@@ -12,6 +12,21 @@ import (
 	"github.com/giantswarm/releases/sdk/api/v1alpha1"
 )
 
+// ExtractKubernetesVersion returns the target Kubernetes version declared in
+// a release.yaml. Empty string if it can't be parsed. Used by the cmd binary
+// to populate the JSON payload it writes for the issue-creation step.
+func ExtractKubernetesVersion(yamlContent string) string {
+	var rel v1alpha1.Release
+	if err := yaml.Unmarshal([]byte(yamlContent), &rel); err != nil {
+		return ""
+	}
+	v, err := rel.GetKubernetesVersion()
+	if err != nil {
+		return ""
+	}
+	return v
+}
+
 // implicitlyK8sCoupledApps lists apps known to need a new release for every
 // Kubernetes minor bump but which don't (yet) declare kubeVersion in their
 // chart. Each entry should be temporary: the long-term fix is to add a

--- a/tools/breakingchanges/pkg/app_compatibility.go
+++ b/tools/breakingchanges/pkg/app_compatibility.go
@@ -3,6 +3,7 @@ package breakingchanges
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -10,6 +11,19 @@ import (
 
 	"github.com/giantswarm/releases/sdk/api/v1alpha1"
 )
+
+// implicitlyK8sCoupledApps lists apps known to need a new release for every
+// Kubernetes minor bump but which don't (yet) declare kubeVersion in their
+// chart. Each entry should be temporary: the long-term fix is to add a
+// kubeVersion declaration to the corresponding chart and remove the entry.
+var implicitlyK8sCoupledApps = map[string]bool{
+	"cloud-provider-aws":             true,
+	"azure-cloud-controller-manager": true,
+	"azure-cloud-node-manager":       true,
+	"cloud-provider-vsphere":         true,
+	"cloud-provider-cloud-director":  true,
+	"cloud-provider-proxmox":         true,
+}
 
 // App Kubernetes-compatibility check.
 //
@@ -71,43 +85,138 @@ func (d *Detector) checkAppKubernetesCompatibility(ctx context.Context, release 
 		return nil
 	}
 
-	fmt.Printf("\nChecking app kubeVersion compatibility against Kubernetes v%s...\n", target.String())
+	// Detect whether this release crosses a Kubernetes minor boundary.
+	// The fallback list (implicitlyK8sCoupledApps) only fires on minor bumps
+	// since cloud-controllers don't need a new release for a patch upgrade.
+	isMinorBump := false
+	for _, vc := range extractKubernetesVersion(release.README) {
+		fromMinor := parseK8sMinorVersion(vc.FromVersion)
+		toMinor := parseK8sMinorVersion(vc.ToVersion)
+		if fromMinor != 0 && toMinor != 0 && fromMinor != toMinor {
+			isMinorBump = true
+		}
+		break
+	}
+
+	fmt.Printf("\nChecking app kubeVersion compatibility against Kubernetes v%s (minor bump: %v)...\n", target.String(), isMinorBump)
 
 	var findings []Finding
 	for _, app := range rel.Spec.Apps {
-		findings = append(findings, d.checkAppCharts(ctx, app, target)...)
+		findings = append(findings, d.checkAppCharts(ctx, app, target, isMinorBump)...)
 	}
 	fmt.Printf("✓ App compatibility check complete: %d finding(s)\n", len(findings))
 	return findings
 }
 
-func (d *Detector) checkAppCharts(ctx context.Context, app v1alpha1.ReleaseSpecApp, target *semver.Version) []Finding {
+func (d *Detector) checkAppCharts(ctx context.Context, app v1alpha1.ReleaseSpecApp, target *semver.Version, isK8sMinorBump bool) []Finding {
 	chart := d.fetchGSAppChart(ctx, app.Name, app.Version)
-	if chart == nil {
-		return nil
-	}
 
 	var findings []Finding
-	if chart.KubeVersion != "" {
+	hasDeclaredConstraint := false
+
+	if chart != nil && chart.KubeVersion != "" {
+		hasDeclaredConstraint = true
 		if f := evaluateKubeVersionConstraint(chart.KubeVersion, target, app.Name, app.Version, "Helm chart kubeVersion (giantswarm app)"); f != nil {
 			findings = append(findings, *f)
 		}
 	}
-	for _, dep := range chart.Dependencies {
-		if !isExternalHelmRepo(dep.Repository) {
-			continue
-		}
-		depKubeVer := d.fetchUpstreamKubeVersion(ctx, dep.Repository, dep.Name, dep.Version)
-		if depKubeVer == "" {
-			continue
-		}
-		component := fmt.Sprintf("%s (upstream %s)", app.Name, dep.Name)
-		source := fmt.Sprintf("Upstream chart kubeVersion (%s %s from %s)", dep.Name, dep.Version, dep.Repository)
-		if f := evaluateKubeVersionConstraint(depKubeVer, target, component, dep.Version, source); f != nil {
-			findings = append(findings, *f)
+	if chart != nil {
+		for _, dep := range chart.Dependencies {
+			if !isExternalHelmRepo(dep.Repository) {
+				continue
+			}
+			depKubeVer := d.fetchUpstreamKubeVersion(ctx, dep.Repository, dep.Name, dep.Version)
+			if depKubeVer == "" {
+				continue
+			}
+			hasDeclaredConstraint = true
+			component := fmt.Sprintf("%s (upstream %s)", app.Name, dep.Name)
+			source := fmt.Sprintf("Upstream chart kubeVersion (%s %s from %s)", dep.Name, dep.Version, dep.Repository)
+			if f := evaluateKubeVersionConstraint(depKubeVer, target, component, dep.Version, source); f != nil {
+				findings = append(findings, *f)
+			}
 		}
 	}
+
+	// Fallback for apps known to be implicitly coupled to Kubernetes that
+	// don't (yet) declare kubeVersion. Only fires on minor bumps.
+	if !hasDeclaredConstraint && isK8sMinorBump && implicitlyK8sCoupledApps[app.Name] {
+		findings = append(findings, makeImplicitlyCoupledFinding(app, target))
+	}
+
+	// Resolve owning team for any findings produced for this app.
+	if len(findings) > 0 {
+		team := d.fetchAppTeam(ctx, app.Name)
+		for i := range findings {
+			findings[i].Team = team
+			findings[i].AppName = app.Name
+		}
+	}
+
 	return findings
+}
+
+// makeImplicitlyCoupledFinding produces a finding for an app on the implicit
+// fallback list when no declared kubeVersion was found and the release crosses
+// a Kubernetes minor.
+func makeImplicitlyCoupledFinding(app v1alpha1.ReleaseSpecApp, target *semver.Version) Finding {
+	return Finding{
+		Severity:    "high",
+		Component:   app.Name,
+		Title:       fmt.Sprintf("`%s` v%s needs a new release for Kubernetes v%s", app.Name, app.Version, target.String()),
+		Description: fmt.Sprintf("`%s` is implicitly coupled to Kubernetes (no declared `kubeVersion`) and a new release is required for every Kubernetes minor bump.", app.Name),
+		Impact:      fmt.Sprintf("Cluster components managed by `%s` may not function correctly on Kubernetes v%s.", app.Name, target.String()),
+		Action:      fmt.Sprintf("Bump `%s` to a release built against Kubernetes v%s; long-term, add a `kubeVersion` to the chart so this fallback can be removed.", app.Name, target.String()),
+		Confidence:  "high",
+		Source:      "Implicit Kubernetes coupling (fallback list)",
+		RawText:     fmt.Sprintf("app %s has no declared kubeVersion", app.Name),
+	}
+}
+
+// fetchAppTeam looks up the owning team for an app by reading CODEOWNERS in
+// the giantswarm app repo. The first @giantswarm/team-* handle wins (the GS
+// convention is one team per repo). Returns "" when no team can be resolved.
+func (d *Detector) fetchAppTeam(ctx context.Context, appName string) string {
+	if cached, ok := d.teamCache[appName]; ok {
+		return cached
+	}
+
+	for _, repo := range d.candidateRepositories(appName) {
+		for _, branch := range []string{"main", "master"} {
+			for _, path := range []string{"CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"} {
+				url := fmt.Sprintf("https://raw.githubusercontent.com/giantswarm/%s/%s/%s", repo, branch, path)
+				body, err := d.fetchURL(ctx, url)
+				if err != nil {
+					continue
+				}
+				if team := parseCodeownersTeam(body); team != "" {
+					d.teamCache[appName] = team
+					return team
+				}
+			}
+		}
+	}
+
+	d.teamCache[appName] = ""
+	return ""
+}
+
+// codeownersTeamRe matches the first @giantswarm/team-* handle on a line.
+var codeownersTeamRe = regexp.MustCompile(`@giantswarm/(team-[A-Za-z0-9_-]+)`)
+
+// parseCodeownersTeam extracts the first @giantswarm/team-* handle from a
+// CODEOWNERS file body. Comment lines and blank lines are skipped.
+func parseCodeownersTeam(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if match := codeownersTeamRe.FindStringSubmatch(trimmed); len(match) >= 2 {
+			return match[1]
+		}
+	}
+	return ""
 }
 
 // evaluateKubeVersionConstraint returns a Finding when the chart's kubeVersion

--- a/tools/breakingchanges/pkg/app_compatibility.go
+++ b/tools/breakingchanges/pkg/app_compatibility.go
@@ -1,0 +1,246 @@
+package breakingchanges
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/releases/sdk/api/v1alpha1"
+)
+
+// App Kubernetes-compatibility check.
+//
+// For every app in release.yaml we read the Helm chart's `kubeVersion` field
+// (a Helm primitive) and evaluate it against the release's target Kubernetes
+// version. We also walk one level of `dependencies:` so that giantswarm app
+// charts which wrap an upstream chart (cilium-app -> upstream cilium) are
+// covered via the upstream's own declaration.
+//
+// Apps whose chart does not declare a kubeVersion are silently skipped —
+// without an authoritative declaration there is no trustworthy signal to
+// surface. This avoids needing a hand-maintained whitelist of "K8s-coupled"
+// apps: charts that care declare it, charts that don't, won't.
+
+type chartYAML struct {
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	KubeVersion  string            `json:"kubeVersion,omitempty"`
+	Dependencies []chartDependency `json:"dependencies,omitempty"`
+}
+
+type chartDependency struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	Repository string `json:"repository"`
+}
+
+type helmIndexEntry struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	KubeVersion string `json:"kubeVersion,omitempty"`
+}
+
+type helmIndex struct {
+	Entries map[string][]helmIndexEntry `json:"entries"`
+}
+
+// checkAppKubernetesCompatibility evaluates every app in the release against
+// the target Kubernetes version using declared Helm kubeVersion constraints.
+func (d *Detector) checkAppKubernetesCompatibility(ctx context.Context, release Release) []Finding {
+	if strings.TrimSpace(release.YAML) == "" {
+		return nil
+	}
+
+	var rel v1alpha1.Release
+	if err := yaml.Unmarshal([]byte(release.YAML), &rel); err != nil {
+		fmt.Printf("Warning: parse release.yaml for %s/%s: %v\n", release.Provider, release.Version, err)
+		return nil
+	}
+
+	targetStr, err := rel.GetKubernetesVersion()
+	if err != nil {
+		fmt.Printf("Warning: get kubernetes version: %v\n", err)
+		return nil
+	}
+	target, err := semver.NewVersion(strings.TrimPrefix(targetStr, "v"))
+	if err != nil {
+		fmt.Printf("Warning: parse target kubernetes version %q: %v\n", targetStr, err)
+		return nil
+	}
+
+	fmt.Printf("\nChecking app kubeVersion compatibility against Kubernetes v%s...\n", target.String())
+
+	var findings []Finding
+	for _, app := range rel.Spec.Apps {
+		findings = append(findings, d.checkAppCharts(ctx, app, target)...)
+	}
+	fmt.Printf("✓ App compatibility check complete: %d finding(s)\n", len(findings))
+	return findings
+}
+
+func (d *Detector) checkAppCharts(ctx context.Context, app v1alpha1.ReleaseSpecApp, target *semver.Version) []Finding {
+	chart := d.fetchGSAppChart(ctx, app.Name, app.Version)
+	if chart == nil {
+		return nil
+	}
+
+	var findings []Finding
+	if chart.KubeVersion != "" {
+		if f := evaluateKubeVersionConstraint(chart.KubeVersion, target, app.Name, app.Version, "Helm chart kubeVersion (giantswarm app)"); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	for _, dep := range chart.Dependencies {
+		if !isExternalHelmRepo(dep.Repository) {
+			continue
+		}
+		depKubeVer := d.fetchUpstreamKubeVersion(ctx, dep.Repository, dep.Name, dep.Version)
+		if depKubeVer == "" {
+			continue
+		}
+		component := fmt.Sprintf("%s (upstream %s)", app.Name, dep.Name)
+		source := fmt.Sprintf("Upstream chart kubeVersion (%s %s from %s)", dep.Name, dep.Version, dep.Repository)
+		if f := evaluateKubeVersionConstraint(depKubeVer, target, component, dep.Version, source); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings
+}
+
+// evaluateKubeVersionConstraint returns a Finding when the chart's kubeVersion
+// constraint does not include the target Kubernetes version. A nil return
+// means the chart explicitly supports the target.
+func evaluateKubeVersionConstraint(kubeVersion string, target *semver.Version, component, version, source string) *Finding {
+	constraint, err := semver.NewConstraint(kubeVersion)
+	if err != nil {
+		return &Finding{
+			Severity:    "low",
+			Component:   component,
+			Title:       fmt.Sprintf("Could not parse Helm kubeVersion constraint for %s", component),
+			Description: fmt.Sprintf("kubeVersion %q failed to parse as a semver constraint.", kubeVersion),
+			Impact:      "Compatibility with the target Kubernetes version could not be verified automatically.",
+			Action:      fmt.Sprintf("Verify manually that `%s` v%s supports Kubernetes v%s.", component, version, target.String()),
+			Confidence:  "low",
+			Source:      source,
+			RawText:     fmt.Sprintf("kubeVersion: %q", kubeVersion),
+		}
+	}
+
+	if ok, _ := constraint.Validate(target); ok {
+		return nil
+	}
+
+	return &Finding{
+		Severity:    "high",
+		Component:   component,
+		Title:       fmt.Sprintf("`%s` v%s does not declare support for Kubernetes v%s", component, version, target.String()),
+		Description: fmt.Sprintf("Helm chart `kubeVersion` `%q` does not include target Kubernetes v%s.", kubeVersion, target.String()),
+		Impact:      fmt.Sprintf("Helm may refuse to deploy `%s` on Kubernetes v%s, or the chart may rely on APIs unavailable on this version.", component, target.String()),
+		Action:      fmt.Sprintf("Bump `%s` to a version whose chart supports Kubernetes v%s, or wait for a compatible upstream release.", component, target.String()),
+		Confidence:  "high",
+		Source:      source,
+		RawText:     fmt.Sprintf("kubeVersion: %q", kubeVersion),
+	}
+}
+
+// isExternalHelmRepo returns true for HTTP(S) Helm repositories. Same-cluster
+// (catalog: cluster) and oci:// references are skipped: cluster-catalog charts
+// are covered by GS component diffs and OCI registries don't expose index.yaml.
+func isExternalHelmRepo(repo string) bool {
+	return strings.HasPrefix(repo, "http://") || strings.HasPrefix(repo, "https://")
+}
+
+// fetchGSAppChart resolves the giantswarm app chart for a given app name and
+// version. The repo name is taken from devctl mappings when available and
+// falls back to the conventional `<name>-app` and `<name>` patterns.
+func (d *Detector) fetchGSAppChart(ctx context.Context, appName, appVersion string) *chartYAML {
+	cacheKey := fmt.Sprintf("%s@%s", appName, appVersion)
+	if cached, ok := d.chartCache[cacheKey]; ok {
+		return cached
+	}
+
+	repoCandidates := d.candidateRepositories(appName)
+	chartDirCandidates := []string{appName, appName + "-app"}
+
+	for _, repo := range repoCandidates {
+		for _, chartDir := range chartDirCandidates {
+			url := fmt.Sprintf("https://raw.githubusercontent.com/giantswarm/%s/v%s/helm/%s/Chart.yaml",
+				repo, appVersion, chartDir)
+			body, err := d.fetchURL(ctx, url)
+			if err != nil {
+				continue
+			}
+			var c chartYAML
+			if err := yaml.Unmarshal([]byte(body), &c); err != nil {
+				continue
+			}
+			d.chartCache[cacheKey] = &c
+			return &c
+		}
+	}
+
+	fmt.Printf("  → Could not locate Chart.yaml for app %s v%s — skipping\n", appName, appVersion)
+	d.chartCache[cacheKey] = nil
+	return nil
+}
+
+// candidateRepositories returns the GitHub repo names to try for a given app.
+// devctl mappings (already loaded by the detector) are authoritative; the
+// `<name>-app` and `<name>` patterns cover everything else.
+func (d *Detector) candidateRepositories(appName string) []string {
+	var candidates []string
+	if mapping, ok := d.componentMappings[appName]; ok && mapping.RepositoryName != "" {
+		candidates = append(candidates, mapping.RepositoryName)
+	}
+	candidates = appendUniqueRepo(candidates, appName+"-app")
+	candidates = appendUniqueRepo(candidates, appName)
+	return candidates
+}
+
+func appendUniqueRepo(slice []string, val string) []string {
+	for _, s := range slice {
+		if s == val {
+			return slice
+		}
+	}
+	return append(slice, val)
+}
+
+// fetchUpstreamKubeVersion fetches index.yaml from a Helm repository and
+// returns the kubeVersion declared by the entry matching depName + depVersion.
+// Returns "" when no kubeVersion is declared or the index can't be parsed.
+func (d *Detector) fetchUpstreamKubeVersion(ctx context.Context, repoURL, depName, depVersion string) string {
+	indexURL := strings.TrimRight(repoURL, "/") + "/index.yaml"
+
+	index, ok := d.helmIndexCache[indexURL]
+	if !ok {
+		body, err := d.fetchURL(ctx, indexURL)
+		if err != nil {
+			fmt.Printf("  → Could not fetch helm index %s: %v\n", indexURL, err)
+			d.helmIndexCache[indexURL] = nil
+			return ""
+		}
+		var parsed helmIndex
+		if err := yaml.Unmarshal([]byte(body), &parsed); err != nil {
+			fmt.Printf("  → Could not parse helm index %s: %v\n", indexURL, err)
+			d.helmIndexCache[indexURL] = nil
+			return ""
+		}
+		index = &parsed
+		d.helmIndexCache[indexURL] = index
+	}
+	if index == nil {
+		return ""
+	}
+
+	targetVer := strings.TrimPrefix(depVersion, "v")
+	for _, e := range index.Entries[depName] {
+		if strings.TrimPrefix(e.Version, "v") == targetVer {
+			return e.KubeVersion
+		}
+	}
+	return ""
+}

--- a/tools/breakingchanges/pkg/app_compatibility_test.go
+++ b/tools/breakingchanges/pkg/app_compatibility_test.go
@@ -105,6 +105,81 @@ func TestParseCodeownersTeam(t *testing.T) {
 	}
 }
 
+func TestBuildTeamIssuesPayload(t *testing.T) {
+	findings := []FindingWithProvider{
+		{
+			Finding: Finding{
+				Severity: "high",
+				Title:    "`cilium` v1.3.4 does not declare support for Kubernetes v1.35.0",
+				Action:   "Bump cilium",
+				Team:     "team-cabbage",
+				AppName:  "cilium",
+			},
+			Provider: "aws",
+			Version:  "v35.0.0",
+		},
+		{
+			// Same app+team as above from a different provider — should dedupe.
+			Finding: Finding{
+				Severity: "high",
+				Title:    "`cilium` v1.3.4 does not declare support for Kubernetes v1.35.0",
+				Action:   "Bump cilium",
+				Team:     "team-cabbage",
+				AppName:  "cilium",
+			},
+			Provider: "azure",
+			Version:  "v35.0.0",
+		},
+		{
+			Finding: Finding{
+				Severity: "high",
+				Title:    "`cloud-provider-aws` v2.0.0 needs a new release for Kubernetes v1.35.0",
+				Action:   "Bump cloud-provider-aws",
+				Team:     "team-phoenix",
+				AppName:  "cloud-provider-aws",
+			},
+			Provider: "aws",
+			Version:  "v35.0.0",
+		},
+		{
+			// Finding without team — should be excluded.
+			Finding: Finding{
+				Severity:  "high",
+				Title:     "Kubernetes 1.35 deprecates v1beta1 FlowSchema",
+				Component: "Kubernetes",
+			},
+			Provider: "aws",
+			Version:  "v35.0.0",
+		},
+	}
+
+	payload := BuildTeamIssuesPayload(findings, "1.35.0")
+
+	if payload.KubernetesVersion != "1.35.0" {
+		t.Errorf("KubernetesVersion = %q, want %q", payload.KubernetesVersion, "1.35.0")
+	}
+	if payload.Version != "v35.0.0" {
+		t.Errorf("Version = %q, want %q", payload.Version, "v35.0.0")
+	}
+	if len(payload.Teams) != 2 {
+		t.Fatalf("Teams length = %d, want 2 (cabbage + phoenix)", len(payload.Teams))
+	}
+
+	// Sorted alphabetically: cabbage, phoenix
+	if payload.Teams[0].Team != "team-cabbage" {
+		t.Errorf("Teams[0] = %q, want team-cabbage", payload.Teams[0].Team)
+	}
+	if len(payload.Teams[0].Apps) != 1 {
+		t.Errorf("team-cabbage apps = %d, want 1 (deduped)", len(payload.Teams[0].Apps))
+	}
+	if payload.Teams[0].Apps[0].Version != "1.3.4" {
+		t.Errorf("cilium version = %q, want 1.3.4", payload.Teams[0].Apps[0].Version)
+	}
+	if payload.Teams[1].Team != "team-phoenix" {
+		t.Errorf("Teams[1] = %q, want team-phoenix", payload.Teams[1].Team)
+	}
+}
+
 func TestImplicitlyK8sCoupledAppsContainsCloudControllers(t *testing.T) {
 	required := []string{
 		"cloud-provider-aws",

--- a/tools/breakingchanges/pkg/app_compatibility_test.go
+++ b/tools/breakingchanges/pkg/app_compatibility_test.go
@@ -1,0 +1,71 @@
+package breakingchanges
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestEvaluateKubeVersionConstraint(t *testing.T) {
+	target := semver.MustParse("1.35.0")
+
+	cases := []struct {
+		name        string
+		kubeVersion string
+		wantFinding bool
+		wantSev     string
+	}{
+		{
+			name:        "open-ended supports target",
+			kubeVersion: ">= 1.21.0-0",
+			wantFinding: false,
+		},
+		{
+			name:        "upper bound excludes target",
+			kubeVersion: ">= 1.27.0-0 < 1.34.0-0",
+			wantFinding: true,
+			wantSev:     "high",
+		},
+		{
+			name:        "explicit minor range includes target",
+			kubeVersion: ">= 1.34.0-0 < 1.36.0-0",
+			wantFinding: false,
+		},
+		{
+			name:        "unparseable surfaces as low-confidence info",
+			kubeVersion: "this is not a constraint",
+			wantFinding: true,
+			wantSev:     "low",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := evaluateKubeVersionConstraint(tc.kubeVersion, target, "test-app", "1.0.0", "test")
+			if tc.wantFinding && f == nil {
+				t.Fatalf("expected a finding, got nil")
+			}
+			if !tc.wantFinding && f != nil {
+				t.Fatalf("expected no finding, got %+v", f)
+			}
+			if tc.wantFinding && f.Severity != tc.wantSev {
+				t.Errorf("severity = %q, want %q", f.Severity, tc.wantSev)
+			}
+		})
+	}
+}
+
+func TestIsExternalHelmRepo(t *testing.T) {
+	cases := map[string]bool{
+		"https://helm.cilium.io": true,
+		"http://charts.example":  true,
+		"oci://ghcr.io/x/y":      false,
+		"":                       false,
+		"file://./local-chart":   false,
+	}
+	for in, want := range cases {
+		if got := isExternalHelmRepo(in); got != want {
+			t.Errorf("isExternalHelmRepo(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/tools/breakingchanges/pkg/app_compatibility_test.go
+++ b/tools/breakingchanges/pkg/app_compatibility_test.go
@@ -55,6 +55,72 @@ func TestEvaluateKubeVersionConstraint(t *testing.T) {
 	}
 }
 
+func TestParseCodeownersTeam(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "single team",
+			content: "* @giantswarm/team-phoenix",
+			want:    "team-phoenix",
+		},
+		{
+			name: "skips comments and blank lines",
+			content: `# Owners
+# of this repo
+
+* @giantswarm/team-rocket
+`,
+			want: "team-rocket",
+		},
+		{
+			name:    "scoped path before team",
+			content: "/helm/ @giantswarm/team-cabbage",
+			want:    "team-cabbage",
+		},
+		{
+			name:    "first non-comment line wins",
+			content: "*.go @giantswarm/team-phoenix\n*.md @giantswarm/team-rocket",
+			want:    "team-phoenix",
+		},
+		{
+			name:    "no giantswarm team handle",
+			content: "* @some-user",
+			want:    "",
+		},
+		{
+			name:    "empty",
+			content: "",
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseCodeownersTeam(tc.content); got != tc.want {
+				t.Errorf("parseCodeownersTeam = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImplicitlyK8sCoupledAppsContainsCloudControllers(t *testing.T) {
+	required := []string{
+		"cloud-provider-aws",
+		"azure-cloud-controller-manager",
+		"azure-cloud-node-manager",
+		"cloud-provider-vsphere",
+		"cloud-provider-cloud-director",
+		"cloud-provider-proxmox",
+	}
+	for _, app := range required {
+		if !implicitlyK8sCoupledApps[app] {
+			t.Errorf("expected %q in implicitlyK8sCoupledApps fallback", app)
+		}
+	}
+}
+
 func TestIsExternalHelmRepo(t *testing.T) {
 	cases := map[string]bool{
 		"https://helm.cilium.io": true,

--- a/tools/breakingchanges/pkg/detector.go
+++ b/tools/breakingchanges/pkg/detector.go
@@ -18,11 +18,13 @@ type Detector struct {
 	componentMappingDone bool
 
 	// Caches to avoid redundant fetches in consolidated PRs
-	flatcarCache     map[string]string // "fromVer->toVer" -> changelog
-	kubernetesCache  map[string]string // "fromVer->toVer" -> changelog
-	componentCache   map[string]string // "component@fromVer->toVer" -> diff
-	etcdVersionCache map[string]string // k8sVersion -> etcdVersion (from kubeadm constants)
-	etcdCache        map[string]string // "fromEtcd->toEtcd" -> filtered changelog
+	flatcarCache     map[string]string     // "fromVer->toVer" -> changelog
+	kubernetesCache  map[string]string     // "fromVer->toVer" -> changelog
+	componentCache   map[string]string     // "component@fromVer->toVer" -> diff
+	etcdVersionCache map[string]string     // k8sVersion -> etcdVersion (from kubeadm constants)
+	etcdCache        map[string]string     // "fromEtcd->toEtcd" -> filtered changelog
+	chartCache       map[string]*chartYAML // "app@version" -> parsed Chart.yaml (nil = negative cache)
+	helmIndexCache   map[string]*helmIndex // index.yaml URL -> parsed index (nil = negative cache)
 }
 
 // NewDetector creates a new Detector instance
@@ -43,6 +45,8 @@ func NewDetector(anthropicAPIKey, githubToken string) (*Detector, error) {
 		componentCache:       make(map[string]string),
 		etcdVersionCache:     make(map[string]string),
 		etcdCache:            make(map[string]string),
+		chartCache:           make(map[string]*chartYAML),
+		helmIndexCache:       make(map[string]*helmIndex),
 	}, nil
 }
 
@@ -136,6 +140,19 @@ func (d *Detector) AnalyzeMultipleReleases(ctx context.Context, releases []Relea
 		}
 	}
 
+	// Append deterministic app/Helm-chart kubeVersion findings per release.
+	// These don't go through the LLM — they're hard facts derived from the
+	// Chart.yaml the release pins.
+	for _, release := range releases {
+		for _, f := range d.checkAppKubernetesCompatibility(ctx, release) {
+			findingsWithProviders = append(findingsWithProviders, FindingWithProvider{
+				Finding:  f,
+				Provider: release.Provider,
+				Version:  release.Version,
+			})
+		}
+	}
+
 	fmt.Printf("\n✓ Consolidated analysis complete. Found %d breaking change(s) affecting %d provider(s)\n",
 		len(findings), len(releases))
 
@@ -168,6 +185,9 @@ func (d *Detector) AnalyzeRelease(ctx context.Context, release Release) ([]Findi
 
 	// Send to LLM for analysis
 	findings := d.analyzeAndAnnotateFindings(ctx, analysisContext, release)
+
+	// Append deterministic app/Helm-chart kubeVersion findings.
+	findings = append(findings, d.checkAppKubernetesCompatibility(ctx, release)...)
 
 	fmt.Printf("\n✓ Analysis complete. Found %d breaking change(s)\n", len(findings))
 	return findings, nil

--- a/tools/breakingchanges/pkg/detector.go
+++ b/tools/breakingchanges/pkg/detector.go
@@ -25,6 +25,7 @@ type Detector struct {
 	etcdCache        map[string]string     // "fromEtcd->toEtcd" -> filtered changelog
 	chartCache       map[string]*chartYAML // "app@version" -> parsed Chart.yaml (nil = negative cache)
 	helmIndexCache   map[string]*helmIndex // index.yaml URL -> parsed index (nil = negative cache)
+	teamCache        map[string]string     // app name -> owning team (from CODEOWNERS, "" = unknown)
 }
 
 // NewDetector creates a new Detector instance
@@ -47,6 +48,7 @@ func NewDetector(anthropicAPIKey, githubToken string) (*Detector, error) {
 		etcdCache:            make(map[string]string),
 		chartCache:           make(map[string]*chartYAML),
 		helmIndexCache:       make(map[string]*helmIndex),
+		teamCache:            make(map[string]string),
 	}, nil
 }
 

--- a/tools/breakingchanges/pkg/report.go
+++ b/tools/breakingchanges/pkg/report.go
@@ -422,7 +422,11 @@ func formatGroupedFinding(index int, gf GroupedFinding) string {
 	}
 
 	sb.WriteString(fmt.Sprintf("#### %d. %s\n\n", index, f.Title))
-	sb.WriteString(fmt.Sprintf("`%s`%s\n\n", f.Component, confidence))
+	teamBadge := ""
+	if f.Team != "" {
+		teamBadge = fmt.Sprintf(" · owner: `%s`", f.Team)
+	}
+	sb.WriteString(fmt.Sprintf("`%s`%s%s\n\n", f.Component, teamBadge, confidence))
 
 	// Description
 	if f.Description != "" {

--- a/tools/breakingchanges/pkg/team_issues.go
+++ b/tools/breakingchanges/pkg/team_issues.go
@@ -1,0 +1,118 @@
+package breakingchanges
+
+import "sort"
+
+// TeamIssuesPayload is the JSON shape consumed by the issue-creation workflow
+// step. It is emitted by the breakingchanges tool so the action only has to
+// render markdown — the detection logic stays in Go.
+type TeamIssuesPayload struct {
+	Version           string       `json:"version"`            // Release version (any of the analyzed releases — used for label-based dedupe)
+	KubernetesVersion string       `json:"kubernetes_version"` // Target Kubernetes version
+	Teams             []TeamIssues `json:"teams"`              // One entry per team with at least one finding
+}
+
+// TeamIssues is the per-team grouping in the payload.
+type TeamIssues struct {
+	Team string             `json:"team"` // CODEOWNERS-resolved team handle (e.g. "team-phoenix")
+	Apps []TeamIssuesAppRef `json:"apps"` // Apps owned by this team that need attention
+}
+
+// TeamIssuesAppRef is a single app on a team's checklist.
+type TeamIssuesAppRef struct {
+	Name     string `json:"name"`     // App name (release.yaml app name)
+	Version  string `json:"version"`  // Currently pinned version
+	Severity string `json:"severity"` // critical/high/medium/low
+	Reason   string `json:"reason"`   // Short explanation (taken from the Finding title)
+	Action   string `json:"action"`   // Recommended action
+}
+
+// BuildTeamIssuesPayload turns the raw FindingWithProvider list into a
+// team-grouped, app-deduplicated payload suitable for issue creation. Any
+// finding without a Team field is excluded — those don't have an owner to
+// route to. Apps are deduplicated per team (multiple providers sharing the
+// same app produce one checklist item per team).
+func BuildTeamIssuesPayload(findings []FindingWithProvider, kubernetesVersion string) TeamIssuesPayload {
+	type appKey struct{ team, app string }
+	seen := make(map[appKey]bool)
+	teamApps := make(map[string][]TeamIssuesAppRef)
+
+	var version string
+	for _, fwp := range findings {
+		f := fwp.Finding
+		if f.Team == "" || f.AppName == "" {
+			continue
+		}
+		key := appKey{team: f.Team, app: f.AppName}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		if version == "" {
+			version = fwp.Version
+		}
+
+		teamApps[f.Team] = append(teamApps[f.Team], TeamIssuesAppRef{
+			Name:     f.AppName,
+			Version:  versionFromFinding(f),
+			Severity: f.Severity,
+			Reason:   f.Title,
+			Action:   f.Action,
+		})
+	}
+
+	teams := make([]TeamIssues, 0, len(teamApps))
+	for team, apps := range teamApps {
+		sort.Slice(apps, func(i, j int) bool { return apps[i].Name < apps[j].Name })
+		teams = append(teams, TeamIssues{Team: team, Apps: apps})
+	}
+	sort.Slice(teams, func(i, j int) bool { return teams[i].Team < teams[j].Team })
+
+	return TeamIssuesPayload{
+		Version:           version,
+		KubernetesVersion: kubernetesVersion,
+		Teams:             teams,
+	}
+}
+
+// versionFromFinding tries to extract the app version from the finding's
+// raw text or component. The kubeVersion findings contain the version in the
+// title (e.g. "`cilium` v1.3.4 does not declare ..."). Fall back to "" so the
+// caller renders something sensible.
+func versionFromFinding(f Finding) string {
+	// The Title carries "`<app>` v<version>" — extract the v<version> token.
+	// Keep it simple; if extraction fails, return empty and let the consumer
+	// omit the version from its output.
+	parts := splitOnFirst(f.Title, " v")
+	if len(parts) < 2 {
+		return ""
+	}
+	rest := parts[1]
+	// Stop at first space or backtick to isolate the version token.
+	for i, r := range rest {
+		if r == ' ' || r == '`' {
+			return rest[:i]
+		}
+	}
+	return rest
+}
+
+func splitOnFirst(s, sep string) []string {
+	idx := indexOf(s, sep)
+	if idx < 0 {
+		return []string{s}
+	}
+	return []string{s[:idx], s[idx+len(sep):]}
+}
+
+func indexOf(s, sub string) int {
+	if len(sub) == 0 || len(sub) > len(s) {
+		return -1
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/tools/breakingchanges/pkg/types.go
+++ b/tools/breakingchanges/pkg/types.go
@@ -1,15 +1,17 @@
 package breakingchanges
 
 type Finding struct {
-	Severity    string `json:"severity"`    // critical, high, medium, low
-	Component   string `json:"component"`   // e.g., "flatcar", "kubernetes", "cluster-azure"
-	Title       string `json:"title"`       // Brief description
-	Description string `json:"description"` // Detailed explanation
-	Impact      string `json:"impact"`      // Who/what is affected
-	Action      string `json:"action"`      // What users need to do
-	Confidence  string `json:"confidence"`  // high, medium, low
-	Source      string `json:"source"`      // Where this was found
-	RawText     string `json:"raw_text"`    // Original text that triggered detection
+	Severity    string `json:"severity"`       // critical, high, medium, low
+	Component   string `json:"component"`      // e.g., "flatcar", "kubernetes", "cluster-azure"
+	Title       string `json:"title"`          // Brief description
+	Description string `json:"description"`    // Detailed explanation
+	Impact      string `json:"impact"`         // Who/what is affected
+	Action      string `json:"action"`         // What users need to do
+	Confidence  string `json:"confidence"`     // high, medium, low
+	Source      string `json:"source"`         // Where this was found
+	RawText     string `json:"raw_text"`       // Original text that triggered detection
+	Team        string `json:"team,omitempty"` // Owning team (resolved from CODEOWNERS), set for app-compat findings
+	AppName     string `json:"app,omitempty"`  // App name (set for app-compat findings, used for team grouping)
 }
 
 type Release struct {
@@ -34,4 +36,3 @@ type ComponentMapping struct {
 	ChangelogURL   string // URL template for CHANGELOG
 	TagURL         string // URL template for releases
 }
-


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4208

Flags apps whose Helm `kubeVersion` excludes the target Kubernetes (incl. one level of upstream chart dependencies). Findings carry the owning team (CODEOWNERS) and drive the readiness action: one roadmap issue per team, replacing the hardcoded provider/team/apps tables. Cloud-controllers without a declared `kubeVersion` are covered by a small fallback list that fires on K8s minor bumps.