### PR TITLE
Keep deprecated releases available while a smaller active release exists

### DIFF
--- a/.github/workflows/archive-releases.yaml
+++ b/.github/workflows/archive-releases.yaml
@@ -66,6 +66,17 @@ jobs:
 
             echo "INFO: Processing provider directory: $PROVIDER_ROOT_DIR"
 
+            # Releases above the lowest active release must stay available even when
+            # deprecated, because clusters on that lower release may still need them as
+            # an intermediate upgrade step.
+            # See https://github.com/giantswarm/roadmap/issues/4325
+            ARCHIVE_FLOOR=$(./tools/lowest-active-release.sh "$PROVIDER_ROOT_DIR")
+            if [ -n "$ARCHIVE_FLOOR" ]; then
+              echo "INFO: Archive floor for $PROVIDER_ROOT_DIR is $ARCHIVE_FLOOR (lowest active release)"
+            else
+              echo "INFO: $PROVIDER_ROOT_DIR has no active releases, no archive floor applies"
+            fi
+
             MOVED_RELEASES_TEMP_FILE=$(mktemp -p "$TEMP_DIR")
 
             find "$PROVIDER_ROOT_DIR" -maxdepth 1 -mindepth 1 -type d -name 'v*.*.*' -print0 | sort -z | while IFS= read -r -d $'\0' release_dir_path; do
@@ -90,10 +101,18 @@ jobs:
                 
                 # Check if this release is safe to archive using Grafana metrics
                 VERSION=$(echo "$RELEASE_NAME" | sed 's/^v//')
-                
+
+                # Skip anything above the archive floor before doing the more expensive
+                # validation below.
+                if [ -n "$ARCHIVE_FLOOR" ] && [ "$VERSION" != "$ARCHIVE_FLOOR" ] && \
+                   [ "$(printf '%s\n%s\n' "$VERSION" "$ARCHIVE_FLOOR" | sort -V | head -n1)" = "$ARCHIVE_FLOOR" ]; then
+                  echo "INFO: Release $RELEASE_NAME stays available: a smaller active release ($ARCHIVE_FLOOR) still exists. Skipping."
+                  continue
+                fi
+
                 # Use the existing validation script to check if it's safe
                 echo "INFO: Checking if $PROVIDER_ROOT_DIR/$VERSION is safe to archive..."
-                
+
                 # Create archive directory if it doesn't exist
                 if [ ! -d "$ARCHIVE_PARENT_DIR" ]; then
                   mkdir -p "$ARCHIVE_PARENT_DIR"
@@ -115,7 +134,7 @@ jobs:
                   echo "INFO: Release $RELEASE_NAME is safe to archive."
                   echo "$PROVIDER_ROOT_DIR:$RELEASE_NAME" >> "$MOVED_RELEASES_TEMP_FILE"
                 else
-                  echo "WARNING: Release $RELEASE_NAME is still in use and cannot be archived. Skipping."
+                  echo "WARNING: Release $RELEASE_NAME cannot be archived yet. Skipping."
                 fi
                 
                 # Switch back to original branch and clean up
@@ -323,7 +342,12 @@ jobs:
             ## Automated Release Archiving for CAPI
 
             This PR archives deprecated releases across all CAPI providers.
-            Archived releases are moved from `<provider>/<version>` to `<provider>/archived/<version>`.
+            Archived releases are moved from `<provider>/<version>` to `<provider>/archived/<version>`,
+            which removes them from the management clusters and makes them unusable as an upgrade target.
+
+            A deprecated release is only archived once no smaller active release exists for that provider.
+            Clusters on a lower release may still need it as an intermediate upgrade step, so it stays
+            available until the lower release is archived itself.
 
             ${{ steps.archive_script.outputs.archived_releases_pr_body_section }}
           branch: auto-archive-capi-releases

--- a/.github/workflows/deprecate-releases.yaml
+++ b/.github/workflows/deprecate-releases.yaml
@@ -203,6 +203,10 @@ jobs:
             - Latest of supported major versions
             - Required for upgrade path
 
+            Deprecating a release does not affect cluster upgrades: it stays registered on the
+            management clusters and remains usable as an upgrade target. Availability only ends
+            when a release is archived, which requires that no smaller active release exists.
+
             ${{ steps.changed-files.outputs.pr_body_changed_files_section }}
 
             ## Verify in Grafana

