### PR TITLE
CAPI: Release v35.0.0 (HR).

### DIFF
--- a/capa/v35.0.0/README.md
+++ b/capa/v35.0.0/README.md
@@ -76,6 +76,7 @@
 - aws-nth-bundle from v1.4.0 to v2.1.0
 - aws-pod-identity-webhook from v2.2.0 to v2.3.0
 - cert-exporter from v2.10.1 to v2.11.1
+- cert-manager from v3.13.0 to v4.0.1
 - cilium from v1.4.3 to v1.4.5
 - cilium-crossplane-resources from v0.2.1 to v0.2.2
 - cluster-autoscaler from v1.34.3-2 to v2.0.2
@@ -88,9 +89,10 @@
 - karpenter-taint-remover from v1.0.2 to v1.1.0
 - net-exporter from v1.23.1 to v1.24.0
 - network-policies from v0.1.3 to v0.2.0
-- observability-bundle from v2.8.0 to v2.9.1
+- observability-bundle from v2.8.0 to v3.3.0
 - prometheus-blackbox-exporter from v0.7.0 to v0.8.0
 - Added rbac-bootstrap v0.3.0
+- security-bundle from v1.17.1 to v2.1.0
 - teleport-kube-agent from v0.10.8 to v0.11.1
 
 ### aws-ebs-csi-driver [v4.1.2...v4.3.0](https://github.com/giantswarm/aws-ebs-csi-driver-app/compare/v4.1.2...v4.3.0)
@@ -150,6 +152,14 @@
 
 - Add a `serialnumber` label to the `cert_exporter_not_after` and `cert_exporter_secret_not_after` metrics so concatenated certificates no longer collide into identical series. The collision made the registry fail `Gather()`, which blanked out the entire `/metrics` endpoint (regression from v2.10.1).
 - Serve `/metrics` with `ContinueOnError` so a single problematic metric can no longer fail the whole scrape.
+
+### cert-manager [v3.13.0...v4.0.1](https://github.com/giantswarm/cert-manager-app/compare/v3.13.0...v4.0.1)
+
+#### Changed
+
+- Improved proxy settings by adding a proxy ConfigMap and setting upstream `envFrom` values for `controller`, `webhook` and `cainjector`.
+- **Breaking:** Helm values to be passed to the upstream `cert-manager` chart will now need to use the `cert-manager` path instead of root. For example, the value `crds.enabled: true` must now be set with `cert-manager.crds.enabled: true`.
+- Moved vendored chart to `helm/cert-manager/charts/` and adapted sync scripts to follow new structure.
 
 ### cilium [v1.4.3...v1.4.5](https://github.com/giantswarm/cilium-app/compare/v1.4.3...v1.4.5)
 
@@ -286,17 +296,25 @@
 
 - Deprecated the .Values.kamaji in favour of the more generic .Values.konnectivityAgent to control the behaviour for the `konnectivity-agent`.
 
-### observability-bundle [v2.8.0...v2.9.1](https://github.com/giantswarm/observability-bundle/compare/v2.8.0...v2.9.1)
+### observability-bundle [v2.8.0...v3.3.0](https://github.com/giantswarm/observability-bundle/compare/v2.8.0...v3.3.0)
 
 #### Added
 
+- Add KSM metrics for Gateway API `ListenerSet` and `ReferenceGrant` resources.
 - Add Backstage audience annotations.
 - Add managementCluster: "" as a top-level value (populated from the cluster chart via defaultValues)
 - Moves full KSM metricRelabelings ownership from kube-prometheus-stack-app into observability-bundle
 
 #### Changed
 
