### PR TITLE
Don't let release metadata changes invalidate coverage

### DIFF
--- a/.github/scripts/e2e-coverage.js
+++ b/.github/scripts/e2e-coverage.js
@@ -243,25 +243,30 @@ const main = async () => {
   // count, so README/announcement-only commits don't invalidate coverage.
   const commits = await paginate(`/pulls/${prNumber}/commits`)
 
-  // devctl sets spec.date to the current time on every generation (see
-  // devctl pkg/release/create.go), so even an /update-release that picks up no new
-  // versions leaves a diff. A timestamp is not something the tests can observe, so a
-  // date-only diff must not invalidate results. `spec.state` is deliberately not
-  // ignored: it is a meaningful change, unlike a generated timestamp.
-  const isDateOnlyDiff = (patch) => {
+  // Two fields in a release.yaml describe the release rather than what gets installed,
+  // so changing them cannot alter a test result:
+  //
+  //   * `date` - devctl rewrites it on every generation (pkg/release/create.go), so even
+  //     an /update-release that picks up no new versions leaves a diff.
+  //   * `state` - active, preview or deprecated. Lifecycle metadata, not content.
+  //
+  // Everything else - component and app versions in particular - still invalidates.
+  const METADATA_FIELDS = /^[+-]\s*(date|state):/
+
+  const isMetadataOnlyDiff = (patch) => {
     // No patch means the diff was too large to include - assume the content changed.
     if (!patch) return false
     const changedLines = patch
       .split('\n')
       .filter(line => /^[+-]/.test(line) && !/^(\+\+\+|---)/.test(line))
-    return changedLines.length > 0 && changedLines.every(line => /^[+-]\s*date:\s*"/.test(line))
+    return changedLines.length > 0 && changedLines.every(line => METADATA_FIELDS.test(line))
   }
 
   const releaseContentChanged = async (sha) => {
     const comparison = await api(`/compare/${sha}...${headSha}`)
     return (comparison.files || [])
       .filter(file => releaseYamlPaths.has(file.filename))
-      .some(file => !isDateOnlyDiff(file.patch))
+      .some(file => !isMetadataOnlyDiff(file.patch))
   }
 
   const validShas = []

--- a/.github/scripts/e2e-coverage.js
+++ b/.github/scripts/e2e-coverage.js
@@ -243,9 +243,25 @@ const main = async () => {
   // count, so README/announcement-only commits don't invalidate coverage.
   const commits = await paginate(`/pulls/${prNumber}/commits`)
 
+  // devctl sets spec.date to the current time on every generation (see
+  // devctl pkg/release/create.go), so even an /update-release that picks up no new
+  // versions leaves a diff. A timestamp is not something the tests can observe, so a
+  // date-only diff must not invalidate results. `spec.state` is deliberately not
+  // ignored: it is a meaningful change, unlike a generated timestamp.
+  const isDateOnlyDiff = (patch) => {
+    // No patch means the diff was too large to include - assume the content changed.
+    if (!patch) return false
+    const changedLines = patch
+      .split('\n')
+      .filter(line => /^[+-]/.test(line) && !/^(\+\+\+|---)/.test(line))
+    return changedLines.length > 0 && changedLines.every(line => /^[+-]\s*date:\s*"/.test(line))
+  }
+
   const releaseContentChanged = async (sha) => {
     const comparison = await api(`/compare/${sha}...${headSha}`)
-    return (comparison.files || []).some(file => releaseYamlPaths.has(file.filename))
+    return (comparison.files || [])
+      .filter(file => releaseYamlPaths.has(file.filename))
+      .some(file => !isDateOnlyDiff(file.patch))
   }
 
   const validShas = []

--- a/docs/workflows-e2e-coverage.md
+++ b/docs/workflows-e2e-coverage.md
@@ -36,6 +36,9 @@ Coverage is tied to the release **content**, not to the head commit:
 - A suite that passed on an earlier commit of the PR still counts, as long as no newly added `release.yaml` has changed since.
 - Editing a README, announcement or `release.diff` does **not** invalidate results.
 - Changing a component or app version — via `/update-release`, `/pin-version`, or the weekly `bump-open-releases.yaml` job — **does** invalidate them, because the suites then tested different content. They have to run again.
+- A change to `spec.date` alone does **not** invalidate them. `devctl` rewrites that timestamp on every generation, so an `/update-release` that picks up no new versions still produces a diff; the tests cannot observe a timestamp. Any other change in the file, including `spec.state`, still counts.
+
+Results are also lost if the release branch is force-pushed, because check runs are attached to a commit and the previous commits are no longer part of the PR. Adding commits (which is what `/update-release` does) is fine.
 
 Reaching Freeze early therefore protects coverage: `stage/freeze` restricts `/update-release` to Team Tenet and excludes the PR from the weekly bump, so results stop being invalidated underneath you.
 

--- a/docs/workflows-e2e-coverage.md
+++ b/docs/workflows-e2e-coverage.md
@@ -36,7 +36,7 @@ Coverage is tied to the release **content**, not to the head commit:
 - A suite that passed on an earlier commit of the PR still counts, as long as no newly added `release.yaml` has changed since.
 - Editing a README, announcement or `release.diff` does **not** invalidate results.
 - Changing a component or app version — via `/update-release`, `/pin-version`, or the weekly `bump-open-releases.yaml` job — **does** invalidate them, because the suites then tested different content. They have to run again.
-- A change to `spec.date` alone does **not** invalidate them. `devctl` rewrites that timestamp on every generation, so an `/update-release` that picks up no new versions still produces a diff; the tests cannot observe a timestamp. Any other change in the file, including `spec.state`, still counts.
+- Changes limited to `spec.date` or `spec.state` do **not** invalidate them. Both describe the release rather than what gets installed: `devctl` rewrites the timestamp on every generation, so an `/update-release` that picks up no new versions still produces a diff, and the state (`active`, `preview`, `deprecated`) is lifecycle metadata. Any other change in the file still counts.
 
 Results are also lost if the release branch is force-pushed, because check runs are attached to a commit and the previous commits are no longer part of the PR. Adding commits (which is what `/update-release` does) is fine.
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4334

Two fields in a `release.yaml` describe the release rather than what gets installed, so changing them cannot alter a test result — but the invalidation rule treated any diff as a content change and discarded every passing suite:

- **`spec.date`** — `devctl` rewrites it on every generation ([`pkg/release/create.go:313`](https://github.com/giantswarm/devctl/blob/main/pkg/release/create.go)), so even an `/update-release` that picks up no new versions leaves a diff:

  ```diff
  -  date: "2026-08-01T09:17:35Z"
  +  date: "2026-08-04T18:22:11Z"
  ```

- **`spec.state`** — `active`, `preview` or `deprecated`. Lifecycle metadata; a release changing state does not need re-testing.

Coverage now inspects the diff instead of merely detecting one. If the only changed lines in a `release.yaml` are those fields, the content counts as unchanged and earlier suite results keep counting. Component and app versions still invalidate, and a missing patch (diff too large to inline) is treated as changed.

Tested against synthetic diffs — date-only, state-only, and both together keep results; a version change discards them; a missing patch discards them — plus the live PRs, whose tallies are unchanged (v35 `0/21`, #2391 `12/18`, archive PR "No new releases added").