### PR TITLE
Fix install-devctl: download raw binary instead of versioned tarball

### DIFF
--- a/.github/actions/install-devctl/action.yml
+++ b/.github/actions/install-devctl/action.yml
@@ -20,8 +20,8 @@ runs:
         mkdir -p /tmp/devctl_install && cd /tmp/devctl_install
         LATEST_DEVCTL_TAG=$(gh release view --repo giantswarm/devctl --json tagName --jq '.tagName')
         echo "version=${LATEST_DEVCTL_TAG#v}" >> $GITHUB_OUTPUT
-        ASSET_NAME="devctl-${LATEST_DEVCTL_TAG}-linux-amd64.tar.gz"
+        ASSET_NAME="devctl-linux-amd64"
         gh release download --repo giantswarm/devctl "$LATEST_DEVCTL_TAG" --pattern "$ASSET_NAME"
-        tar -xzf "$ASSET_NAME"
-        find . -name "devctl" -type f -exec sudo mv {} /usr/local/bin/devctl \;
+        chmod +x "$ASSET_NAME"
+        sudo mv "$ASSET_NAME" /usr/local/bin/devctl
         cd -


### PR DESCRIPTION
devctl releases no longer ship `devctl-<tag>-linux-amd64.tar.gz`. Assets are now plain binaries named `devctl-linux-amd64`, so the install action failed with "no assets match the file pattern".

Download the binary directly and `chmod +x` + `mv` it into place, instead of extracting a tarball that no longer exists.