### PR TITLE
Fix release-<provider> chart versioning: publish clean semver instead of dev tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,20 +164,13 @@ jobs:
                   \"release_version\": \"${version}\",
                   \"chart_version\": \"${CHART_VERSION}\"
                 }},
-                {\"architect/push-to-app-catalog\": {
+                {\"push-retag-chart\": {
                   \"name\": \"push-${provider}-${version}\",
                   \"context\": \"architect\",
                   \"requires\": [\"prepare-${provider}-${version}\"],
-                  \"attach_workspace\": true,
-                  \"chart\": \"release-chart\",
-                  \"explicit_allow_chart_name_mismatch\": true,
-                  \"executor\": \"app-build-suite\",
-                  \"app_catalog\": \"cluster-catalog\",
-                  \"app_catalog_test\": \"cluster-catalog\",
-                  \"push_to_appcatalog\": true,
-                  \"push_to_oci_registry\": true,
-                  \"force-public\": true,
-                  \"on_tag\": false
+                  \"provider\": \"${provider}\",
+                  \"release_version\": \"${version}\",
+                  \"chart_version\": \"${CHART_VERSION}\"
                 }}
               ]" /tmp/continue-config.yml
             done < /tmp/releases.txt

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -129,3 +129,70 @@ jobs:
           paths:
             - helm/release-chart
             - .abs
+
+  # Push the retagged chart WITHOUT letting the architect orb re-version it.
+  #
+  # The architect/push-to-app-catalog job runs `VERSION=$(gitsemver get)` and
+  # overrides the chart version with it. On a branch build that resolves to
+  # `0.0.0-dev.<branch>.<timestamp>`, which clobbers the clean release version
+  # (e.g. 34.4.0) that prepare-retag-chart stamps into Chart.yaml — so no clean
+  # semver tag ever gets published. We instead package with ABS (which keeps the
+  # Chart.yaml version) and push via the lower-level architect/push-helm command.
+  push-retag-chart:
+    executor: architect/app-build-suite
+    parameters:
+      provider:
+        type: string
+      release_version:
+        type: string
+      chart_version:
+        type: string
+        default: ""
+    steps:
+      - checkout
+      - architect/tools-info:
+          show_abs_version: true
+          show_architect_version: false
+          show_go_version: false
+      - architect/determine-catalog-name:
+          app_catalog: cluster-catalog
+          app_catalog_test: cluster-catalog
+          on_tag: false
+      - attach_workspace:
+          at: .
+      - run:
+          name: Package retagged chart (preserve stamped version)
+          command: |
+            set -euo pipefail
+
+            # Expected OCI tag: PR previews use chart_version (<ver>-<sha>);
+            # merges to master use the clean release version.
+            EXPECTED="<< parameters.chart_version >>"
+            if [[ -z "${EXPECTED}" ]]; then
+              EXPECTED="$(echo '<< parameters.release_version >>' | sed 's/^v//')"
+            fi
+
+            # No --override-chart-version: ABS uses the version stamped into
+            # Chart.yaml by prepare-retag-chart.
+            mkdir build
+            python -m app_build_suite \
+              --chart-dir ./helm/release-chart \
+              --destination build \
+              --generate-metadata \
+              --catalog-base-url "https://giantswarm.github.io/$(cat .app_catalog_name)/" \
+              --keep-chart-changes
+
+            # Guard against a silent regression: refuse to push if the packaged
+            # chart was re-versioned away from the expected release version.
+            tgz=$(find build -maxdepth 1 -name '*.tgz' | head -1)
+            echo "Packaged: ${tgz}"
+            if ! echo "${tgz}" | grep -q "\-${EXPECTED}\.tgz$"; then
+              echo "ERROR: packaged chart version does not match expected '${EXPECTED}'." >&2
+              echo "Refusing to push a mis-versioned chart." >&2
+              exit 1
+            fi
+      - architect/push-helm:
+          chart: release-chart
+          force-public: true
+          push_to_appcatalog: true
+          push_to_oci_registry: true


### PR DESCRIPTION
Addresses: https://gigantic.slack.com/archives/C07KSM2E51A/p1783516542422869

The auto-retag pipeline stopped publishing clean semver OCI tags for
release-<provider> charts after the architect orb v8→v9 bump (#2327, merged
2026-06-01). The v9 architect/push-to-app-catalog job overrides the chart
version with `gitsemver get`, which on a branch build resolves to
`0.0.0-dev.<branch>.<timestamp>` and clobbers the release version stamped by
prepare-retag-chart. Result: releases published since June only have
`0.0.0-dev.*` tags in gsoci.azurecr.io/charts/giantswarm/release-<provider>,
no X.Y.Z.

Replace the architect/push-to-app-catalog job with a push-retag-chart job that
packages with ABS (preserving the Chart.yaml version) and publishes via the
lower-level architect/push-helm command, which does not re-version. A guard
fails the job if the packaged chart is not the expected version.

Affected releases still need a re-trigger to backfill the missing clean tags.