--- a/archive_floor_test.go
+++ b/archive_floor_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const lowestActiveReleaseScript = "tools/lowest-active-release.sh"
+
+// writeFixtureRelease creates a minimal release directory for the given version and state.
+func writeFixtureRelease(t *testing.T, providerDir string, version string, state string, archived bool) {
+	t.Helper()
+
+	releaseDir := providerDir
+	if archived {
+		releaseDir = filepath.Join(providerDir, "archived")
+	}
+	releaseDir = filepath.Join(releaseDir, version)
+
+	if err := os.MkdirAll(releaseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "apiVersion: release.giantswarm.io/v1alpha1\nkind: Release\nspec:\n  state: " + state + "\n"
+	if err := os.WriteFile(filepath.Join(releaseDir, releaseFilename), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test_ArchiveFloor covers the archive floor used to decide which deprecated releases
+// may be archived. Anything above the lowest active release has to stay available,
+// because clusters on that lower release may still need it as an intermediate upgrade
+// step. See https://github.com/giantswarm/roadmap/issues/4325
+func Test_ArchiveFloor(t *testing.T) {
+	scriptPath, err := filepath.Abs(lowestActiveReleaseScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name string
+		// releases maps a version to its state, "archived" marks an already archived release.
+		releases map[string]string
+		expected string
+	}{
+		{
+			name:     "case 0: no releases at all yields no floor",
+			expected: "",
+		},
+		{
+			name: "case 1: only archived releases yields no floor",
+			releases: map[string]string{
+				"v32.1.0": "archived",
+				"v32.2.0": "archived",
+			},
+			expected: "",
+		},
+		{
+			name: "case 2: single active release is the floor",
+			releases: map[string]string{
+				"v33.4.0": "active",
+			},
+			expected: "33.4.0",
+		},
+		{
+			name: "case 3: lowest active release wins over higher ones",
+			releases: map[string]string{
+				"v33.1.1": "active",
+				"v33.4.0": "active",
+				"v34.5.0": "active",
+			},
+			expected: "33.1.1",
+		},
+		{
+			name: "case 4: deprecated releases do not lower the floor",
+			releases: map[string]string{
+				"v33.1.1": "deprecated",
+				"v33.4.0": "active",
+			},
+			expected: "33.4.0",
+		},
+		{
+			name: "case 5: archived releases do not lower the floor",
+			releases: map[string]string{
+				"v32.1.0": "archived",
+				"v33.4.0": "active",
+			},
+			expected: "33.4.0",
+		},
+		{
+			name: "case 6: floor is compared by version, not lexically",
+			releases: map[string]string{
+				"v33.9.0":  "active",
+				"v33.10.0": "active",
+			},
+			expected: "33.9.0",
+		},
+		{
+			name: "case 7: patch versions are ordered correctly",
+			releases: map[string]string{
+				"v33.1.2":  "active",
+				"v33.1.10": "active",
+			},
+			expected: "33.1.2",
+		},
+		{
+			// The situation that caused https://github.com/giantswarm/roadmap/issues/4325:
+			// clusters lagging on v33.1.1 while v33.2.0 was deprecated as unused.
+			name: "case 8: deprecated intermediate release stays above the floor",
+			releases: map[string]string{
+				"v33.1.1": "active",
+				"v33.2.0": "deprecated",
+				"v33.3.0": "deprecated",
+				"v33.4.0": "active",
+			},
+			expected: "33.1.1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The script resolves providers relative to the working directory, so build
+			// the fixture provider inside a temporary directory and run from there.
+			workDir := t.TempDir()
+			providerDir := filepath.Join(workDir, "capa")
+			if err := os.MkdirAll(providerDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			for version, state := range tc.releases {
+				writeFixtureRelease(t, providerDir, version, state, state == "archived")
+			}
+
+			cmd := exec.Command(scriptPath, "capa")
+			cmd.Dir = workDir
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("running %s failed: %v\noutput: %s", lowestActiveReleaseScript, err, output)
+			}
+
+			actual := strings.TrimSpace(string(output))
+			if actual != tc.expected {
+				t.Errorf("expected archive floor %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
+// Test_ArchiveFloorHoldsForProviders checks that the archive floor can be determined
+// for every provider that has releases, so the archive workflow never falls back to
+// archiving without a floor by accident.
+func Test_ArchiveFloorHoldsForProviders(t *testing.T) {
+	providers := []string{"azure", "capa", "vsphere", "eks", "proxmox", "aks"}
+
+	for _, provider := range providers {
+		t.Run(provider, func(t *testing.T) {
+			releases, err := findReleases(provider, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hasActive := false
+			for _, release := range releases {
+				if release.Spec.State == "active" {
+					hasActive = true
+					break
+				}
+			}
+
+			output, err := exec.Command(lowestActiveReleaseScript, provider).CombinedOutput()
+			if err != nil {
+				t.Fatalf("running %s failed: %v\noutput: %s", lowestActiveReleaseScript, err, output)
+			}
+			floor := strings.TrimSpace(string(output))
+
+			if hasActive && floor == "" {
+				t.Errorf("provider %s has active releases but no archive floor was determined", provider)
+			}
+			if !hasActive && floor != "" {
+				t.Errorf("provider %s has no active releases but archive floor %q was determined", provider, floor)
+			}
+		})
+	}
+}

--- a/tools/check-release-archive.sh
+++ b/tools/check-release-archive.sh
@@ -24,10 +24,56 @@ fi
 
 # Array to store active releases (still in use)
 declare -a active_releases
-# Array to store provider versions 
-declare -a provider_versions
-# Track providers which are already queried
-declare -a queried_providers
+# Releases blocked because a smaller active release still exists
+declare -a below_floor_releases
+# Releases blocked because they were never deprecated
+declare -a still_active_releases
+
+# Caches, kept as "key|value" records so this stays compatible with bash 3.2 (macOS)
+# which has no associative arrays.
+in_use_records=""    # "provider|version" per line, versions currently in use
+queried_providers="" # "provider" per line, providers already queried
+floor_records=""     # "provider|floor" per line, empty floor means none applies
+
+# Compare two semver versions, true if $1 > $2
+version_gt() {
+  [[ "$1" != "$2" ]] && [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" == "$2" ]]
+}
+
+# Resolve the archive floor for a provider into ARCHIVE_FLOOR, determining it only
+# once per provider. Sets an empty value when no floor applies. This assigns to a
+# global instead of printing, so that the cache survives across calls.
+ARCHIVE_FLOOR=""
+resolve_archive_floor() {
+  local provider=$1
+
+  if ! printf '%s\n' "$floor_records" | grep -q "^${provider}|"; then
+    local floor
+    floor=$("$(dirname "$0")/lowest-active-release.sh" "$provider")
+    floor_records="${floor_records}${provider}|${floor}"$'\n'
+
+    if [[ -n "$floor" ]]; then
+      echo "Archive floor for $provider is $floor (lowest active release)"
+    else
+      echo "Provider $provider has no active releases, no archive floor applies"
+    fi
+  fi
+
+  ARCHIVE_FLOOR=$(printf '%s\n' "$floor_records" | grep "^${provider}|" | head -n1 | cut -d'|' -f2)
+}
+
+# Check whether a version sits above the provider's archive floor, i.e. whether a
+# smaller active release still exists. Such releases must stay available even when
+# deprecated, because clusters on the lower release may still need them as an
+# intermediate upgrade step. See https://github.com/giantswarm/roadmap/issues/4325
+is_above_archive_floor() {
+  local provider=$1
+  local version=$2
+
+  resolve_archive_floor "$provider"
+
+  [[ -n "$ARCHIVE_FLOOR" ]] && version_gt "$version" "$ARCHIVE_FLOOR"
+}
 
 # Get all active versions for a provider
 get_active_versions() {
@@ -41,12 +87,15 @@ get_active_versions() {
   
   echo "Fetching currently used versions for provider $provider..."
   
-  # Grafana DataSource Query with error handling
+  # Grafana DataSource Query with error handling.
+  # The 7d lookback keeps a release from looking unused just because its metrics were
+  # briefly missing: a scrape gap, an unreachable management cluster, or a dev cluster
+  # that is shut down over the weekend.
   response=$(curl --silent --fail --show-error --location --request POST 'https://giantswarm.grafana.net/api/ds/query' \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -H "Authorization: Bearer $GRAFANA_API_KEY" \
-    -d "{\"from\":\"now-5m\",\"to\":\"now\",\"queries\":[{\"refId\":\"A\",\"expr\":\"sum(aggregation:giantswarm:cluster_release_version{provider=\\\"$api_provider\\\", release_version=~\\\".*\\\", installation=~\\\".*\\\", cluster_type=~\\\".*\\\", customer=~\\\".*\\\"}) by (release_version)\",\"datasource\":{\"uid\":\"000000006\",\"type\":\"prometheus\"}}]}" 2>&1)
+    -d "{\"from\":\"now-5m\",\"to\":\"now\",\"queries\":[{\"refId\":\"A\",\"expr\":\"sum(max_over_time(aggregation:giantswarm:cluster_release_version{provider=\\\"$api_provider\\\", release_version=~\\\".*\\\", installation=~\\\".*\\\", cluster_type=~\\\".*\\\", customer=~\\\".*\\\"}[7d])) by (release_version)\",\"datasource\":{\"uid\":\"000000006\",\"type\":\"prometheus\"}}]}" 2>&1)
   
   # Check for curl failures
   if [[ $? -ne 0 ]]; then
@@ -76,9 +125,12 @@ get_active_versions() {
   echo "$used_versions"
   
   # Store the result
-  provider_versions["$provider"]="$used_versions"
-  queried_providers+=("$provider")
-  
+  while IFS= read -r used_version; do
+    [[ -z "$used_version" ]] && continue
+    in_use_records="${in_use_records}${provider}|${used_version}"$'\n'
+  done <<< "$used_versions"
+  queried_providers="${queried_providers}${provider}"$'\n'
+
   return 0
 }
 
@@ -88,19 +140,15 @@ is_version_in_use() {
   local version=$2
   
   # If we haven't queried this provider yet, do it now
-  if ! echo "${queried_providers[@]}" | grep -q "$provider"; then
+  if ! printf '%s\n' "$queried_providers" | grep -qxF "$provider"; then
     if ! get_active_versions "$provider"; then
       # If API call failed, assume version is in use to be safe
       return 0
     fi
   fi
-  
+
   # Check if the version is in the list of used versions
-  if echo "${provider_versions[$provider]}" | grep -q "^$version$"; then
-    return 0
-  else
-    return 1
-  fi
+  printf '%s\n' "$in_use_records" | grep -qxF "${provider}|${version}"
 }
 
 # Process renamed files
@@ -143,17 +191,58 @@ fi
 for version_entry in "${versions_to_check[@]}"; do
   provider=$(echo "$version_entry" | cut -d'/' -f1)
   version=$(echo "$version_entry" | cut -d'/' -f2)
-  
+
+  # Only deprecated releases may be archived. The archive floor below is derived from
+  # the active releases, so archiving one straight from active would move the floor
+  # instead of being blocked by it.
+  archived_release_yaml="$provider/archived/v$version/release.yaml"
+  if [[ -f "$archived_release_yaml" ]] && grep -q -E "^\s*state:\s*active\s*$" "$archived_release_yaml"; then
+    still_active_releases+=("$provider/$version")
+    continue
+  fi
+
   if is_version_in_use "$provider" "$version"; then
     active_releases+=("$provider/$version")
+    continue
+  fi
+
+  if is_above_archive_floor "$provider" "$version"; then
+    below_floor_releases+=("$provider/$version")
   fi
 done
 
+blocked=false
+
+if [ ${#still_active_releases[@]} -gt 0 ]; then
+  blocked=true
+  echo "::error:: The following releases cannot be archived because they are still active."
+  echo "::error:: A release has to be deprecated before it can be archived."
+  for release in "${still_active_releases[@]}"; do
+    echo "  - $release"
+  done
+fi
+
 if [ ${#active_releases[@]} -gt 0 ]; then
+  blocked=true
   echo "::error:: The following releases cannot be archived because they are still in use:"
   for release in "${active_releases[@]}"; do
     echo "  - $release"
   done
+fi
+
+if [ ${#below_floor_releases[@]} -gt 0 ]; then
+  blocked=true
+  echo "::error:: The following releases cannot be archived because a smaller active release still exists."
+  echo "::error:: Clusters on the lower release may still need them as an intermediate upgrade step."
+  echo "::error:: They can stay deprecated, but must remain available until the lower release is archived."
+  for release in "${below_floor_releases[@]}"; do
+    provider=$(echo "$release" | cut -d'/' -f1)
+    resolve_archive_floor "$provider"
+    echo "  - $release (lowest active release for $provider is $ARCHIVE_FLOOR)"
+  done
+fi
+
+if [ "$blocked" = true ]; then
   exit 1
 fi
 

--- a/tools/deprecate-release.go
+++ b/tools/deprecate-release.go
@@ -194,7 +194,10 @@ func checkReleasesInUse(releases []*ReleaseInfo, apiKey string, provider string,
 		"queries": []map[string]interface{}{
 			{
 				"refId": "A",
-				"expr":  fmt.Sprintf(`sum(aggregation:giantswarm:cluster_release_version{provider="%s", release_version=~".*", installation=~".*", cluster_type=~".*", customer=~".*"}) by (release_version)`, apiProvider),
+				// A 7 day lookback keeps a release from looking unused just because its
+				// metrics were briefly missing: a scrape gap, an unreachable management
+				// cluster, or a dev cluster that is shut down over the weekend.
+				"expr": fmt.Sprintf(`sum(max_over_time(aggregation:giantswarm:cluster_release_version{provider="%s", release_version=~".*", installation=~".*", cluster_type=~".*", customer=~".*"}[7d])) by (release_version)`, apiProvider),
 				"datasource": map[string]string{
 					"uid":  "000000006",
 					"type": "prometheus",

--- a/tools/lowest-active-release.sh
+++ b/tools/lowest-active-release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Prints the lowest active release version (without the "v" prefix) for a provider.
+#
+# This version is the "archive floor": clusters sitting on it may still need any
+# higher release as an intermediate step of an upgrade path that was tested earlier,
+# so nothing above the floor may be archived even once it is deprecated.
+# See https://github.com/giantswarm/roadmap/issues/4325
+#
+# Only releases directly under the provider directory are considered; anything
+# already under <provider>/archived/ is ignored. Prints nothing if the provider has
+# no active releases.
+#
+# Usage: lowest-active-release.sh <provider>
+
+set -eo pipefail
+
+PROVIDER=$1
+
+if [[ -z "$PROVIDER" ]]; then
+  echo "Error: provider is required" >&2
+  echo "Usage: $0 <provider>" >&2
+  exit 1
+fi
+
+if [[ ! -d "$PROVIDER" ]]; then
+  echo "Error: provider directory $PROVIDER does not exist" >&2
+  exit 1
+fi
+
+active_versions=""
+
+while IFS= read -r -d $'\0' release_dir; do
+  release_yaml="$release_dir/release.yaml"
+  [[ -f "$release_yaml" ]] || continue
+
+  if grep -q -E "^\s*state:\s*active\s*$" "$release_yaml"; then
+    active_versions+="$(basename "$release_dir" | sed 's/^v//')"$'\n'
+  fi
+done < <(find "$PROVIDER" -maxdepth 1 -mindepth 1 -type d -name 'v*.*.*' -print0)
+
+if [[ -z "${active_versions//[[:space:]]/}" ]]; then
+  exit 0
+fi
+
+printf '%s' "$active_versions" | grep -v '^$' | sort -V | head -n1


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4325

Deprecated releases were archived as soon as they were no longer in use. Archiving removes them from the management clusters, so they stop working as an upgrade target — which is what broke the planned `33.2.0` upgrade for adidas.

Archiving now requires that no smaller active release exists for the provider. The lowest active release acts as an archive floor: anything above it stays available, deprecated but installable, until the lower release is archived itself. With `33.1.1` active in `capa`, `33.2.0` would no longer be archivable.

- `tools/lowest-active-release.sh` determines the floor per provider
- `tools/check-release-archive.sh` blocks moves above the floor, and blocks archiving a release that was never deprecated
- `.github/workflows/archive-releases.yaml` skips floor-protected releases before the expensive per-release validation
- usage lookback widened from 5 minutes to 7 days, so a release is not treated as unused because its metrics were briefly missing
- both automated PR bodies now state that deprecation does not affect upgrades

Deprecation itself needed no change: it only flips `spec.state` and keeps the release in `kustomization.yaml` and `releases.json`, so the Release CR stays on the management clusters. The existing suite already asserts that every non-archived release — active or deprecated — is registered in `kustomization.yaml`, which locks that in.

Deprecated releases now accumulate in the provider directory until the floor rises, since the floor drains from the bottom one release at a time.