### PR TITLE
Require full E2E suite coverage on release PRs

### DIFF
--- a/.github/pr-body-templates/consolidated-release-instructions.md
+++ b/.github/pr-body-templates/consolidated-release-instructions.md
@@ -104,6 +104,16 @@ For conformance tests:
 
 `/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`
 
+**Required coverage:** which suites run by default depends on the release stage, so the variant suites (`private`, `china`, `cilium-eni-mode`, `on-capa`, `on-capz`) only start automatically once this PR reaches `stage/freeze`. The `E2E Coverage` check requires the **full** set for every new release regardless of stage, lists what is still outstanding with a ready-to-paste command, and must be green before merging.
+
+If a suite genuinely cannot pass — for example because its test environment is down — waive it with a reason:
+
+`/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234`
+
+A reason is required. The waiver applies to that one suite only and becomes void as soon as a release in this PR changes.
+
+See [E2E Test Coverage](https://github.com/giantswarm/releases/blob/master/docs/workflows-e2e-coverage.md) for details.
+
 </details>
 
 <details>

--- a/.github/pr-body-templates/individual-release-instructions.md
+++ b/.github/pr-body-templates/individual-release-instructions.md
@@ -100,6 +100,16 @@ For conformance tests:
 
 `/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`
 
+**Required coverage:** which suites run by default depends on the release stage, so the variant suites (`private`, `china`, `cilium-eni-mode`, `on-capa`, `on-capz`) only start automatically once this PR reaches `stage/freeze`. The `E2E Coverage` check requires the **full** set for every new release regardless of stage, lists what is still outstanding with a ready-to-paste command, and must be green before merging.
+
+If a suite genuinely cannot pass — for example because its test environment is down — waive it with a reason:
+
+`/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234`
+
+A reason is required. The waiver applies to that one suite only and becomes void as soon as a release in this PR changes.
+
+See [E2E Test Coverage](https://github.com/giantswarm/releases/blob/master/docs/workflows-e2e-coverage.md) for details.
+
 </details>
 
 <details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,8 @@ You can also limit which tests are run:
 
 `/run releases-test-suites TARGET_SUITES=./providers/capa/standard`
 
+Which suites run by default depends on the release stage, so the variant suites (`private`, `china`, `cilium-eni-mode`, `on-capa`, `on-capz`) only run once the PR reaches `stage/freeze`. The `E2E Coverage` check requires the full set for every new release regardless of stage and lists what is still outstanding, so check it before merging. If a suite cannot pass, waive it with a reason using `/waive-suite <provider>/<suite> <reason>`.
+
 If you want to trigger conformance tests, you can do so by adding a comment similar to the following:
 
 `/run conformance-tests PROVIDER=capa RELEASE_VERSION=29.1.0`

--- a/.github/scripts/e2e-coverage.js
+++ b/.github/scripts/e2e-coverage.js
@@ -1,0 +1,482 @@
+// Publishes the `E2E Coverage` check run for release PRs in this repo.
+//
+// Requires the full set of E2E test suites for every newly added release, whatever
+// release stage the PR is currently in, so a release can't be merged having only run
+// the suites its stage happens to trigger. See giantswarm/roadmap#4334 and the
+// "Test coverage requirements" section of the README.
+//
+// Run from .github/workflows/e2e-coverage.yaml. Uses the REST API directly rather than
+// actions/github-script: pinning that action's SHA trips the repo's gitleaks rule,
+// which matches any long alphanumeric run next to the word "github".
+//
+// Environment:
+//   GITHUB_TOKEN       - token with checks:write
+//   GITHUB_REPOSITORY  - owner/repo
+//   GITHUB_EVENT_NAME  - triggering event
+//   GITHUB_EVENT_PATH  - path to the event payload
+//   CAPI_NAMES         - JSON map of provider directory → CAPI name
+//   PR_NUMBER          - PR to evaluate (workflow_dispatch only)
+
+const fs = require('fs')
+
+const API_ROOT = 'https://api.github.com'
+const [owner, repo] = (process.env.GITHUB_REPOSITORY || '').split('/')
+const token = process.env.GITHUB_TOKEN
+const eventName = process.env.GITHUB_EVENT_NAME
+const payload = process.env.GITHUB_EVENT_PATH && fs.existsSync(process.env.GITHUB_EVENT_PATH)
+  ? JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
+  : {}
+
+const log = (message) => console.log(message)
+
+// Single request against the repo's REST namespace. `path` is relative to
+// /repos/{owner}/{repo}, e.g. `/pulls/2400`.
+const request = async (path, method = 'GET', body = undefined) => {
+  const url = path.startsWith('http') ? path : `${API_ROOT}/repos/${owner}/${repo}${path}`
+  const response = await fetch(url, {
+    method,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      'user-agent': 'giantswarm-releases-e2e-coverage',
+      'x-github-api-version': '2022-11-28',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    throw new Error(`${method} ${url} failed: ${response.status} ${await response.text()}`)
+  }
+  return { data: response.status === 204 ? null : await response.json(), response }
+}
+
+const api = async (path, method = 'GET', body = undefined) => (await request(path, method, body)).data
+
+// Follows Link headers and concatenates the pages. Used for list endpoints that
+// return a bare array.
+const paginate = async (path, extract = (data) => data) => {
+  let next = `${API_ROOT}/repos/${owner}/${repo}${path}${path.includes('?') ? '&' : '?'}per_page=100`
+  const items = []
+  while (next) {
+    const { data, response } = await request(next)
+    items.push(...extract(data))
+    const link = response.headers.get('link') || ''
+    const match = link.match(/<([^>]+)>;\s*rel="next"/)
+    next = match ? match[1] : null
+  }
+  return items
+}
+
+// Check runs come back wrapped in an object rather than as a bare array.
+const listCheckRuns = (ref, checkName) => paginate(
+  `/commits/${ref}/check-runs${checkName ? `?check_name=${encodeURIComponent(checkName)}` : ''}`,
+  (data) => data.check_runs,
+)
+
+const main = async () => {
+  const CHECK_NAME = 'E2E Coverage'
+  const SUITE_CHECK_PREFIX = 'Release Tests / '
+
+  // Directory name → CAPI name used in the per-suite check runs (from get-providers).
+  const capiNames = JSON.parse(process.env.CAPI_NAMES)
+
+  // The full ("freeze stage") matrix that releases-test-suites expands to per
+  // provider, keyed by the provider directory in this repo.
+  const EXPECTED_SUITES = {
+    'capa': ['standard', 'upgrade', 'upgrade-major', 'cilium-eni-mode', 'china', 'private'],
+    'azure': ['standard', 'upgrade', 'upgrade-major', 'private'],
+    'vsphere': ['standard', 'upgrade', 'upgrade-major', 'on-capa', 'on-capz'],
+    'cloud-director': ['standard', 'upgrade', 'upgrade-major'],
+    'eks': ['standard', 'upgrade', 'upgrade-major'],
+    // aks and proxmox have no releases-test-suites mapping yet, so nothing is expected.
+    'aks': [],
+    'proxmox': [],
+  }
+
+  // Suite → the check run name produced by check-run-results-to-pr, minus the
+  // prefix. `{capi}` is the provider's CAPI name, e.g. CAPA.
+  const CHECK_NAME_FORMATS = {
+    'standard': '{capi} Standard Suite',
+    'upgrade': '{capi} Upgrade Suite',
+    'upgrade-major': '(Previous Major) {capi} Upgrade Suite',
+    'upgrade-major-first': '(First Previous Major) {capi} Upgrade Suite',
+    'private': '{capi} Private Suite',
+    'china': '{capi} China Suite',
+    'cilium-eni-mode': '{capi} Cilium ENI Mode Suite',
+    'on-capa': '{capi} on CAPA Suite',
+    'on-capz': '{capi} on CAPZ Suite',
+  }
+
+  // Provider directory → the provider name used in cluster-test-suites paths.
+  const SUITE_PATH_PROVIDER = {
+    'capa': 'capa', 'azure': 'capz', 'vsphere': 'capv', 'cloud-director': 'capvcd', 'eks': 'eks',
+  }
+
+  // Waivers may be written with either spelling, e.g. `azure/private` or `capz/private`.
+  const PROVIDER_ALIASES = { 'aws': 'capa' }
+  for (const [dir, suiteProvider] of Object.entries(SUITE_PATH_PROVIDER)) {
+    PROVIDER_ALIASES[dir] = dir
+    PROVIDER_ALIASES[suiteProvider] = dir
+  }
+
+  const FAILED_CONCLUSIONS = ['failure', 'timed_out', 'cancelled', 'action_required', 'stale']
+
+
+  // --- Resolve the PR this run is about -----------------------------------------
+  let prNumber
+  switch (eventName) {
+    case 'pull_request':
+      prNumber = payload.pull_request.number
+      break
+    case 'issue_comment':
+      prNumber = payload.issue.number
+      break
+    case 'workflow_dispatch':
+      prNumber = parseInt(process.env.PR_NUMBER, 10)
+      break
+    case 'check_run': {
+      const attached = payload.check_run.pull_requests || []
+      if (attached.length > 0) {
+        prNumber = attached[0].number
+      } else {
+        // Check runs created through the API aren't always linked to their PR.
+        const associated = await api(`/commits/${payload.check_run.head_sha}/pulls`)
+        const open = associated.find(candidate => candidate.state === 'open')
+        if (!open) {
+          log('Check run is not associated with an open PR, nothing to do')
+          return
+        }
+        prNumber = open.number
+      }
+      break
+    }
+    default:
+      log(`Unsupported event ${eventName}, nothing to do`)
+      return
+  }
+
+  const pr = await api(`/pulls/${prNumber}`)
+  if (pr.state !== 'open') {
+    log(`PR #${prNumber} is ${pr.state}, skipping`)
+    return
+  }
+  if (pr.head.repo.full_name !== `${owner}/${repo}`) {
+    log('PR is from a fork, skipping - the token cannot write check runs')
+    return
+  }
+
+  const headSha = pr.head.sha
+  log(`Evaluating coverage for PR #${prNumber} at ${headSha}`)
+
+  // Always update the existing check run instead of creating another one with the
+  // same name: pr-gatekeeper refuses to evaluate a name that matches several runs.
+  const publish = async ({ status, conclusion, title, summary }) => {
+    const existing = await listCheckRuns(headSha, CHECK_NAME)
+    const checkPayload = { status, output: { title, summary } }
+    if (conclusion) checkPayload.conclusion = conclusion
+
+    if (existing.length > 0) {
+      const newest = existing.sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0]
+      await api(`/check-runs/${newest.id}`, 'PATCH', checkPayload)
+    } else {
+      await api('/check-runs', 'POST', { name: CHECK_NAME, head_sha: headSha, ...checkPayload })
+    }
+  }
+
+  // --- Which new releases does this PR add? -------------------------------------
+  // Only newly added releases need coverage. Deprecating (modified) or archiving
+  // (renamed) an existing release leaves its release.yaml otherwise untouched.
+  const files = await paginate(`/pulls/${prNumber}/files`)
+
+  const releaseYamlPattern = /^([^/]+)\/(v[0-9]+\.[0-9]+\.[0-9]+[^/]*)\/release\.yaml$/
+  const releases = new Map() // provider dir → Set of versions
+  const releaseYamlPaths = new Set()
+  for (const file of files) {
+    const match = file.filename.match(releaseYamlPattern)
+    if (!match || file.status !== 'added') continue
+    const [, provider, version] = match
+    if (!(provider in EXPECTED_SUITES)) continue
+    if (!releases.has(provider)) releases.set(provider, new Set())
+    releases.get(provider).add(version)
+    releaseYamlPaths.add(file.filename)
+  }
+
+  if (releases.size === 0) {
+    log('PR adds no new releases, reporting coverage as not applicable')
+    await publish({
+      status: 'completed',
+      conclusion: 'success',
+      title: 'No new releases added',
+      summary: 'This PR does not add a new release, so no E2E test coverage is required.',
+    })
+    return
+  }
+
+  // --- Coverage stays valid until the release content changes -------------------
+  // Walk the PR's commits newest first and stop at the first one whose release
+  // content differs from head. Suites that passed on the commits in between still
+  // count, so README/announcement-only commits don't invalidate coverage.
+  const commits = await paginate(`/pulls/${prNumber}/commits`)
+
+  const releaseContentChanged = async (sha) => {
+    const comparison = await api(`/compare/${sha}...${headSha}`)
+    return (comparison.files || []).some(file => releaseYamlPaths.has(file.filename))
+  }
+
+  const validShas = []
+  let contentChangedAt = null
+  for (const commit of [...commits].reverse()) {
+    if (commit.sha !== headSha && await releaseContentChanged(commit.sha)) {
+      // This commit, and anything older, predates the current release content.
+      contentChangedAt = new Date(commit.commit.committer.date)
+      break
+    }
+    validShas.push(commit.sha)
+  }
+  if (!validShas.includes(headSha)) validShas.unshift(headSha)
+  log(`Counting results from ${validShas.length} commit(s) holding the current release content`)
+
+  // --- Collect suite results across those commits -------------------------------
+  // validShas is ordered newest first, and within one commit the most recently
+  // started run wins. A success is then kept even if another run of the same suite
+  // failed afterwards: every commit considered here carries identical release
+  // content, so the pass still applies to what is being merged. A genuinely red
+  // run is still surfaced by the `Release Test Suites` check, which the PR
+  // gatekeeper requires separately.
+  const suiteResults = new Map() // check name → { conclusion, url, sha }
+  for (const sha of validShas) {
+    const checkRuns = await listCheckRuns(sha)
+    const byStartedAt = checkRuns
+      .filter(run => run.name.startsWith(SUITE_CHECK_PREFIX))
+      .sort((a, b) => new Date(b.started_at) - new Date(a.started_at))
+
+    for (const run of byStartedAt) {
+      const existing = suiteResults.get(run.name)
+      if (existing && (existing.conclusion === 'success' || existing.sha === sha)) continue
+      suiteResults.set(run.name, { conclusion: run.conclusion, url: run.html_url, sha })
+    }
+  }
+
+  // --- Waivers ------------------------------------------------------------------
+  // `/waive-suite <provider>/<suite> <reason>` from an org member waives one suite.
+  // A waiver is void once the release content changes, same as a test result.
+  const comments = await paginate(`/issues/${prNumber}/comments`)
+
+  const waivers = new Map() // `${providerDir}/${suite}` → { user, reason }
+  const waiverPattern = /^\/waive-suite\s+(?:\.\/providers\/)?([a-z-]+)\/([a-z0-9-]+)\s+(.+)$/i
+  for (const comment of comments) {
+    if (!['OWNER', 'MEMBER', 'COLLABORATOR'].includes(comment.author_association)) continue
+    if (contentChangedAt && new Date(comment.created_at) < contentChangedAt) continue
+    for (const line of (comment.body || '').split(/\r?\n/)) {
+      const match = line.trim().match(waiverPattern)
+      if (!match) continue
+      const [, rawProvider, suite, reason] = match
+      const provider = PROVIDER_ALIASES[rawProvider.toLowerCase()]
+      if (!provider) continue
+      waivers.set(`${provider}/${suite.toLowerCase()}`, {
+        user: comment.user.login,
+        reason: reason.trim(),
+      })
+    }
+  }
+
+  // --- What would a plain `/run releases-test-suites` cover right now? ----------
+  // releases-test-suites picks suites from the stage label, so the trigger to
+  // suggest depends on the stage: the variant suites only run at freeze.
+  const stageLabel = ['freeze', 'active', 'development']
+    .find(stage => pr.labels.some(label => label.name === `stage/${stage}`)) || ''
+
+  const suitesRunByStage = (provider) => {
+    const all = EXPECTED_SUITES[provider]
+    // No stage label means the pipeline runs the full matrix.
+    if (stageLabel === 'freeze' || stageLabel === '') return all
+    const base = stageLabel === 'development'
+      ? ['standard', 'upgrade', 'upgrade-major']
+      : ['standard', 'upgrade']
+    return all.filter(suite => base.includes(suite))
+  }
+
+  // release-stages.yaml only allows development -> active -> freeze, so the next
+  // command depends on where the PR is now. Suggesting `/stage freeze` from
+  // development would be rejected as an invalid transition.
+  const NEXT_STAGE_COMMAND = { '': '/stage active', 'development': '/stage active', 'active': '/stage freeze' }
+  const stageAdvanceCommand = NEXT_STAGE_COMMAND[stageLabel]
+  const stageRunsDescription = {
+    'development': '`standard`, `upgrade` and `upgrade-major` per provider',
+    'active': '`standard` and `upgrade` per provider',
+    'freeze': 'every suite per provider',
+    '': 'every suite per provider',
+  }[stageLabel]
+
+  // --- Evaluate -----------------------------------------------------------------
+  const lines = []
+  const outstanding = [] // { provider, suite, path } still to pass
+  let expectedCount = 0
+  let coveredCount = 0
+  let anyFailed = false
+
+  const byCapiName = (a, b) => (capiNames[a[0]] || a[0]).localeCompare(capiNames[b[0]] || b[0])
+  for (const [provider, versions] of [...releases.entries()].sort(byCapiName)) {
+    const capi = capiNames[provider] || provider
+    const suites = EXPECTED_SUITES[provider]
+    const versionList = [...versions].sort().join(', ')
+
+    if (suites.length === 0) {
+      lines.push(`### ${capi} (${versionList})`, '', 'ℹ️ No E2E test suites are defined for this provider - nothing to enforce.', '')
+      continue
+    }
+
+    lines.push(`### ${capi} (${versionList})`, '', '| Suite | Status |', '| --- | --- |')
+
+    for (const suite of suites) {
+      expectedCount++
+      const suitePath = `./providers/${SUITE_PATH_PROVIDER[provider]}/${suite}`
+      const checkName = SUITE_CHECK_PREFIX + CHECK_NAME_FORMATS[suite].replace('{capi}', capi)
+      const result = suiteResults.get(checkName)
+      const waiver = waivers.get(`${provider}/${suite}`)
+
+      if (result && result.conclusion === 'success') {
+        coveredCount++
+        const note = result.sha === headSha
+          ? ''
+          : ` (on \`${result.sha.substring(0, 7)}\`, release content unchanged since)`
+        lines.push(`| [${suite}](${result.url}) | ✅ passed${note} |`)
+      } else if (waiver) {
+        coveredCount++
+        lines.push(`| ${suite} | ⚠️ waived by @${waiver.user} - _${waiver.reason}_ |`)
+      } else if (result && FAILED_CONCLUSIONS.includes(result.conclusion)) {
+        anyFailed = true
+        outstanding.push({ provider, suite, path: suitePath })
+        lines.push(`| [${suite}](${result.url}) | ❌ ${result.conclusion} |`)
+      } else if (result) {
+        outstanding.push({ provider, suite, path: suitePath })
+        lines.push(`| ${suite} | 🚧 in progress |`)
+      } else {
+        outstanding.push({ provider, suite, path: suitePath })
+        // Make it obvious which suites the current stage will never start on
+        // its own, so a missing result doesn't look like something went wrong.
+        const stageNote = suitesRunByStage(provider).includes(suite)
+          ? ''
+          : ' - runs automatically at `stage/freeze`'
+        lines.push(`| ${suite} | ⬜ not run${stageNote} |`)
+      }
+    }
+    lines.push('')
+  }
+
+  const complete = coveredCount === expectedCount
+
+  if (!complete) {
+    // While most of what the current stage runs is still outstanding, the plain
+    // trigger is the better advice: it covers all of them and keeps the hint
+    // short. Once the stage's suites are mostly green, re-running them all just
+    // burns test capacity, so list only what is actually outstanding instead.
+    const runByStage = (entry) => suitesRunByStage(entry.provider).includes(entry.suite)
+    const stageTotal = [...releases.keys()].reduce((total, provider) => total + suitesRunByStage(provider).length, 0)
+    const stageOutstanding = outstanding.filter(runByStage)
+    const notRunByStage = outstanding.filter(entry => !runByStage(entry))
+    const stageRerunCount = stageTotal - stageOutstanding.length
+    const useStageTrigger = stageTotal > 0 && stageOutstanding.length * 2 > stageTotal
+
+    const stageDescription = stageLabel ? `\`stage/${stageLabel}\`` : 'this PR (no stage label)'
+
+    // Stages advance one step at a time, so spell out the command that applies now
+    // and mention the step after it when freeze is still two transitions away.
+    const stageAdvanceInstruction = stageAdvanceCommand
+      ? (stageAdvanceCommand === '/stage active'
+          ? `Advance the stage with \`/stage active\` when the release is ready for team review, then \`/stage freeze\` - stages move one step at a time.`
+          : `Advance the stage with \`/stage freeze\` when the release is ready.`)
+      : ''
+
+    lines.push('---', '', '#### Run the outstanding suites', '')
+
+    if (useStageTrigger) {
+      const rerunNote = stageRerunCount > 0
+        ? ` It also re-runs the ${stageRerunCount} suite(s) that already passed - target them individually with \`TARGET_SUITES\` if you want to avoid that.`
+        : ''
+      lines.push(
+        `This runs every suite ${stageDescription} covers${notRunByStage.length > 0 ? '' : ', which is all of the outstanding ones'}.${rerunNote}`,
+        '',
+        '```',
+        '/run releases-test-suites',
+        '```',
+        '',
+      )
+      if (notRunByStage.length > 0) {
+        lines.push(
+          `The remaining ${notRunByStage.length} suite(s) are not run by ${stageDescription} and only start automatically once the PR reaches \`stage/freeze\`. ${stageAdvanceInstruction} Or run them now without changing the stage:`,
+          '',
+          '```',
+          `/run releases-test-suites TARGET_SUITES=${notRunByStage.map(entry => entry.path).join(',')}`,
+          '```',
+          '',
+        )
+      }
+    } else {
+      lines.push(
+        '```',
+        `/run releases-test-suites TARGET_SUITES=${outstanding.map(entry => entry.path).join(',')}`,
+        '```',
+        '',
+      )
+      if (notRunByStage.length > 0 && stageLabel && stageLabel !== 'freeze') {
+        lines.push(
+          `Note that ${notRunByStage.length} of these are not run by ${stageDescription}, so a plain \`/run releases-test-suites\` will not cover them until the PR reaches \`stage/freeze\`. ${stageAdvanceInstruction}`,
+          '',
+        )
+      }
+    }
+
+    lines.push(
+      'If a suite genuinely cannot pass - for example because its test environment is down -',
+      'waive it with a reason. The waiver is recorded here and becomes void as soon as a',
+      'release in this PR changes:',
+      '',
+      '```',
+      '/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234',
+      '```',
+      '',
+    )
+  }
+
+  lines.push(
+    '---',
+    '_Coverage is required regardless of the release stage - see [giantswarm/roadmap#4334](https://github.com/giantswarm/roadmap/issues/4334)._',
+  )
+
+  // Put the stage in the title so it is readable from the checks list without
+  // expanding anything - it is the main reason suites are missing.
+  const stageSuffix = stageLabel ? ` · stage/${stageLabel}` : ''
+  const title = complete
+    ? `All ${expectedCount} expected suites covered${stageSuffix}`
+    : `${coveredCount}/${expectedCount} expected suites covered${stageSuffix}`
+
+  const stageHeader = stageLabel
+    ? `**Current stage:** \`stage/${stageLabel}\` - a plain \`/run releases-test-suites\` runs ${stageRunsDescription}.`
+    : `**Current stage:** none - a plain \`/run releases-test-suites\` runs ${stageRunsDescription}.`
+
+  const summary = complete
+    ? `✅ Every expected E2E test suite has passed for the releases added in this PR.\n\n${stageHeader}`
+    : `🚧 ${expectedCount - coveredCount} expected E2E test suite(s) still need to pass before this release can be merged.\n\n${stageHeader}`
+
+  // A failed suite is reported as a failure. Suites that simply haven't run yet
+  // leave the check in progress, which blocks the merge without marking the PR
+  // as broken while a release is still being worked on.
+  await publish({
+    status: complete || anyFailed ? 'completed' : 'in_progress',
+    conclusion: complete ? 'success' : (anyFailed ? 'failure' : undefined),
+    title,
+    summary: `${summary}\n\n${lines.join('\n')}`,
+  })
+
+  log(`${title} (${complete ? 'success' : anyFailed ? 'failure' : 'in progress'})`)
+}
+
+const finished = main()
+finished.catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})
+
+module.exports = finished

