### PR TITLE
Don't re-announce releases restored from archive

### DIFF
--- a/.github/workflows/publish-github-release.yaml
+++ b/.github/workflows/publish-github-release.yaml
@@ -134,6 +134,9 @@ jobs:
           # Only announce releases whose release.yaml was ADDED in the
           # commits of this push. Subsequent pushes that only modify the
           # same release.yaml (e.g. deprecate/archive) must not re-announce.
+          # A release moved back OUT of archived/ (un-archive) must also not
+          # re-announce: with rename detection it is classified as a rename
+          # (R), not an addition (A), and is therefore skipped.
           if [[ -z "$GITHUB_EVENT_BEFORE" || "$GITHUB_EVENT_BEFORE" =~ ^0+$ ]]; then
             # workflow_dispatch or initial push: fall back to the HEAD commit.
             RANGE="${GITHUB_SHA}^..${GITHUB_SHA}"
@@ -141,11 +144,16 @@ jobs:
             RANGE="${GITHUB_EVENT_BEFORE}..${GITHUB_SHA}"
           fi
 
+          # Enable rename detection (-M) and include the archived/ path in the
+          # pathspec so git can see both endpoints of an un-archive move and
+          # pair them into a rename instead of reporting a bare addition.
           declare -A ADDED_RELEASES
           while IFS= read -r f; do
             [[ -z "$f" ]] && continue
+            # Ignore archived paths; only announce live release directories.
+            [[ "$f" == */archived/* ]] && continue
             ADDED_RELEASES["${f%/release.yaml}"]=1
-          done < <(git diff --name-only --diff-filter=A "$RANGE" -- ':(glob)*/v*.*.*/release.yaml' 2>/dev/null || true)
+          done < <(git diff --name-only --diff-filter=A -M "$RANGE" -- ':(glob)*/v*.*.*/release.yaml' ':(glob)*/archived/v*.*.*/release.yaml' 2>/dev/null || true)
 
           # Group releases by version and collect provider display names
           declare -A VERSION_PROVIDERS


### PR DESCRIPTION
When a release is moved back out of archived/ (un-archive, e.g. #2371 for CAPA v33.2.0), the "Release X — Published" Slack message to #news-product is sent again as if it were brand new.

The notify-news-product guard only announces release.yaml files that git reports as ADDED. An un-archive is a rename, but the diff pathspec only matched the non-archived path, so git saw just the destination and classified it as an addition — re-announcing it.

Fix: enable rename detection (-M) and include the archived/ path in the pathspec so the move is paired into a rename (R) and skipped. Archived paths are also filtered out explicitly.

Verified against merge commit 32b70652 (#2371): old logic reports capa/v33.2.0/release.yaml as added; new logic reports nothing.