### PR TITLE
Use TAYLORBOT_GITHUB_ACTION for installations checkout in announce-release

### DIFF
--- a/.github/workflows/announce-release.yaml
+++ b/.github/workflows/announce-release.yaml
@@ -59,7 +59,7 @@ jobs:
     outputs:
       provider_channels: ${{ steps.collect.outputs.provider_channels }}
     env:
-      GH_TOKEN: ${{ secrets.ANNOUNCE_NOTIFY_TOKEN }}
+      GH_TOKEN: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
     steps:
       - name: Checkout installations code
         uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
           repository: giantswarm/installations
           path: installations
           ref: master
-          token: ${{ secrets.ANNOUNCE_NOTIFY_TOKEN }}
+          token: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}
       - name: Collect channels
         id: collect
         run: |


### PR DESCRIPTION
`ANNOUNCE_NOTIFY_TOKEN` was a PAT belonging to a user who has left the org, so the workflow can no longer read `giantswarm/installations` and fails at the checkout step. Switch to the org-level `TAYLORBOT_GITHUB_ACTION` secret, owned by the bot already running release automation.