### PR TITLE
feat: create new AKS release v35.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,10 @@ to all Giant Swarm installations.
 
 ## AKS
 
+- v35
+  - v35.0
+    - [v35.0.0](https://github.com/giantswarm/releases/tree/master/aks/v35.0.0)
+
 # PR Commands
 
 ## Summarize Upstream Changes

--- a/aks/kustomization.yaml
+++ b/aks/kustomization.yaml
@@ -1,6 +1,7 @@
 commonAnnotations:
   giantswarm.io/docs: https://docs.giantswarm.io/use-the-api/management-api/crd/releases.release.giantswarm.io
-resources: []
+resources:
+- v35.0.0
 transformers:
 - |
   apiVersion: builtin

--- a/aks/releases.json
+++ b/aks/releases.json
@@ -1,0 +1,14 @@
+{
+  "releases": [
+    {
+      "version": "35.0.0",
+      "isDeprecated": false,
+      "releaseTimestamp": "2026-06-18T16:37:01Z",
+      "changelogUrl": "https://github.com/giantswarm/releases/blob/master/aks/v35.0.0/README.md",
+      "isStable": true
+    }
+  ],
+  "sourceUrl": "https://github.com/giantswarm/releases",
+  "changelogUrl": "https://github.com/giantswarm/releases/blob/main/README.md",
+  "homepage": "https://giantswarm.io"
+}

--- a/aks/v35.0.0/README.md
+++ b/aks/v35.0.0/README.md
@@ -1,3 +1,3 @@
 # :zap: Giant Swarm Release v35.0.0 for AKS :zap:
 
-We are pleased to announce the first release for AKS which uses the release framework.
+This is first Giant Swarm release supporting deployment of AKS Workload Clusters with kubernetes v35 series.

--- a/aks/v35.0.0/README.md
+++ b/aks/v35.0.0/README.md
@@ -1,0 +1,3 @@
+# :zap: Giant Swarm Release v35.0.0 for AKS :zap:
+
+We are pleased to announce the first release for AKS which uses the release framework.

--- a/aks/v35.0.0/announcement.md
+++ b/aks/v35.0.0/announcement.md
@@ -1,3 +1,5 @@
 **Workload cluster release v35.0.0 for AKS is available**.
 
+This is first Giant Swarm release supporting deployment of AKS Workload Clusters with kubernetes v35 series.
+
 Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aks/releases/aks-35.0.0).

