### PR TITLE
Rename the coverage job so it isn't mistaken for the gate

### DIFF
--- a/.github/workflows/e2e-coverage.yaml
+++ b/.github/workflows/e2e-coverage.yaml
@@ -47,7 +47,10 @@ concurrency:
 
 jobs:
   coverage:
-    name: Evaluate E2E coverage
+    # This job only publishes the report. The gate itself is the `E2E Coverage` check run,
+    # so the job name is deliberately subordinate to keep the two rows distinguishable in
+    # the Checks tab.
+    name: Publish coverage report
     runs-on: ubuntu-latest
     # Only react to events that can change the outcome. Ignoring our own check run is what
     # keeps this workflow from re-triggering itself indefinitely.

--- a/docs/workflows-e2e-coverage.md
+++ b/docs/workflows-e2e-coverage.md
@@ -104,6 +104,19 @@ The `check_run` trigger re-evaluates coverage as each suite finishes, filtered t
 
 `check_run` and `issue_comment` always use the workflow file from the default branch, so changes only take effect once merged. Use `workflow_dispatch` with a PR number to evaluate a PR on demand.
 
+### What you see in the Checks tab
+
+The workflow produces two rows, which are easy to mistake for duplicates:
+
+| Row | Meaning |
+|-----|---------|
+| `E2E Coverage / Publish coverage report` | The job that ran the script. Green just means the evaluation completed. |
+| `E2E Coverage` | The gate. Its title carries the result, e.g. `12/21 expected suites covered · stage/development`, and this is the check the PR gatekeeper requires. |
+
+The gate row is often prefixed with an unrelated workflow name, such as `gitleaks / E2E Coverage`. GitHub groups check runs by check suite and names the group after the first workflow that ran in it. A check run created through the REST API is adopted by an existing suite for the same app and commit rather than getting its own, and the workflow run that creates it reports against a different commit (the merge ref for `pull_request`, the default branch for `workflow_dispatch`). The grouping is cosmetic: `pr-gatekeeper` and branch protection both resolve checks by name, not by suite. Giving the check its own group would require publishing it from a dedicated GitHub App.
+
+Unrelated to this workflow, `gitleaks` also appears twice on every PR in this repo, because `zz_generated.gitleaks.yaml` is generated with both `push` and `pull_request` triggers.
+
 ### Implementation
 
 The logic lives in `.github/scripts/e2e-coverage.js` and talks to the REST API directly rather than through `actions/github-script`, whose pinned SHA trips the repo's gitleaks rule (it matches any long alphanumeric run next to the word "github").


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

The E2E Coverage workflow shows two rows in the Checks tab and they read like duplicates:

- `E2E Coverage / Evaluate E2E coverage` — the job that runs the script
- `E2E Coverage` — the check run that actually gates the merge, carrying `12/21 expected suites covered · stage/development`

Renames the job to `Publish coverage report` so it is obviously subordinate to the gate, and documents both rows in `docs/workflows-e2e-coverage.md` — including why the gate row often appears grouped under an unrelated workflow name (`gitleaks / E2E Coverage`), which is check-suite labelling and cosmetic only.