--- a/.github/workflows/e2e-coverage.yaml
+++ b/.github/workflows/e2e-coverage.yaml
@@ -1,0 +1,73 @@
+name: E2E Coverage
+
+# Enforces that the *extended* set of E2E test suites has run and passed for every new
+# release in a PR before it can be merged.
+#
+# Background: `releases-test-suites` selects suites based on the release stage, so a PR in
+# `stage/development` only runs standard + upgrade + upgrade-major. Releases were getting
+# merged from that stage, meaning the variant suites (private, china, cilium-eni-mode,
+# on-capa, on-capz) never ran at all. See giantswarm/roadmap#4334.
+#
+# This workflow publishes a single `E2E Coverage` check run that only succeeds once every
+# expected suite has passed, regardless of the stage the PR is currently in.
+# `pr-gatekeeper` (Heimdall) requires that check before merge.
+#
+# Coverage is tied to the release *content* rather than to the head SHA: a suite that
+# passed on an earlier commit still counts as long as no new release's `release.yaml` has
+# changed since. README, announcement and release.diff edits therefore don't force a
+# re-run, while bumping a component or app does.
+#
+# NOTE: the `check_run` and `issue_comment` triggers always use the workflow file from the
+# default branch, so changes here only take effect once merged.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  check_run:
+    types: [completed]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to evaluate coverage for'
+        required: true
+        type: string
+
+permissions:
+  checks: write
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  # Serialise per PR so concurrent suite completions don't race on the check run.
+  group: e2e-coverage-${{ github.event.pull_request.number || github.event.issue.number || github.event.check_run.pull_requests[0].number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  coverage:
+    name: Evaluate E2E coverage
+    runs-on: ubuntu-latest
+    # Only react to events that can change the outcome. Ignoring our own check run is what
+    # keeps this workflow from re-triggering itself indefinitely.
+    if: |
+      (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      || (github.event_name == 'check_run' && startsWith(github.event.check_run.name, 'Release Tests / '))
+      || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/waive-suite'))
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get provider lists
+        id: providers
+        uses: ./.github/actions/get-providers
+
+      - name: Evaluate coverage and publish check run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CAPI_NAMES: ${{ steps.providers.outputs.capi_names }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: node .github/scripts/e2e-coverage.js

--- a/README.md
+++ b/README.md
@@ -601,7 +601,9 @@ If a suite genuinely cannot pass — for example because its test environment is
 
 `/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234`
 
-Waivers are recorded in the `E2E Coverage` check output, apply to that one suite only, and become void as soon as a release in the PR changes.
+A reason is required, and the waiver must come from an organisation member. Waivers are recorded in the `E2E Coverage` check output, apply to that one suite only, and become void as soon as a release in the PR changes.
+
+Full details are in [docs/workflows-e2e-coverage.md](docs/workflows-e2e-coverage.md).
 
 ## Conformance Tests
 

--- a/README.md
+++ b/README.md
@@ -587,6 +587,22 @@ The `upgrade` tests will first install a cluster using the latest previously pub
 
 The workload cluster E2E tests are enforced by our PR gatekeeper to ensure they are passing before PRs are allowed to be merged.
 
+### Test coverage requirements
+
+Which suites `/run releases-test-suites` picks depends on the release stage (`stage/development` runs `standard`, `upgrade` and `upgrade-major`, while the variant suites such as `private`, `china`, `cilium-eni-mode`, `on-capa` and `on-capz` only run at `stage/freeze`). To make sure a release is never merged without the variant suites having run at all, the `E2E Coverage` check requires the **full** set of suites for every new release in the PR, whatever stage the PR is currently in.
+
+The check lists every expected suite per provider along with a ready-to-use trigger comment for the ones still outstanding. It only turns green once they have all passed, and the PR gatekeeper requires it before merge.
+
+It also names the stage the PR is currently in, which suites a plain `/run releases-test-suites` covers in that stage, and the command to advance to the next one (`/stage active`, then `/stage freeze` — stages move one step at a time). Suites that the current stage does not run are marked accordingly, so a missing result is never mistaken for a problem.
+
+Results stay valid while the release content stays the same: a suite that passed on an earlier commit still counts, and only a change to a new release's `release.yaml` (a component or app bump) invalidates it. Editing a README, announcement or `release.diff` does not force a re-run.
+
+If a suite genuinely cannot pass — for example because its test environment is down — it can be waived with a reason:
+
+`/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234`
+
+Waivers are recorded in the `E2E Coverage` check output, apply to that one suite only, and become void as soon as a release in the PR changes.
+
 ## Conformance Tests
 
 To trigger the CNCF Conformance tests for a new Release added in a PR, add a comment with something similar to the following:

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,14 @@ Documentation for the staged release lifecycle:
 - Freeze stage blocks non-Tenet changes and skips weekly bumps
 - Slack notifications for consolidated releases on stage transitions
 
+### [E2E Test Coverage](workflows-e2e-coverage.md)
+Documentation for the test coverage merge gate:
+- **E2E Coverage** (`e2e-coverage.yaml`) - Requires the full suite set for every new release in a PR, whatever stage it is in
+- **Waivers** - `/waive-suite <provider>/<suite> <reason>` for suites that genuinely cannot pass
+- Coverage is tied to the release content, so results survive README edits but not component bumps
+
+Because `releases-test-suites` selects suites by stage, releases merged before Freeze used to skip the variant suites (`private`, `china`, `cilium-eni-mode`, `on-capa`, `on-capz`) entirely. This check makes that impossible to do unnoticed.
+
 ### [Controller Readiness Tracking](workflows-controller-readiness.md)
 Documentation for the automated controller readiness tracking system for major releases:
 - **Create Controller Readiness Issues** (composite action) - Creates tracking issues in `giantswarm/roadmap` for teams that own cloud controller apps
@@ -63,6 +71,7 @@ This workflow retags cluster provider charts (e.g., `cluster-aws:7.2.5` → `34.
 | Update Release PR | On PR comment | ❌ |
 | Summarize Upstream Changes | On PR comment (`/summarize-ai`) | ❌ |
 | Release Stage | On PR comment (`/stage`) | ❌ |
+| E2E Coverage | On PR update, suite completion, `/waive-suite` | ✅ |
 | Bump Open Releases | Monday 9:00 AM UTC | ✅ |
 | Check Controller Readiness | Daily 8:00 AM UTC | ✅ |
 | Deprecate Releases | Monday 6:00 AM UTC | ✅ |

--- a/docs/workflows-e2e-coverage.md
+++ b/docs/workflows-e2e-coverage.md
@@ -1,0 +1,121 @@
+# E2E Test Coverage
+
+This document describes the `E2E Coverage` merge gate (`e2e-coverage.yaml`) and the `/waive-suite` slash command.
+
+## Overview
+
+`releases-test-suites` picks which test suites to run based on the release stage, so a PR in `stage/development` only runs `standard`, `upgrade` and `upgrade-major`. The variant suites (`private`, `china`, `cilium-eni-mode`, `on-capa`, `on-capz`) only start automatically once the PR reaches `stage/freeze`.
+
+Releases were being merged before reaching Freeze, which meant those variant suites never ran at all — v34.5.0 was merged from `stage/development` having tested only 12 of the 18 suites expected for its providers.
+
+The `E2E Coverage` check closes that gap. It requires the **full** suite set for every newly added release in the PR, whatever stage the PR is currently in, and only reports success once all of them have passed.
+
+See [giantswarm/roadmap#4334](https://github.com/giantswarm/roadmap/issues/4334).
+
+## What is required
+
+Expected suites per provider directory:
+
+| Provider directory | Expected suites |
+|--------------------|-----------------|
+| `capa` | `standard`, `upgrade`, `upgrade-major`, `cilium-eni-mode`, `china`, `private` |
+| `azure` | `standard`, `upgrade`, `upgrade-major`, `private` |
+| `vsphere` | `standard`, `upgrade`, `upgrade-major`, `on-capa`, `on-capz` |
+| `cloud-director` | `standard`, `upgrade`, `upgrade-major` |
+| `eks` | `standard`, `upgrade`, `upgrade-major` |
+| `aks`, `proxmox` | _none_ — no `releases-test-suites` mapping exists yet |
+
+This mirrors what `releases-test-suites` expands to during Freeze. A suite counts as covered when its per-suite check run (`Release Tests / <suite description>`, published by the `check-run-results-to-pr` Tekton task) has concluded successfully.
+
+Only **newly added** releases are considered. A PR that deprecates (modifies) or archives (renames) an existing `release.yaml` requires no coverage and reports `No new releases added`.
+
+## How coverage is evaluated
+
+Coverage is tied to the release **content**, not to the head commit:
+
+- A suite that passed on an earlier commit of the PR still counts, as long as no newly added `release.yaml` has changed since.
+- Editing a README, announcement or `release.diff` does **not** invalidate results.
+- Changing a component or app version — via `/update-release`, `/pin-version`, or the weekly `bump-open-releases.yaml` job — **does** invalidate them, because the suites then tested different content. They have to run again.
+
+Reaching Freeze early therefore protects coverage: `stage/freeze` restricts `/update-release` to Team Tenet and excludes the PR from the weekly bump, so results stop being invalidated underneath you.
+
+Within one release content, a successful run is never overridden by a later failing run of the same suite — a flaky re-run cannot pull coverage back down. A genuinely failing run is still visible through the `Release Test Suites` check, which the PR gatekeeper requires separately.
+
+## Stage interaction
+
+The gate does not require the PR to pass through any particular stage. It reports the current stage and which suites a plain `/run releases-test-suites` covers there, because that is the usual reason suites are missing:
+
+- While most of what the current stage runs is still outstanding, the check suggests a plain `/run releases-test-suites`, and separately lists the suites that stage will never run.
+- Once the stage's suites are mostly green, it lists only the outstanding suites as an explicit `TARGET_SUITES` command, so already-passed suites are not re-run.
+- It suggests the next stage command (`/stage active` from Development, `/stage freeze` from Active). Stages advance one step at a time, so `/stage freeze` directly from Development is rejected.
+
+Switching stage does not affect existing results: labels do not change the release content.
+
+## Commands
+
+### `/waive-suite <provider>/<suite> <reason>`
+
+Marks a single suite as covered when it genuinely cannot pass — for example because its test environment is down.
+
+```
+/waive-suite capa/china Beijing environment down, see giantswarm/roadmap#1234
+```
+
+**Rules:**
+
+- A reason is **required**. `/waive-suite capa/china` with no reason is ignored.
+- The comment author must be an organisation member, owner or collaborator.
+- The provider can be written either as the release directory or as the cluster-test-suites name (`azure/private` and `capz/private` are equivalent), with or without a `./providers/` prefix.
+- The waiver applies to that one suite only; everything else stays enforced.
+- The waiver is recorded in the check output (`⚠️ waived by @user`) and becomes **void** as soon as a release in the PR changes, exactly like a test result.
+
+## Check states
+
+| State | Meaning |
+|-------|---------|
+| ✅ success | Every expected suite passed or is waived |
+| 🚧 in progress | Suites are still missing or running — blocks merge without marking the PR as broken |
+| ❌ failure | An expected suite failed |
+
+Per-suite rows are reported as `✅ passed`, `⚠️ waived`, `❌ <conclusion>`, `🚧 in progress` or `⬜ not run`. Suites the current stage does not run are marked `runs automatically at stage/freeze`, so a missing result is not mistaken for a problem.
+
+## Enforcement
+
+The check is required by [pr-gatekeeper](https://github.com/giantswarm/pr-gatekeeper) (Heimdall) for this repo, and Heimdall is the required status check on `master`.
+
+Note that a `/skip-ci <reason>` comment bypasses **all** Heimdall requirements, including this one. When that happens Heimdall records who skipped it and why, and the `E2E Coverage` output still shows which suites never ran.
+
+## Workflow details
+
+### Triggers
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  check_run:
+    types: [completed]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+```
+
+The `check_run` trigger re-evaluates coverage as each suite finishes, filtered to `Release Tests / *` so the workflow does not react to its own check run. The `issue_comment` trigger only runs for comments containing `/waive-suite`.
+
+`check_run` and `issue_comment` always use the workflow file from the default branch, so changes only take effect once merged. Use `workflow_dispatch` with a PR number to evaluate a PR on demand.
+
+### Implementation
+
+The logic lives in `.github/scripts/e2e-coverage.js` and talks to the REST API directly rather than through `actions/github-script`, whose pinned SHA trips the repo's gitleaks rule (it matches any long alphanumeric run next to the word "github").
+
+The check run is always updated in place rather than recreated, because `pr-gatekeeper` refuses to evaluate a check name that matches several runs on the same commit.
+
+## Related Files
+
+- `.github/workflows/e2e-coverage.yaml`: Workflow definition
+- `.github/scripts/e2e-coverage.js`: Coverage evaluation and check run publishing
+- `.github/actions/get-providers/action.yml`: Provider directory → CAPI name mapping
+- `docs/workflows-release-stages.md`: Stage lifecycle and what each stage runs
+- [`tekton-resources/tekton-pipelines/pipelines/releases-test-suites.yaml`](https://github.com/giantswarm/tekton-resources/blob/main/tekton-resources/tekton-pipelines/pipelines/releases-test-suites.yaml): Stage-based suite selection
+- [`tekton-resources/tekton-pipelines/tasks/check-run-results-to-pr.yaml`](https://github.com/giantswarm/tekton-resources/blob/main/tekton-resources/tekton-pipelines/tasks/check-run-results-to-pr.yaml): Publishes the per-suite check runs
+- [`pr-gatekeeper/config.yaml`](https://github.com/giantswarm/pr-gatekeeper/blob/main/config.yaml): Required checks per repo

--- a/docs/workflows-release-stages.md
+++ b/docs/workflows-release-stages.md
@@ -64,6 +64,10 @@ The `stage/development` label is informational only. It signals that Tenet is wo
 
 All users can make changes during the Active stage.
 
+### Merge gating is separate
+
+Stages do not gate merging. The `E2E Coverage` check requires the full test suite set for every new release regardless of stage — see [E2E Test Coverage](workflows-e2e-coverage.md). Reaching Freeze still matters for coverage: it stops `/update-release` and the weekly bump from changing the release content and invalidating results that already passed.
+
 ### Freeze (hard gate)
 
 During Freeze:
@@ -142,3 +146,4 @@ Created via `gh label create`:
 - `.github/workflows/bump-open-releases.yaml`: Excludes frozen PRs from weekly bump
 - `.github/pr-body-templates/consolidated-release-instructions.md`: Stage command docs
 - `.github/pr-body-templates/individual-release-instructions.md`: Stage command docs
+- `docs/workflows-e2e-coverage.md`: Test coverage merge gate and how it relates to stages


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

`releases-test-suites` picks suites by release stage, so a PR in `stage/development` only runs `standard`, `upgrade` and `upgrade-major`. Releases were merged from that stage, so the variant suites never ran — v34.5.0 (#2391) merged without `capa/private`, `capa/china`, `capa/cilium-eni-mode`, `capz/private`, `capv/on-capa` and `capv/on-capz`.

Adds an `E2E Coverage` check that requires the full suite set for every **newly added** release in the PR, whatever stage it is in, and lists the outstanding suites with a ready-to-paste trigger comment. Deprecate/archive PRs are unaffected (they modify or rename `release.yaml`, they do not add one).

Coverage is tied to release content rather than the head SHA: a suite that passed on an earlier commit still counts until a new release's `release.yaml` changes, so README/announcement edits do not force re-runs while component bumps do. Individual suites can be waived with `/waive-suite <provider>/<suite> <reason>`; waivers are recorded in the check output and void once the release content changes.

Merge this before giantswarm/pr-gatekeeper#307, which makes the check required.