--- a/aks/v35.0.0/announcement.md
+++ b/aks/v35.0.0/announcement.md
@@ -1,0 +1,3 @@
+**Workload cluster release v35.0.0 for AKS is available**.
+
+Further details can be found in the [release notes](https://docs.giantswarm.io/changes/workload-cluster-releases-aks/releases/aks-35.0.0).

--- a/aks/v35.0.0/kustomization.yaml
+++ b/aks/v35.0.0/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- release.yaml
+
+replacements:
+- source:
+    group: release.giantswarm.io
+    kind: Release
+    fieldPath: metadata.name
+    options:
+      delimiter: "-"
+      index: 1
+  targets:
+  - select:
+      group: release.giantswarm.io
+      kind: Release
+    fieldPaths:
+    - metadata.annotations.[giantswarm.io/release-notes]
+    options:
+      create: true

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -27,6 +27,9 @@ spec:
     version: 3.5.0
     dependsOn:
     - prometheus-operator-crd
+  - name: external-dns-crossplane-resources
+    version: 0.2.1-dev.external-dn--ad-identity.2026-07-14.09-31-39.h2b7b02b
+    catalog: default
   - name: k8s-audit-metrics
     version: 0.10.13
     dependsOn:
@@ -76,7 +79,7 @@ spec:
   components:
   - name: cluster-aks
     catalog: cluster
-    version: 0.2.0
+    version: 0.2.1-dev.external-dn--ad-identity.2026-07-14.12-30-40.h0350444
   - name: kubernetes
     version: 1.35.5
   date: "2026-06-18T16:37:01Z"

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -4,100 +4,100 @@ metadata:
   name: aks-35.0.0
 spec:
   apps:
-    - catalog: default
+    - name: cert-exporter
+      catalog: default
+      version: 2.11.0
       dependsOn:
         - kyverno-crds
-      name: cert-exporter
-      version: 2.11.0
-    - catalog: default
+    - name: cert-manager
+      catalog: default
+      version: 3.13.0
       dependsOn:
         - alloy-logs
         - prometheus-operator-crd
-      name: cert-manager
-      version: 3.13.0
-    - catalog: default
-      dependsOn:
-        - prometheus-operator-crd
-      name: chart-operator-extensions
+    - name: chart-operator-extensions
+      catalog: default
       version: 1.1.3
-    - catalog: default
       dependsOn:
         - prometheus-operator-crd
-      name: cilium-servicemonitors
+    - name: cilium-servicemonitors
+      catalog: default
       version: 0.1.4
-    - catalog: default
-      name: azure-aks-extras
+      dependsOn:
+        - prometheus-operator-crd
+    - name: azure-aks-extras
+      catalog: default
       version: 0.1.0
-    - catalog: default
-      dependsOn:
-        - prometheus-operator-crd
-      name: external-dns
+    - name: external-dns
+      catalog: default
       version: 3.5.0
-    - catalog: default
       dependsOn:
-        - kyverno-crds
-      name: k8s-audit-metrics
+        - prometheus-operator-crd
+    - name: k8s-audit-metrics
+      catalog: default
       version: 0.10.13
-    - catalog: default
       dependsOn:
         - kyverno-crds
-      name: k8s-dns-node-cache
+    - name: k8s-dns-node-cache
+      catalog: default
       version: 2.11.0
-    - catalog: default
       dependsOn:
-        - prometheus-operator-crd
-      name: net-exporter
+        - kyverno-crds
+    - name: net-exporter
+      catalog: default
       version: 1.24.0
-    - catalog: cluster
-      name: network-policies
-      version: 0.2.0
-    - catalog: default
-      dependsOn:
-        - kyverno-crds
-      name: node-exporter
-      version: 1.20.11
-    - catalog: default
-      name: observability-bundle
-      version: 2.9.1
-    - catalog: default
-      dependsOn:
-        - kyverno-crds
-      name: observability-policies
-      version: 0.0.4
-    - catalog: default
-      name: priority-classes
-      version: 0.3.1
-    - catalog: default
       dependsOn:
         - prometheus-operator-crd
-      name: prometheus-blackbox-exporter
+    - name: network-policies
+      catalog: cluster
+      version: 0.2.0
+    - name: node-exporter
+      catalog: default
+      version: 1.20.11
+      dependsOn:
+        - kyverno-crds
+    - name: observability-bundle
+      catalog: default
+      version: 2.9.1
+    - name: observability-policies
+      catalog: default
+      version: 0.0.4
+      dependsOn:
+        - kyverno-crds
+    - name: priority-classes
+      catalog: default
+      version: 0.3.1
+    - name: prometheus-blackbox-exporter
+      catalog: default
       version: 0.8.0
+      dependsOn:
+        - prometheus-operator-crd
     - name: rbac-bootstrap
       version: 0.3.0
-    - catalog: giantswarm
-      dependsOn:
-        - prometheus-operator-crd
-      name: security-bundle
+    - name: security-bundle
+      catalog: giantswarm
       version: 1.17.1
-    - catalog: default
       dependsOn:
         - prometheus-operator-crd
-      name: teleport-kube-agent
+    - name: teleport-kube-agent
+      catalog: default
       version: 0.11.1
-    - catalog: default
       dependsOn:
         - prometheus-operator-crd
-      name: vertical-pod-autoscaler
+    - name: vertical-pod-autoscaler
+      catalog: default
       version: 6.1.2
-    - catalog: default
-      name: vertical-pod-autoscaler-crd
+      dependsOn:
+        - prometheus-operator-crd
+    - name: vertical-pod-autoscaler-crd
+      catalog: default
       version: 4.1.2
   components:
-    - catalog: cluster
-      name: cluster-aks
+    - name: cluster-aks
+      catalog: cluster
       version: 0.1.0
-    - catalog: control-plane-catalog
-      name: kubernetes
+    - name: kubernetes
+      catalog: control-plane-catalog
       version: 1.35.5
   date: "2026-06-18T16:37:01Z"
   state: active

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -4,100 +4,83 @@ metadata:
   name: aks-35.0.0
 spec:
   apps:
-    - name: cert-exporter
-      catalog: default
-      version: 2.11.0
-      dependsOn:
-        - kyverno-crds
-    - name: cert-manager
-      catalog: default
-      version: 3.13.0
-      dependsOn:
-        - alloy-logs
-        - prometheus-operator-crd
-    - name: chart-operator-extensions
-      catalog: default
-      version: 1.1.3
-      dependsOn:
-        - prometheus-operator-crd
-    - name: cilium-servicemonitors
-      catalog: default
-      version: 0.1.4
-      dependsOn:
-        - prometheus-operator-crd
-    - name: azure-aks-extras
-      catalog: default
-      version: 0.1.0
-    - name: external-dns
-      catalog: default
-      version: 3.5.0
-      dependsOn:
-        - prometheus-operator-crd
-    - name: k8s-audit-metrics
-      catalog: default
-      version: 0.10.13
-      dependsOn:
-        - kyverno-crds
-    - name: k8s-dns-node-cache
-      catalog: default
-      version: 2.11.0
-      dependsOn:
-        - kyverno-crds
-    - name: net-exporter
-      catalog: default
-      version: 1.24.0
-      dependsOn:
-        - prometheus-operator-crd
-    - name: network-policies
-      catalog: cluster
-      version: 0.2.0
-    - name: node-exporter
-      catalog: default
-      version: 1.20.11
-      dependsOn:
-        - kyverno-crds
-    - name: observability-bundle
-      catalog: default
-      version: 2.9.1
-    - name: observability-policies
-      catalog: default
-      version: 0.0.4
-      dependsOn:
-        - kyverno-crds
-    - name: priority-classes
-      catalog: default
-      version: 0.3.1
-    - name: prometheus-blackbox-exporter
-      catalog: default
-      version: 0.8.0
-      dependsOn:
-        - prometheus-operator-crd
-    - name: rbac-bootstrap
-      version: 0.3.0
-    - name: security-bundle
-      catalog: giantswarm
-      version: 1.17.1
-      dependsOn:
-        - prometheus-operator-crd
-    - name: teleport-kube-agent
-      catalog: default
-      version: 0.11.1
-      dependsOn:
-        - prometheus-operator-crd
-    - name: vertical-pod-autoscaler
-      catalog: default
-      version: 6.1.2
-      dependsOn:
-        - prometheus-operator-crd
-    - name: vertical-pod-autoscaler-crd
-      catalog: default
-      version: 4.1.2
+  - name: cert-exporter
+    version: 2.11.0
+    dependsOn:
+    - kyverno-crds
+  - name: cert-manager
+    version: 3.13.0
+    dependsOn:
+    - alloy-logs
+    - prometheus-operator-crd
+  - name: chart-operator-extensions
+    version: 1.1.3
+    dependsOn:
+    - prometheus-operator-crd
+  - name: cilium-servicemonitors
+    version: 0.1.4
+    dependsOn:
+    - prometheus-operator-crd
+  - name: azure-aks-extras
+    version: 0.1.0
+  - name: external-dns
+    version: 3.5.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: k8s-audit-metrics
+    version: 0.10.13
+    dependsOn:
+    - kyverno-crds
+  - name: k8s-dns-node-cache
+    version: 2.11.0
+    dependsOn:
+    - kyverno-crds
+  - name: net-exporter
+    version: 1.24.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: network-policies
+    catalog: cluster
+    version: 0.2.0
+  - name: node-exporter
+    version: 1.20.11
+    dependsOn:
+    - kyverno-crds
+  - name: observability-bundle
+    version: 2.9.1
+  - name: observability-policies
+    version: 0.0.4
+    dependsOn:
+    - kyverno-crds
+  - name: priority-classes
+    version: 0.3.1
+  - name: prometheus-blackbox-exporter
+    version: 0.8.0
+    dependsOn:
+    - prometheus-operator-crd
+  - name: rbac-bootstrap
+    version: 0.3.0
+  - name: security-bundle
+    catalog: giantswarm
+    version: 1.17.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: teleport-kube-agent
+    version: 0.11.1
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler
+    version: 6.1.2
+    dependsOn:
+    - prometheus-operator-crd
+  - name: vertical-pod-autoscaler-crd
+    version: 4.1.2
   components:
-    - name: cluster-aks
-      catalog: cluster
-      version: 0.1.0
-    - name: kubernetes
-      catalog: control-plane-catalog
-      version: 1.35.5
+  - name: cluster-aks
+    catalog: cluster
+    version: 0.1.0
+  - name: kubernetes
+    catalog: control-plane-catalog
+    version: 1.35.5
   date: "2026-06-18T16:37:01Z"
   state: active

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -58,7 +58,7 @@ spec:
       version: 1.20.11
     - catalog: default
       name: observability-bundle
-      version: 2.9.0
+      version: 2.9.1
     - catalog: default
       dependsOn:
         - kyverno-crds

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -78,7 +78,7 @@ spec:
       dependsOn:
         - prometheus-operator-crd
       name: security-bundle
-      version: 2.1.0
+      version: 1.17.1
     - catalog: default
       dependsOn:
         - prometheus-operator-crd

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -93,7 +93,7 @@ spec:
       name: vertical-pod-autoscaler-crd
       version: 4.1.2
   components:
-    - catalog: cluster-test
+    - catalog: cluster
       name: cluster-aks
       version: 0.1.0
     - catalog: control-plane-catalog

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -76,7 +76,7 @@ spec:
   components:
   - name: cluster-aks
     catalog: cluster
-    version: 0.1.0
+    version: 0.2.0
   - name: kubernetes
     version: 1.35.5
   date: "2026-06-18T16:37:01Z"

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -58,8 +58,6 @@ spec:
     version: 0.8.0
     dependsOn:
     - prometheus-operator-crd
-  - name: rbac-bootstrap
-    version: 0.3.0
   - name: security-bundle
     catalog: giantswarm
     version: 1.17.1

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -28,7 +28,7 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: external-dns-crossplane-resources
-    version: 0.2.1-dev.external-dn--ad-identity.2026-07-14.09-31-39.h2b7b02b
+    version: 0.3.0
     catalog: default
   - name: k8s-audit-metrics
     version: 0.10.13
@@ -79,7 +79,7 @@ spec:
   components:
   - name: cluster-aks
     catalog: cluster
-    version: 0.2.1-dev.external-dn--ad-identity.2026-07-14.12-30-40.h0350444
+    version: 0.3.0
   - name: kubernetes
     version: 1.35.5
   date: "2026-06-18T16:37:01Z"

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -1,0 +1,103 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  name: aks-35.0.0
+spec:
+  apps:
+    - catalog: default
+      dependsOn:
+        - kyverno-crds
+      name: cert-exporter
+      version: 2.11.0
+    - catalog: default
+      dependsOn:
+        - alloy-logs
+        - prometheus-operator-crd
+      name: cert-manager
+      version: 3.13.0
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: chart-operator-extensions
+      version: 1.1.3
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: cilium-servicemonitors
+      version: 0.1.4
+    - catalog: default
+      name: azure-aks-extras
+      version: 0.1.0
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: external-dns
+      version: 3.5.0
+    - catalog: default
+      dependsOn:
+        - kyverno-crds
+      name: k8s-audit-metrics
+      version: 0.10.13
+    - catalog: default
+      dependsOn:
+        - kyverno-crds
+      name: k8s-dns-node-cache
+      version: 2.11.0
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: net-exporter
+      version: 1.24.0
+    - catalog: cluster
+      name: network-policies
+      version: 0.2.0
+    - catalog: default
+      dependsOn:
+        - kyverno-crds
+      name: node-exporter
+      version: 1.20.11
+    - catalog: default
+      name: observability-bundle
+      version: 3.0.1
+    - catalog: default
+      dependsOn:
+        - kyverno-crds
+      name: observability-policies
+      version: 0.0.4
+    - catalog: default
+      name: priority-classes
+      version: 0.3.1
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: prometheus-blackbox-exporter
+      version: 0.8.0
+    - name: rbac-bootstrap
+      version: 0.3.0
+    - catalog: giantswarm
+      dependsOn:
+        - prometheus-operator-crd
+      name: security-bundle
+      version: 2.1.0
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: teleport-kube-agent
+      version: 0.11.1
+    - catalog: default
+      dependsOn:
+        - prometheus-operator-crd
+      name: vertical-pod-autoscaler
+      version: 6.1.2
+    - catalog: default
+      name: vertical-pod-autoscaler-crd
+      version: 4.1.2
+  components:
+    - catalog: cluster-test
+      name: cluster-aks
+      version: 0.1.0
+    - catalog: control-plane-catalog
+      name: kubernetes
+      version: 1.35.5
+  date: "2026-06-18T16:37:01Z"
+  state: active

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -4,6 +4,8 @@ metadata:
   name: aks-35.0.0
 spec:
   apps:
+  - name: azure-aks-extras
+    version: 0.1.0
   - name: cert-exporter
     version: 2.11.0
     dependsOn:
@@ -21,8 +23,6 @@ spec:
     version: 0.1.4
     dependsOn:
     - prometheus-operator-crd
-  - name: azure-aks-extras
-    version: 0.1.0
   - name: external-dns
     version: 3.5.0
     dependsOn:
@@ -80,7 +80,6 @@ spec:
     catalog: cluster
     version: 0.1.0
   - name: kubernetes
-    catalog: control-plane-catalog
     version: 1.35.5
   date: "2026-06-18T16:37:01Z"
   state: active

--- a/aks/v35.0.0/release.yaml
+++ b/aks/v35.0.0/release.yaml
@@ -58,7 +58,7 @@ spec:
       version: 1.20.11
     - catalog: default
       name: observability-bundle
-      version: 3.0.1
+      version: 2.9.0
     - catalog: default
       dependsOn:
         - kyverno-crds


### PR DESCRIPTION
<!--
If this is a PR with details for a new release, please review the [Workload Cluster Releases Board](https://github.com/orgs/giantswarm/projects/365):

- If there's an issue for this release open in the "Planned" column without a team assigned, please use it and try to include requested changes in your release (details of this process can be found [here](https://intranet.giantswarm.io/docs/product/releases/requesting-changes-in-next-platform-release)).
- Otherwise create an appropriate issue for your release in https://github.com/giantswarm/roadmap and add it to the releases board.

Ping @sig-product for review of release notes.
--->

### Checklist

- [ ] Roadmap issue created
- [x] ~Release uses latest stable Flatcar~ Doesn't use flatcar
- [x] Release uses latest Kubernetes patch version
- [x] Release uses latest supported version of all default apps
- [x] ~MC creation test passed (see "Triggering MC Creation Tests" below)~ AKS MCs are currently not supported

### Triggering E2E tests

To trigger the E2E test for each new Release added in this PR, add a comment with the following:

`/run releases-test-suites`

If your release is a new _patch_ release for an older major release, you need to specify the previous release for use in upgrade tests, for example for `25.1.2` (exists) to `25.1.3` (added in your PR):

`/run releases-test-suites PREVIOUS_RELEASE=25.1.2`

If your release is a new _minor_ release for an older major release, e.g. `25.3.0` (exists) to `25.4.0` (added in your PR), it works the same way:

`/run releases-test-suites PREVIOUS_RELEASE=25.3.0`

You can also limit which tests are run:

`/run releases-test-suites TARGET_SUITES=./providers/capa/standard`

If you want to trigger conformance tests, you can do so by adding a comment similar to the following:

`/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

For more details see the [README.md](/README.md#running-tests-against-prs).

### Triggering MC Creation Tests

To prevent releases from breaking Management Cluster creation, run these tests before merging. The test recreates MCs using the release from your PR branch (auto-detected from the PR's commit SHA) to catch issues early.

**Test a specific provider:**

`/run generate-mc INSTALLATION=<installation> PROVIDER=<provider>`

Examples:
- `/run generate-mc INSTALLATION=goten PROVIDER=capa`
- `/run generate-mc INSTALLATION=goose PROVIDER=capz`
- `/run generate-mc INSTALLATION=goshawk PROVIDER=cloud-director`
- `/run generate-mc INSTALLATION=gmc PROVIDER=vsphere`

### Test all providers

`/run generate-mc-all`

**NOTE:** This command tests recreating `capa/goten`, `capz/goose`, `cloud-director/goshawk` and `vsphere/gmc` on head commit of PR.

**Optional parameters:**
- `MC_BOOTSTRAP_REF` - Git ref for mc-bootstrap repo (default: `main`). Use this to test with a specific mc-bootstrap branch.

This will:
- Recreate an MC using the release from your PR branch
- Post a GitHub check status to this PR
- Automatically clean up on completion

**Note:** This test is separate from the WC E2E tests and validates that MC creation works with the new release.

For more details see the [CAPI release drafting documentation](https://intranet.giantswarm.io/docs/product/releases/capi/capi-release-drafting/#mc-creation-tests).
