### PR TITLE
CAPI: Release v34.4.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ to all Giant Swarm installations.
 ## AWS
 
 - v34
+  - v34.4
+    - [v34.4.0](https://github.com/giantswarm/releases/tree/master/capa/v34.4.0)
   - v34.3
     - [v34.3.0](https://github.com/giantswarm/releases/tree/master/capa/v34.3.0)
   - v34.2
@@ -178,6 +180,8 @@ to all Giant Swarm installations.
 ## Azure
 
 - v34
+  - v34.4
+    - [v34.4.0](https://github.com/giantswarm/releases/tree/master/azure/v34.4.0)
   - v34.3
     - [v34.3.0](https://github.com/giantswarm/releases/tree/master/azure/v34.3.0)
   - v34.2
@@ -371,6 +375,8 @@ to all Giant Swarm installations.
 ## vSphere
 
 - v34
+  - v34.4
+    - [v34.4.0](https://github.com/giantswarm/releases/tree/master/vsphere/v34.4.0)
   - v34.3
     - [v34.3.0](https://github.com/giantswarm/releases/tree/master/vsphere/v34.3.0)
   - v34.2

--- a/azure/kustomization.yaml
+++ b/azure/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - v34.1.0
 - v34.2.0
 - v34.3.0
+- v34.4.0
 transformers:
 - |
   apiVersion: builtin

--- a/azure/releases.json
+++ b/azure/releases.json
@@ -41,6 +41,13 @@
       "releaseTimestamp": "2026-05-13T05:30:19Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v34.3.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.4.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-06-02T16:37:01Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/azure/v34.4.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/azure/v34.4.0/README.md
+++ b/azure/v34.4.0/README.md
@@ -1,0 +1,21 @@
+# :zap: Giant Swarm Release v34.4.0 for Azure :zap:
+
+## Changes compared to v34.3.0
+
+### Components
+
+- cluster-azure from v5.4.1 to v5.4.2
+- cluster from v5.3.1 to v5.3.2
+- Flatcar from v4593.2.1 to [v4593.2.2](https://www.flatcar.org/releases/#release-4593.2.2)
+
+### cluster-azure [v5.4.1...v5.4.2](https://github.com/giantswarm/cluster-azure/compare/v5.4.1...v5.4.2)
+
+#### Changed
+
+- Chart: Fix validation errors.
+
+### cluster [v5.3.1...v5.3.2](https://github.com/giantswarm/cluster/compare/v5.3.1...v5.3.2)
+
+#### Changed
+
+- Chart: Fix validation errors.

--- a/azure/v34.4.0/announcement.md
+++ b/azure/v34.4.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.4.0 for Azure is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-azure/releases/azure-34.4.0).

--- a/azure/v34.4.0/kustomization.yaml
+++ b/azure/v34.4.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/azure/v34.4.0/release.diff
+++ b/azure/v34.4.0/release.diff
@@ -1,0 +1,129 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: azure-34.3.0                                            |    name: azure-34.4.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: azure-cloud-controller-manager                             - name: azure-cloud-controller-manager
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager                                   - name: azure-cloud-node-manager
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver                                       - name: azuredisk-csi-driver
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: azurefile-csi-driver                                       - name: azurefile-csi-driver
+    version: 2.0.0                                                     version: 2.0.0
+    dependsOn:                                                         dependsOn:
+    - azure-cloud-controller-manager                                   - azure-cloud-controller-manager
+    - azure-cloud-node-manager                                         - azure-cloud-node-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.10.1                                                    version: 2.10.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.13.0                                                    version: 3.13.0
+    dependsOn:                                                         dependsOn:
+    - alloy-logs                                                       - alloy-logs
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.3                                                     version: 1.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.4.3                                                     version: 1.4.3
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.4                                                     version: 0.1.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: coredns                                                    - name: coredns
+    version: 1.30.0                                                    version: 1.30.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.6                                                     version: 1.2.6
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.14                                                   version: 1.10.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.4.0                                                     version: 3.4.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.13                                                   version: 0.10.13
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.11.0                                                    version: 2.11.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.1                                                    version: 1.23.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.11                                                   version: 1.20.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.4                                                     version: 0.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: priority-classes                                           - name: priority-classes
+    version: 0.3.1                                                     version: 0.3.1
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.7.0                                                     version: 0.7.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.17.1                                                    version: 1.17.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.8                                                    version: 0.10.8
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.2                                                     version: 6.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.2                                                     version: 4.1.2
+  components:                                                        components:
+  - name: cluster-azure                                              - name: cluster-azure
+    catalog: cluster                                                   catalog: cluster
+    version: 5.4.1                                              |      version: 5.4.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4593.2.1                                           |      version: 4593.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.34.7                                                    version: 1.34.7
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.31.0                                                    version: 1.31.0
+  date: "2026-05-13T07:30:19Z"                                  |    date: "2026-06-02T16:37:01Z"
+  state: active                                                      state: active

--- a/azure/v34.4.0/release.yaml
+++ b/azure/v34.4.0/release.yaml
@@ -1,0 +1,129 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: azure-34.4.0
+spec:
+  apps:
+  - name: azure-cloud-controller-manager
+    version: 2.1.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azure-cloud-node-manager
+    version: 2.1.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: azuredisk-csi-driver
+    version: 2.1.0
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: azurefile-csi-driver
+    version: 2.0.0
+    dependsOn:
+    - azure-cloud-controller-manager
+    - azure-cloud-node-manager
+  - name: cert-exporter
+    version: 2.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.13.0
+    dependsOn:
+    - alloy-logs
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.4.3
+  - name: cilium-servicemonitors
+    version: 0.1.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: coredns
+    version: 1.30.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.6
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.14
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.13
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.11.0
+    dependsOn:
+    - kyverno-crds
+  - name: metrics-server
+    version: 2.8.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.11
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.8.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.1
+  - name: prometheus-blackbox-exporter
+    version: 0.7.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.17.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.8
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2
+  components:
+  - name: cluster-azure
+    catalog: cluster
+    version: 5.4.2
+  - name: flatcar
+    version: 4593.2.2
+  - name: kubernetes
+    version: 1.34.7
+  - name: os-tooling
+    version: 1.31.0
+  date: "2026-06-02T16:37:01Z"
+  state: active

--- a/capa/kustomization.yaml
+++ b/capa/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - v34.1.0
 - v34.1.1
 - v34.3.0
+- v34.4.0
 transformers:
 - |
   apiVersion: builtin

--- a/capa/releases.json
+++ b/capa/releases.json
@@ -90,6 +90,13 @@
       "releaseTimestamp": "2026-05-13T05:31:09Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v34.3.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.4.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-06-02T16:36:59Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/capa/v34.4.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/capa/v34.4.0/README.md
+++ b/capa/v34.4.0/README.md
@@ -1,0 +1,21 @@
+# :zap: Giant Swarm Release v34.4.0 for CAPA :zap:
+
+## Changes compared to v34.3.0
+
+### Components
+
+- cluster-aws from v7.7.1 to v7.7.2
+- cluster from v5.3.1 to v5.3.2
+- Flatcar from v4593.2.1 to [v4593.2.2](https://www.flatcar.org/releases/#release-4593.2.2)
+
+### cluster-aws [v7.7.1...v7.7.2](https://github.com/giantswarm/cluster-aws/compare/v7.7.1...v7.7.2)
+
+#### Changed
+
+- Chart: Fix validation errors.
+
+### cluster [v5.3.1...v5.3.2](https://github.com/giantswarm/cluster/compare/v5.3.1...v5.3.2)
+
+#### Changed
+
+- Chart: Fix validation errors.

--- a/capa/v34.4.0/announcement.md
+++ b/capa/v34.4.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.4.0 for CAPA is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-capa/releases/aws-34.4.0).

--- a/capa/v34.4.0/kustomization.yaml
+++ b/capa/v34.4.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/capa/v34.4.0/release.diff
+++ b/capa/v34.4.0/release.diff
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: aws-34.3.0                                              |    name: aws-34.4.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
+    version: 4.1.2                                                     version: 4.1.2
+    dependsOn:                                                         dependsOn:
+    - cloud-provider-aws                                               - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.2                                                     version: 0.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: aws-nth-bundle                                             - name: aws-nth-bundle
+    version: 1.4.0                                                     version: 1.4.0
+  - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
+    version: 2.2.0                                                     version: 2.2.0
+    dependsOn:                                                         dependsOn:
+    - cert-manager                                                     - cert-manager
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.10.1                                                    version: 2.10.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.13.0                                                    version: 3.13.0
+    dependsOn:                                                         dependsOn:
+    - alloy-logs                                                       - alloy-logs
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.1                                                     version: 0.1.1
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.3                                                     version: 1.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.4.3                                                     version: 1.4.3
+  - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
+    catalog: cluster                                                   catalog: cluster
+    version: 0.2.1                                                     version: 0.2.1
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.4                                                     version: 0.1.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-aws                                         - name: cloud-provider-aws
+    version: 2.1.0                                                     version: 2.1.0
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler                                         - name: cluster-autoscaler
+    version: 1.34.3-2                                                  version: 1.34.3-2
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: coredns                                                    - name: coredns
+    version: 1.30.0                                                    version: 1.30.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.6                                                     version: 1.2.6
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.14                                                   version: 1.10.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: external-dns                                               - name: external-dns
+    version: 3.4.0                                                     version: 3.4.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: irsa-servicemonitors                                       - name: irsa-servicemonitors
+    version: 0.1.1                                                     version: 0.1.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: k8s-audit-metrics                                          - name: k8s-audit-metrics
+    version: 0.10.13                                                   version: 0.10.13
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.11.0                                                    version: 2.11.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: karpenter                                                  - name: karpenter
+    version: 2.3.0                                                     version: 2.3.0
+  - name: karpenter-crossplane-resources                             - name: karpenter-crossplane-resources
+    version: 0.5.1                                                     version: 0.5.1
+  - name: karpenter-taint-remover                                    - name: karpenter-taint-remover
+    version: 1.0.2                                                     version: 1.0.2
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.1                                                    version: 1.23.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.11                                                   version: 1.20.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: node-problem-detector                                      - name: node-problem-detector
+    version: 0.5.2                                                     version: 0.5.2
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.4                                                     version: 0.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: priority-classes                                           - name: priority-classes
+    version: 0.3.1                                                     version: 0.3.1
+  - name: prometheus-blackbox-exporter                               - name: prometheus-blackbox-exporter
+    version: 0.7.0                                                     version: 0.7.0
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.17.1                                                    version: 1.17.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.8                                                    version: 0.10.8
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.2                                                     version: 6.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.2                                                     version: 4.1.2
+  components:                                                        components:
+  - name: cluster-aws                                                - name: cluster-aws
+    catalog: cluster                                                   catalog: cluster
+    version: 7.7.1                                              |      version: 7.7.2
+  - name: flatcar                                                    - name: flatcar
+    version: 4593.2.1                                           |      version: 4593.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.34.7                                                    version: 1.34.7
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.31.0                                                    version: 1.31.0
+  date: "2026-05-13T07:31:09Z"                                  |    date: "2026-06-02T16:36:59Z"
+  state: active                                                      state: active

--- a/capa/v34.4.0/release.yaml
+++ b/capa/v34.4.0/release.yaml
@@ -1,0 +1,151 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aws-34.4.0
+spec:
+  apps:
+  - name: aws-ebs-csi-driver
+    version: 4.1.2
+    dependsOn:
+    - cloud-provider-aws
+  - name: aws-ebs-csi-driver-servicemonitors
+    version: 0.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: aws-nth-bundle
+    version: 1.4.0
+  - name: aws-pod-identity-webhook
+    version: 2.2.0
+    dependsOn:
+    - cert-manager
+  - name: cert-exporter
+    version: 2.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.13.0
+    dependsOn:
+    - alloy-logs
+    - prometheus-operator-crd
+  - name: cert-manager-crossplane-resources
+    catalog: cluster
+    version: 0.1.1
+  - name: chart-operator-extensions
+    version: 1.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.4.3
+  - name: cilium-crossplane-resources
+    catalog: cluster
+    version: 0.2.1
+  - name: cilium-servicemonitors
+    version: 0.1.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-aws
+    version: 2.1.0
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: cluster-autoscaler
+    version: 1.34.3-2
+    dependsOn:
+    - kyverno-crds
+  - name: coredns
+    version: 1.30.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.6
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.14
+    dependsOn:
+    - kyverno-crds
+  - name: external-dns
+    version: 3.4.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: irsa-servicemonitors
+    version: 0.1.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.13
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.11.0
+    dependsOn:
+    - kyverno-crds
+  - name: karpenter
+    version: 2.3.0
+  - name: karpenter-crossplane-resources
+    version: 0.5.1
+  - name: karpenter-taint-remover
+    version: 1.0.2
+  - name: metrics-server
+    version: 2.8.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.11
+    dependsOn:
+    - kyverno-crds
+  - name: node-problem-detector
+    version: 0.5.2
+  - name: observability-bundle
+    version: 2.8.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.1
+  - name: prometheus-blackbox-exporter
+    version: 0.7.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.17.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.8
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2
+  components:
+  - name: cluster-aws
+    catalog: cluster
+    version: 7.7.2
+  - name: flatcar
+    version: 4593.2.2
+  - name: kubernetes
+    version: 1.34.7
+  - name: os-tooling
+    version: 1.31.0
+  date: "2026-06-02T16:36:59Z"
+  state: active

--- a/vsphere/kustomization.yaml
+++ b/vsphere/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - v34.1.1
 - v34.2.0
 - v34.3.0
+- v34.4.0
 transformers:
 - |
   apiVersion: builtin

--- a/vsphere/releases.json
+++ b/vsphere/releases.json
@@ -41,6 +41,13 @@
       "releaseTimestamp": "2026-05-13T05:30:45Z",
       "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v34.3.0/README.md",
       "isStable": true
+    },
+    {
+      "version": "34.4.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-06-02T16:37:02Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/vsphere/v34.4.0/README.md",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/giantswarm/releases",

--- a/vsphere/v34.4.0/README.md
+++ b/vsphere/v34.4.0/README.md
@@ -1,0 +1,21 @@
+# :zap: Giant Swarm Release v34.4.0 for vSphere :zap:
+
+## Changes compared to v34.3.0
+
+### Components
+
+- cluster-vsphere from v5.1.3 to v5.1.4
+- cluster from v5.3.1 to v5.3.2
+- Flatcar from v4593.2.1 to [v4593.2.2](https://www.flatcar.org/releases/#release-4593.2.2)
+
+### cluster-vsphere [v5.1.3...v5.1.4](https://github.com/giantswarm/cluster-vsphere/compare/v5.1.3...v5.1.4)
+
+#### Changed
+
+- Chart: Fix validation errors.
+
+### cluster [v5.3.1...v5.3.2](https://github.com/giantswarm/cluster/compare/v5.3.1...v5.3.2)
+
+#### Changed
+
+- Chart: Fix validation errors.

--- a/vsphere/v34.4.0/announcement.md
+++ b/vsphere/v34.4.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v34.4.0 for vSphere is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-vsphere/releases/vsphere-34.4.0).

--- a/vsphere/v34.4.0/kustomization.yaml
+++ b/vsphere/v34.4.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/vsphere/v34.4.0/release.diff
+++ b/vsphere/v34.4.0/release.diff
@@ -1,0 +1,115 @@
+apiVersion: release.giantswarm.io/v1alpha1                         apiVersion: release.giantswarm.io/v1alpha1
+kind: Release                                                      kind: Release
+metadata:                                                          metadata:
+  name: vsphere-34.3.0                                          |    name: vsphere-34.4.0
+spec:                                                              spec:
+  apps:                                                              apps:
+  - name: cert-exporter                                              - name: cert-exporter
+    version: 2.10.1                                                    version: 2.10.1
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: cert-manager                                               - name: cert-manager
+    version: 3.13.0                                                    version: 3.13.0
+    dependsOn:                                                         dependsOn:
+    - alloy-logs                                                       - alloy-logs
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: chart-operator-extensions                                  - name: chart-operator-extensions
+    version: 1.1.3                                                     version: 1.1.3
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cilium                                                     - name: cilium
+    version: 1.4.3                                                     version: 1.4.3
+  - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
+    version: 0.1.4                                                     version: 0.1.4
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: cloud-provider-vsphere                                     - name: cloud-provider-vsphere
+    version: 2.4.0                                                     version: 2.4.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns                                                    - name: coredns
+    version: 1.30.0                                                    version: 1.30.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: coredns-extensions                                         - name: coredns-extensions
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - vertical-pod-autoscaler-crd                                      - vertical-pod-autoscaler-crd
+  - name: etcd-defrag                                                - name: etcd-defrag
+    version: 1.2.6                                                     version: 1.2.6
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: etcd-k8s-res-count-exporter                                - name: etcd-k8s-res-count-exporter
+    version: 1.10.14                                                   version: 1.10.14
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: k8s-dns-node-cache                                         - name: k8s-dns-node-cache
+    version: 2.11.0                                                    version: 2.11.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: kube-vip                                                   - name: kube-vip
+    version: 0.3.0                                                     version: 0.3.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: kube-vip-cloud-provider                                    - name: kube-vip-cloud-provider
+    version: 0.3.0                                                     version: 0.3.0
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: metrics-server                                             - name: metrics-server
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: net-exporter                                               - name: net-exporter
+    version: 1.23.1                                                    version: 1.23.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: network-policies                                           - name: network-policies
+    catalog: cluster                                                   catalog: cluster
+    version: 0.1.3                                                     version: 0.1.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  - name: node-exporter                                              - name: node-exporter
+    version: 1.20.11                                                   version: 1.20.11
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: observability-bundle                                       - name: observability-bundle
+    version: 2.8.0                                                     version: 2.8.0
+    dependsOn:                                                         dependsOn:
+    - coredns                                                          - coredns
+  - name: observability-policies                                     - name: observability-policies
+    version: 0.0.4                                                     version: 0.0.4
+    dependsOn:                                                         dependsOn:
+    - kyverno-crds                                                     - kyverno-crds
+  - name: priority-classes                                           - name: priority-classes
+    version: 0.3.1                                                     version: 0.3.1
+  - name: security-bundle                                            - name: security-bundle
+    catalog: giantswarm                                                catalog: giantswarm
+    version: 1.17.1                                                    version: 1.17.1
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: teleport-kube-agent                                        - name: teleport-kube-agent
+    version: 0.10.8                                                    version: 0.10.8
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler                                    - name: vertical-pod-autoscaler
+    version: 6.1.2                                                     version: 6.1.2
+    dependsOn:                                                         dependsOn:
+    - prometheus-operator-crd                                          - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd                                - name: vertical-pod-autoscaler-crd
+    version: 4.1.2                                                     version: 4.1.2
+  - name: vsphere-csi-driver                                         - name: vsphere-csi-driver
+    version: 3.4.3                                                     version: 3.4.3
+    dependsOn:                                                         dependsOn:
+    - cilium                                                           - cilium
+  components:                                                        components:
+  - name: cluster-vsphere                                            - name: cluster-vsphere
+    catalog: cluster                                                   catalog: cluster
+    version: 5.1.3                                              |      version: 5.1.4
+  - name: flatcar                                                    - name: flatcar
+    version: 4593.2.1                                           |      version: 4593.2.2
+  - name: kubernetes                                                 - name: kubernetes
+    version: 1.34.7                                                    version: 1.34.7
+  - name: os-tooling                                                 - name: os-tooling
+    version: 1.31.0                                                    version: 1.31.0
+  date: "2026-05-13T07:30:45Z"                                  |    date: "2026-06-02T16:37:02Z"
+  state: active                                                      state: active

--- a/vsphere/v34.4.0/release.yaml
+++ b/vsphere/v34.4.0/release.yaml
@@ -1,0 +1,115 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: vsphere-34.4.0
+spec:
+  apps:
+  - name: cert-exporter
+    version: 2.10.1
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.13.0
+    dependsOn:
+    - alloy-logs
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium
+    version: 1.4.3
+  - name: cilium-servicemonitors
+    version: 0.1.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cloud-provider-vsphere
+    version: 2.4.0
+    dependsOn:
+    - cilium
+  - name: coredns
+    version: 1.30.0
+    dependsOn:
+    - cilium
+  - name: coredns-extensions
+    version: 0.1.3
+    dependsOn:
+    - vertical-pod-autoscaler-crd
+  - name: etcd-defrag
+    version: 1.2.6
+    dependsOn:
+    - kyverno-crds
+  - name: etcd-k8s-res-count-exporter
+    version: 1.10.14
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.11.0
+    dependsOn:
+    - kyverno-crds
+  - name: kube-vip
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: kube-vip-cloud-provider
+    version: 0.3.0
+    dependsOn:
+    - cilium
+  - name: metrics-server
+    version: 2.8.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.23.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.1.3
+    dependsOn:
+    - cilium
+  - name: node-exporter
+    version: 1.20.11
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.8.0
+    dependsOn:
+    - coredns
+  - name: observability-policies
+    version: 0.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.1
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.17.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.10.8
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2
+  - name: vsphere-csi-driver
+    version: 3.4.3
+    dependsOn:
+    - cilium
+  components:
+  - name: cluster-vsphere
+    catalog: cluster
+    version: 5.1.4
+  - name: flatcar
+    version: 4593.2.2
+  - name: kubernetes
+    version: 1.34.7
+  - name: os-tooling
+    version: 1.31.0
+  date: "2026-06-02T16:37:02Z"
+  state: active


### PR DESCRIPTION
```sh
for provider version in aws 7.7.2 azure 5.4.2 vsphere 5.1.4
do
  devctl release create \
    --provider "${provider}" \
    --base 34.3.0 \
    --name 34.4.0 \
    --component "cluster-${provider}@${version}" \
    --component flatcar@4593.2.2 \
    --overwrite \
    --yes
done
```