### PR TITLE
Publish coverage as a commit status so it is findable

### DIFF
--- a/.github/scripts/e2e-coverage.js
+++ b/.github/scripts/e2e-coverage.js
@@ -169,19 +169,43 @@ const main = async () => {
   const headSha = pr.head.sha
   log(`Evaluating coverage for PR #${prNumber} at ${headSha}`)
 
-  // Always update the existing check run instead of creating another one with the
-  // same name: pr-gatekeeper refuses to evaluate a name that matches several runs.
+  // The result is published twice, because the two mechanisms are good at different
+  // things:
+  //
+  //   * A check run carries the full per-provider report, but GitHub adopts API-created
+  //     check runs into an existing check suite for this app and commit, so it ends up
+  //     grouped under an unrelated workflow (`gitleaks / E2E Coverage`) and is easy to
+  //     miss in the Checks tab.
+  //   * A commit status is always its own top-level row - like the `ci/circleci: ...`
+  //     rows - so it is easy to find, and it can be required in branch protection
+  //     directly rather than only through pr-gatekeeper. It carries no markdown, so its
+  //     `target_url` points at the check run holding the detail.
+  //
+  // The check run is updated in place rather than recreated, because pr-gatekeeper
+  // refuses to evaluate a name that matches several runs on one commit.
   const publish = async ({ status, conclusion, title, summary }) => {
     const existing = await listCheckRuns(headSha, CHECK_NAME)
     const checkPayload = { status, output: { title, summary } }
     if (conclusion) checkPayload.conclusion = conclusion
 
+    let checkRun
     if (existing.length > 0) {
       const newest = existing.sort((a, b) => new Date(b.started_at) - new Date(a.started_at))[0]
-      await api(`/check-runs/${newest.id}`, 'PATCH', checkPayload)
+      checkRun = await api(`/check-runs/${newest.id}`, 'PATCH', checkPayload)
     } else {
-      await api('/check-runs', 'POST', { name: CHECK_NAME, head_sha: headSha, ...checkPayload })
+      checkRun = await api('/check-runs', 'POST', { name: CHECK_NAME, head_sha: headSha, ...checkPayload })
     }
+
+    // Statuses have no in-progress state; `pending` is the equivalent and blocks just the
+    // same. Descriptions are limited to 140 characters.
+    const state = conclusion === 'success' ? 'success' : (conclusion ? 'failure' : 'pending')
+    await api(`/statuses/${headSha}`, 'POST', {
+      context: CHECK_NAME,
+      state,
+      description: title.length > 140 ? `${title.slice(0, 137)}...` : title,
+      target_url: checkRun && checkRun.html_url ? checkRun.html_url : undefined,
+    })
+    log(`Published status ${CHECK_NAME}=${state}`)
   }
 
   // --- Which new releases does this PR add? -------------------------------------

--- a/.github/workflows/e2e-coverage.yaml
+++ b/.github/workflows/e2e-coverage.yaml
@@ -39,6 +39,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  statuses: write
 
 concurrency:
   # Serialise per PR so concurrent suite completions don't race on the check run.

--- a/docs/workflows-e2e-coverage.md
+++ b/docs/workflows-e2e-coverage.md
@@ -81,9 +81,11 @@ Per-suite rows are reported as `✅ passed`, `⚠️ waived`, `❌ <conclusion>`
 
 ## Enforcement
 
-The check is required by [pr-gatekeeper](https://github.com/giantswarm/pr-gatekeeper) (Heimdall) for this repo, and Heimdall is the required status check on `master`.
+The check run is required by [pr-gatekeeper](https://github.com/giantswarm/pr-gatekeeper) (Heimdall) for this repo, and Heimdall is a required status check on `master`.
 
 Note that a `/skip-ci <reason>` comment bypasses **all** Heimdall requirements, including this one. When that happens Heimdall records who skipped it and why, and the `E2E Coverage` output still shows which suites never ran.
+
+To make coverage impossible to skip, add the `E2E Coverage` **commit status** to the required status checks on `master`. Branch protection evaluates it directly, so `/skip-ci` — which only affects Heimdall's own verdict — cannot bypass it.
 
 ## Workflow details
 
@@ -106,14 +108,17 @@ The `check_run` trigger re-evaluates coverage as each suite finishes, filtered t
 
 ### What you see in the Checks tab
 
-The workflow produces two rows, which are easy to mistake for duplicates:
+The result is published twice, so the workflow contributes three rows:
 
 | Row | Meaning |
 |-----|---------|
+| `E2E Coverage` (commit status) | The gate, as a top-level row next to the `ci/circleci: ...` rows. Shows the tally, e.g. `12/21 expected suites covered · stage/development`, and links to the full report. |
+| `gitleaks / E2E Coverage` (check run) | The same result with the full per-provider report. This is the check `pr-gatekeeper` requires. |
 | `E2E Coverage / Publish coverage report` | The job that ran the script. Green just means the evaluation completed. |
-| `E2E Coverage` | The gate. Its title carries the result, e.g. `12/21 expected suites covered · stage/development`, and this is the check the PR gatekeeper requires. |
 
-The gate row is often prefixed with an unrelated workflow name, such as `gitleaks / E2E Coverage`. GitHub groups check runs by check suite and names the group after the first workflow that ran in it. A check run created through the REST API is adopted by an existing suite for the same app and commit rather than getting its own, and the workflow run that creates it reports against a different commit (the merge ref for `pull_request`, the default branch for `workflow_dispatch`). The grouping is cosmetic: `pr-gatekeeper` and branch protection both resolve checks by name, not by suite. Giving the check its own group would require publishing it from a dedicated GitHub App.
+Why both: a check run can hold a markdown report but cannot control where it appears. GitHub adopts API-created check runs into an existing check suite for the same app and commit, and names the group after the first workflow that ran in it — so the check ends up filed under an unrelated workflow such as `gitleaks`, which is easy to miss. A commit status is always its own row and can be required in branch protection directly, but carries only a 140-character description, so it links to the check run for the detail.
+
+Status states map to the check states above: `pending` while suites are missing, `success` when complete, `failure` when an expected suite failed.
 
 Unrelated to this workflow, `gitleaks` also appears twice on every PR in this repo, because `zz_generated.gitleaks.yaml` is generated with both `push` and `pull_request` triggers.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

The `E2E Coverage` check run shows up nested under an unrelated workflow — `gitleaks / E2E Coverage` — so the merge gate is buried in the Checks tab. GitHub adopts API-created check runs into an existing check suite for the same app and commit and labels the group after the first workflow that ran in it, so where it lands is not ours to choose.

Publishes the same result as a **commit status** as well. A status is always its own top-level row, next to the `ci/circleci: ...` rows:

```
● E2E Coverage    0/21 expected suites covered · stage/development
```

States: `pending` while suites are missing, `success` when complete, `failure` when an expected suite failed. A status carries only a 140-character description, so its `target_url` links to the check run with the full per-provider report, which stays as-is for `pr-gatekeeper`.

Follow-up worth doing: adding the `E2E Coverage` status to the required status checks on `master` would make coverage enforceable independently of Heimdall — and therefore not bypassable with `/skip-ci`.