-- Update `alloy-app` to 0.20.1
+- Update Gateway API KSM configs to `v1` for `Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, `TLSRoute` and `BackendTLSPolicy`.
+- Update `kube-prometheus-stack` and `prometheus-operator-crd` to 22.0.0
+- Update `alloy-app` to 0.21.0
+- HelmReleases: honor the App platform `priority` field (1-150, default 25) on `extraConfigs` entries. `spec.valuesFrom` now reproduces the App platform merge order — all configMaps before all secrets (a secret always overrides a configMap), each kind ordered by priority around the user-config layer — preserving the App CR merge semantics after the migration. ([giantswarm#36096](https://github.com/giantswarm/giantswarm/issues/36096))
+- Migrate sub-apps from App CRs to Flux HelmRelease CRs.
+- Remove 'cluster-values' ConfigMap reference from HelmReleases.
+- Add new `alloy-podlogs-crds` chart.
+- Update alloy-app to 0.20.0
 - Update dependency kube-prometheus-stack-app and prometheus-operator-crd to v21.0.0
 - Update alloy-app to 0.19.0
 
@@ -316,6 +334,24 @@
 #### Changed
 
 - Migrate chart metadata annotations to OCI-compatible format.
+
+### security-bundle [v1.17.1...v2.1.0](https://github.com/giantswarm/security-bundle/compare/v1.17.1...v2.1.0)
+
+#### Changed
+
+- Update `cloudnative-pg` (app) to v0.1.0.
+- Update `trivy` (app) to v0.15.0.
+- Update `falco` (app) to v0.12.0.
+- HelmReleases: honor the App platform `priority` field (1-150, default 25) on `extraConfigs` entries. `spec.valuesFrom` now reproduces the App platform merge order — all configMaps before all secrets (a secret always overrides a configMap), each kind ordered by priority around the user-config layer — preserving the App CR merge semantics after the migration. ([giantswarm#36096](https://github.com/giantswarm/giantswarm/issues/36096))
+- Migrate sub-apps from App CRs to Flux HelmRelease CRs.
+- No longer pass the 'cluster-values' ConfigMap to the applications inside the bundle.
+- Update `kyverno` (app) to v0.24.2.
+  - This release includes a new Kyverno minor version. Please refer to the upstream release notes for the latest changes:
+  - https://github.com/kyverno/kyverno/releases/tag/v1.17.0
+- Update `kyverno-crds` (app) to v1.17.0.
+- Update `kyverno-policies` (app) to v0.25.0.
+- Update `kyverno-policy-operator` (app) to v0.2.2.
+- Update `kubescape` (app) to v0.1.0.
 
 ### teleport-kube-agent [v0.10.8...v0.11.1](https://github.com/giantswarm/teleport-kube-agent-app/compare/v0.10.8...v0.11.1)
 

--- a/capa/v35.0.0/release.diff
+++ b/capa/v35.0.0/release.diff
@@ -7,13 +7,16 @@ spec:                                                              spec:
   - name: aws-ebs-csi-driver                                         - name: aws-ebs-csi-driver
     version: 4.1.2                                              |      version: 4.3.0
     dependsOn:                                                         dependsOn:
-    - cloud-provider-aws                                               - cloud-provider-aws
+    - cloud-provider-aws                                        |      - kyverno-crds
+                                                                >      - vertical-pod-autoscaler-crd
   - name: aws-ebs-csi-driver-servicemonitors                         - name: aws-ebs-csi-driver-servicemonitors
     version: 0.1.2                                                     version: 0.1.2
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: aws-nth-bundle                                             - name: aws-nth-bundle
     version: 1.4.0                                              |      version: 2.1.0
+                                                                >      dependsOn:
+                                                                >      - kyverno-crds
   - name: aws-pod-identity-webhook                                   - name: aws-pod-identity-webhook
     version: 2.2.0                                              |      version: 2.3.0
     dependsOn:                                                         dependsOn:
@@ -23,12 +26,12 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - kyverno-crds                                                     - kyverno-crds
   - name: cert-manager                                               - name: cert-manager
-    version: 3.13.0                                                    version: 3.13.0
+    version: 3.13.0                                             |      version: 4.0.1
     dependsOn:                                                         dependsOn:
-    - alloy-logs                                                       - alloy-logs
+    - alloy-logs                                                |      - alloy-podlogs-crds
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: cert-manager-crossplane-resources                          - name: cert-manager-crossplane-resources
-    catalog: cluster                                                   catalog: cluster
+    catalog: cluster                                            <
     version: 0.1.1                                                     version: 0.1.1
   - name: chart-operator-extensions                                  - name: chart-operator-extensions
     version: 1.1.3                                                     version: 1.1.3
@@ -37,8 +40,8 @@ spec:                                                              spec:
   - name: cilium                                                     - name: cilium
     version: 1.4.3                                              |      version: 1.4.5
   - name: cilium-crossplane-resources                                - name: cilium-crossplane-resources
-    catalog: cluster                                                   catalog: cluster
-    version: 0.2.1                                              |      version: 0.2.2
+    catalog: cluster                                            |      version: 0.2.2
+    version: 0.2.1                                              <
   - name: cilium-servicemonitors                                     - name: cilium-servicemonitors
     version: 0.1.4                                                     version: 0.1.4
     dependsOn:                                                         dependsOn:
@@ -89,10 +92,14 @@ spec:                                                              spec:
     - kyverno-crds                                                     - kyverno-crds
   - name: karpenter                                                  - name: karpenter
     version: 2.3.0                                              |      version: 2.4.0
+                                                                >      dependsOn:
+                                                                >      - alloy-podlogs-crds
   - name: karpenter-crossplane-resources                             - name: karpenter-crossplane-resources
     version: 0.5.1                                                     version: 0.5.1
   - name: karpenter-taint-remover                                    - name: karpenter-taint-remover
     version: 1.0.2                                              |      version: 1.1.0
+                                                                >      dependsOn:
+                                                                >      - alloy-podlogs-crds
   - name: metrics-server                                             - name: metrics-server
     version: 2.8.0                                                     version: 2.8.0
     dependsOn:                                                         dependsOn:
@@ -102,8 +109,8 @@ spec:                                                              spec:
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: network-policies                                           - name: network-policies
-    catalog: cluster                                                   catalog: cluster
-    version: 0.1.3                                              |      version: 0.2.0
+    catalog: cluster                                            |      version: 0.2.0
+    version: 0.1.3                                              <
     dependsOn:                                                         dependsOn:
     - cilium                                                           - cilium
   - name: node-exporter                                              - name: node-exporter
@@ -112,8 +119,11 @@ spec:                                                              spec:
     - kyverno-crds                                                     - kyverno-crds
   - name: node-problem-detector                                      - name: node-problem-detector
     version: 0.5.2                                                     version: 0.5.2
+                                                                >      dependsOn:
+                                                                >      - kyverno-crds
+                                                                >      - prometheus-operator-crd
   - name: observability-bundle                                       - name: observability-bundle
-    version: 2.8.0                                              |      version: 2.9.1
+    version: 2.8.0                                              |      version: 3.3.0
     dependsOn:                                                         dependsOn:
     - coredns                                                          - coredns
   - name: observability-policies                                     - name: observability-policies
@@ -129,8 +139,8 @@ spec:                                                              spec:
                                                                 >    - name: rbac-bootstrap
                                                                 >      version: 0.3.0
   - name: security-bundle                                            - name: security-bundle
-    catalog: giantswarm                                                catalog: giantswarm
-    version: 1.17.1                                                    version: 1.17.1
+    catalog: giantswarm                                         |      version: 2.1.0
+    version: 1.17.1                                             <
     dependsOn:                                                         dependsOn:
     - prometheus-operator-crd                                          - prometheus-operator-crd
   - name: teleport-kube-agent                                        - name: teleport-kube-agent
@@ -145,8 +155,8 @@ spec:                                                              spec:
     version: 4.1.2                                                     version: 4.1.2
   components:                                                        components:
   - name: cluster-aws                                                - name: cluster-aws
-    catalog: cluster                                                   catalog: cluster
-    version: 7.7.2                                              |      version: 8.7.0
+    catalog: cluster                                            |      catalog: cluster-test
+    version: 7.7.2                                              |      version: 8.7.1-dev.migrate-app--elmreleases.2026-07-02.04-4
   - name: flatcar                                                    - name: flatcar
     version: 4593.2.2                                           |      version: 4593.2.3
   - name: kubernetes                                                 - name: kubernetes

--- a/capa/v35.0.0/release.yaml
+++ b/capa/v35.0.0/release.yaml
@@ -7,13 +7,16 @@ spec:
   - name: aws-ebs-csi-driver
     version: 4.3.0
     dependsOn:
-    - cloud-provider-aws
+    - kyverno-crds
+    - vertical-pod-autoscaler-crd
   - name: aws-ebs-csi-driver-servicemonitors
     version: 0.1.2
     dependsOn:
     - prometheus-operator-crd
   - name: aws-nth-bundle
     version: 2.1.0
+    dependsOn:
+    - kyverno-crds
   - name: aws-pod-identity-webhook
     version: 2.3.0
     dependsOn:
@@ -23,12 +26,11 @@ spec:
     dependsOn:
     - kyverno-crds
   - name: cert-manager
-    version: 3.13.0
+    version: 4.0.1
     dependsOn:
-    - alloy-logs
+    - alloy-podlogs-crds
     - prometheus-operator-crd
   - name: cert-manager-crossplane-resources
-    catalog: cluster
     version: 0.1.1
   - name: chart-operator-extensions
     version: 1.1.3
@@ -37,7 +39,6 @@ spec:
   - name: cilium
     version: 1.4.5
   - name: cilium-crossplane-resources
-    catalog: cluster
     version: 0.2.2
   - name: cilium-servicemonitors
     version: 0.1.4
@@ -89,10 +90,14 @@ spec:
     - kyverno-crds
   - name: karpenter
     version: 2.4.0
+    dependsOn:
+    - alloy-podlogs-crds
   - name: karpenter-crossplane-resources
     version: 0.5.1
   - name: karpenter-taint-remover
     version: 1.1.0
+    dependsOn:
+    - alloy-podlogs-crds
   - name: metrics-server
     version: 2.8.0
     dependsOn:
@@ -102,7 +107,6 @@ spec:
     dependsOn:
     - prometheus-operator-crd
   - name: network-policies
-    catalog: cluster
     version: 0.2.0
     dependsOn:
     - cilium
@@ -112,8 +116,11 @@ spec:
     - kyverno-crds
   - name: node-problem-detector
     version: 0.5.2
+    dependsOn:
+    - kyverno-crds
+    - prometheus-operator-crd
   - name: observability-bundle
-    version: 2.9.1
+    version: 3.3.0
     dependsOn:
     - coredns
   - name: observability-policies
@@ -129,8 +136,7 @@ spec:
   - name: rbac-bootstrap
     version: 0.3.0
   - name: security-bundle
-    catalog: giantswarm
-    version: 1.17.1
+    version: 2.1.0
     dependsOn:
     - prometheus-operator-crd
   - name: teleport-kube-agent
@@ -145,8 +151,8 @@ spec:
     version: 4.1.2
   components:
   - name: cluster-aws
-    catalog: cluster
-    version: 8.7.0
+    catalog: cluster-test
+    version: 8.7.1-dev.migrate-app--elmreleases.2026-07-02.04-45-06.h81434aa
   - name: flatcar
     version: 4593.2.3
   - name: kubernetes


### PR DESCRIPTION
```sh
for provider in aws
do
  base="34.4.0"
  apps=(
    "--app" "cert-manager@@@alloy-podlogs-crds#prometheus-operator-crd"
    "--app" "rbac-bootstrap@0.3.0"
  )
  components=()

  case "${provider}" in
    aws)
      apps+=(
        "--app" "aws-ebs-csi-driver@@@kyverno-crds#vertical-pod-autoscaler-crd"
        "--app" "aws-nth-bundle@@@kyverno-crds"
        "--app" "cluster-autoscaler-crossplane-resources@1.0.0"
        "--app" "external-dns-crossplane-resources@0.2.0"
        "--app" "karpenter@@@alloy-podlogs-crds"
        "--app" "karpenter-taint-remover@@@alloy-podlogs-crds"
        "--app" "node-problem-detector@@@kyverno-crds#prometheus-operator-crd"
      )
      ;;
    eks)
      base="34.0.1"
      ;;
    azure)
      apps+=("--app" "cluster-autoscaler@2.0.2")
      components+=("--component" "flatcar@4593.2.2")
      ;;
  esac

  devctl release create \
    --provider "${provider}" \
    --base "${base}" \
    --name 35.0.0 \
    ${apps[@]} \
    ${components[@]} \
    --bumpall \
    --overwrite \
    --yes
done
```